### PR TITLE
Move SQLite DB operations to worker

### DIFF
--- a/scripts/esbuild.config.mjs
+++ b/scripts/esbuild.config.mjs
@@ -11,10 +11,9 @@ if (!fs.existsSync(outDir)) {
   fs.mkdirSync(outDir, { recursive: true });
 }
 
-const result = await esbuild.build({
-  entryPoints: [path.join(rootDir, "src/extension.ts")],
+// Common build options
+const commonOptions = {
   bundle: true,
-  outfile: path.join(outDir, "extension.cjs"),
   platform: "node",
   target: "node18",
   format: "cjs",
@@ -30,6 +29,20 @@ const result = await esbuild.build({
   ],
   sourcemap: false,
   minify: false,
+};
+
+// Build main extension
+await esbuild.build({
+  ...commonOptions,
+  entryPoints: [path.join(rootDir, "src/extension.ts")],
+  outfile: path.join(outDir, "extension.cjs"),
+});
+
+// Build database worker as separate bundle
+await esbuild.build({
+  ...commonOptions,
+  entryPoints: [path.join(rootDir, "src/database/database-worker.ts")],
+  outfile: path.join(outDir, "database-worker.cjs"),
 });
 
 console.log("Bundle created successfully");

--- a/src/database/database-worker-client.ts
+++ b/src/database/database-worker-client.ts
@@ -1,0 +1,308 @@
+/**
+ * Database Worker Client - Main thread client for communicating with database worker
+ *
+ * This client provides the same interface as DatabaseDriver but routes
+ * all operations to a worker thread, keeping the main event loop responsive.
+ */
+
+import { Worker } from "worker_threads";
+import * as path from "path";
+import { Logger } from "../utils/logger";
+import type {
+  DatabaseDriver,
+  RequestLog,
+  LogFilter,
+  LogQueryResult,
+  DatabaseStats,
+  RequestStatus,
+  DatabaseDriverConfig,
+} from "./types";
+
+// Message types (must match worker)
+type WorkerMessageType =
+  | "init"
+  | "close"
+  | "insertLog"
+  | "insertLogPending"
+  | "updateLogCompleted"
+  | "updateLogStatus"
+  | "writeBatch"
+  | "queryLogs"
+  | "getLogById"
+  | "deleteLogs"
+  | "clearAllLogs"
+  | "getStats"
+  | "cleanOldLogs"
+  | "forceFlush";
+
+interface WorkerMessage {
+  id: string;
+  type: WorkerMessageType;
+  payload?: unknown;
+}
+
+interface WorkerResponse {
+  id: string;
+  success: boolean;
+  data?: unknown;
+  error?: string;
+}
+
+// Default timeout for worker operations (30 seconds)
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Generate unique request ID
+ */
+function generateRequestId(): string {
+  return `${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
+}
+
+/**
+ * Database Worker Client - Proxies database operations to worker thread
+ */
+export class DatabaseWorkerClient implements DatabaseDriver {
+  private worker: Worker | null = null;
+  private pendingRequests: Map<
+    string,
+    {
+      resolve: (value: unknown) => void;
+      reject: (error: Error) => void;
+      timeout: NodeJS.Timeout;
+    }
+  > = new Map();
+  private log = Logger.getInstance();
+  private _enabled: boolean = false;
+  private config: DatabaseDriverConfig;
+
+  constructor(config: DatabaseDriverConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Start the worker thread
+   */
+  private startWorker(): void {
+    if (this.worker) {
+      return;
+    }
+
+    // Worker is bundled separately by esbuild to out/dist/database-worker.cjs
+    // __dirname points to out/dist/ after bundling
+    const workerPath = path.join(__dirname, "database-worker.cjs");
+    this.worker = new Worker(workerPath);
+
+    this.worker.on("message", (response: WorkerResponse) => {
+      const pending = this.pendingRequests.get(response.id);
+      if (pending) {
+        clearTimeout(pending.timeout);
+        this.pendingRequests.delete(response.id);
+
+        if (response.success) {
+          pending.resolve(response.data);
+        } else {
+          pending.reject(new Error(response.error ?? "Unknown worker error"));
+        }
+      }
+    });
+
+    this.worker.on("error", err => {
+      this.log.error("[DatabaseWorker] Worker error:", err);
+      // Reject all pending requests
+      for (const [id, pending] of this.pendingRequests) {
+        clearTimeout(pending.timeout);
+        pending.reject(err);
+        this.pendingRequests.delete(id);
+      }
+    });
+
+    this.worker.on("exit", code => {
+      this.log.info(`[DatabaseWorker] Worker exited with code ${code}`);
+      this.worker = null;
+      this._enabled = false;
+    });
+  }
+
+  /**
+   * Send message to worker and wait for response
+   */
+  private async send<T = unknown>(
+    type: WorkerMessageType,
+    payload?: unknown,
+    timeoutMs: number = DEFAULT_TIMEOUT_MS
+  ): Promise<T> {
+    return new Promise((resolve, reject) => {
+      if (!this.worker) {
+        reject(new Error("Worker not initialized"));
+        return;
+      }
+
+      const id = generateRequestId();
+      const message: WorkerMessage = { id, type, payload };
+
+      const timeout = setTimeout(() => {
+        this.pendingRequests.delete(id);
+        reject(new Error(`Worker operation timeout after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      this.pendingRequests.set(id, {
+        resolve: (value: unknown) => resolve(value as T),
+        reject,
+        timeout,
+      });
+
+      this.worker.postMessage(message);
+    });
+  }
+
+  /**
+   * Initialize the database
+   */
+  async initialize(): Promise<void> {
+    this.startWorker();
+    await this.send("init", this.config);
+    this._enabled = true;
+    this.log.info("[DatabaseWorker] Initialized");
+  }
+
+  /**
+   * Close the database and terminate worker
+   */
+  async close(): Promise<void> {
+    if (this.worker) {
+      await this.send("close");
+      await this.worker.terminate();
+      this.worker = null;
+    }
+    this._enabled = false;
+  }
+
+  /**
+   * Check if driver is enabled
+   */
+  get enabled(): boolean {
+    return this._enabled;
+  }
+
+  /**
+   * Insert a log entry (fire-and-forget)
+   */
+  insertLog(log: RequestLog): void {
+    void this.send("insertLog", log).catch(err => {
+      this.log.error("[DatabaseWorker] insertLog error:", err);
+    });
+  }
+
+  /**
+   * Insert a log entry with "pending" status
+   */
+  insertLogPending(log: RequestLog): void {
+    void this.send("insertLogPending", log).catch(err => {
+      this.log.error("[DatabaseWorker] insertLogPending error:", err);
+    });
+  }
+
+  /**
+   * Update a log entry by clientId with response data
+   */
+  updateLogCompleted(
+    clientId: string,
+    statusCode: number,
+    responseBody: string | undefined,
+    duration: number,
+    success: boolean,
+    errorMessage: string | undefined,
+    originalResponseBody?: string
+  ): void {
+    void this.send("updateLogCompleted", {
+      clientId,
+      statusCode,
+      responseBody,
+      duration,
+      success,
+      errorMessage,
+      originalResponseBody,
+    }).catch(err => {
+      this.log.error("[DatabaseWorker] updateLogCompleted error:", err);
+    });
+  }
+
+  /**
+   * Update a log entry by clientId with custom status
+   */
+  updateLogStatus(
+    clientId: string,
+    status: RequestStatus,
+    statusCode: number,
+    duration: number,
+    errorMessage: string | undefined
+  ): void {
+    void this.send("updateLogStatus", {
+      clientId,
+      status,
+      statusCode,
+      duration,
+      errorMessage,
+    }).catch(err => {
+      this.log.error("[DatabaseWorker] updateLogStatus error:", err);
+    });
+  }
+
+  /**
+   * Batch insert logs
+   */
+  async writeBatch(logs: RequestLog[]): Promise<void> {
+    await this.send("writeBatch", logs);
+  }
+
+  /**
+   * Query logs with filter
+   */
+  async queryLogs(filter: LogFilter): Promise<LogQueryResult> {
+    return this.send<LogQueryResult>("queryLogs", { filter });
+  }
+
+  /**
+   * Get a single log by ID
+   */
+  async getLogById(id: number): Promise<RequestLog | null> {
+    return this.send<RequestLog | null>("getLogById", { id });
+  }
+
+  /**
+   * Delete logs by IDs
+   */
+  async deleteLogs(ids: number[]): Promise<void> {
+    await this.send("deleteLogs", { ids });
+  }
+
+  /**
+   * Clear all logs
+   */
+  async clearAllLogs(): Promise<void> {
+    await this.send("clearAllLogs");
+  }
+
+  /**
+   * Get database statistics
+   */
+  async getStats(): Promise<DatabaseStats> {
+    return this.send<DatabaseStats>("getStats");
+  }
+
+  /**
+   * Clean old logs (background maintenance)
+   */
+  async cleanOldLogs(): Promise<void> {
+    await this.send("cleanOldLogs");
+  }
+
+  /**
+   * Force flush any pending writes
+   */
+  forceFlush(): void {
+    void this.send("forceFlush").catch(err => {
+      this.log.error("[DatabaseWorker] forceFlush error:", err);
+    });
+  }
+}

--- a/src/database/database-worker.ts
+++ b/src/database/database-worker.ts
@@ -1,0 +1,173 @@
+/**
+ * Database Worker - Runs SQLite operations in a separate thread
+ *
+ * This worker isolates database operations (especially JSON parsing)
+ * from the main thread, preventing event loop blocking.
+ *
+ * Communication:
+ * - Main thread -> Worker: { id, type, payload }
+ * - Worker -> Main thread: { id, success, data?, error? }
+ */
+
+import { parentPort } from "worker_threads";
+import { SqliteCliDriver } from "./drivers/sqlite-cli";
+import type { RequestLog, LogFilter, RequestStatus, SqliteDriverConfig } from "./types";
+
+// Message types
+type WorkerMessageType =
+  | "init"
+  | "close"
+  | "insertLog"
+  | "insertLogPending"
+  | "updateLogCompleted"
+  | "updateLogStatus"
+  | "writeBatch"
+  | "queryLogs"
+  | "getLogById"
+  | "deleteLogs"
+  | "clearAllLogs"
+  | "getStats"
+  | "cleanOldLogs"
+  | "forceFlush";
+
+interface WorkerMessage {
+  id: string;
+  type: WorkerMessageType;
+  payload?: unknown;
+}
+
+interface WorkerResponse {
+  id: string;
+  success: boolean;
+  data?: unknown;
+  error?: string;
+}
+
+// Driver instance
+let driver: SqliteCliDriver | null = null;
+
+/**
+ * Handle incoming message from main thread
+ */
+async function handleMessage(message: WorkerMessage): Promise<WorkerResponse> {
+  const { id, type, payload } = message;
+
+  try {
+    switch (type) {
+      case "init": {
+        const config = payload as SqliteDriverConfig;
+        driver = new SqliteCliDriver(config);
+        await driver.initialize();
+        return { id, success: true };
+      }
+
+      case "close": {
+        if (driver) {
+          await driver.close();
+          driver = null;
+        }
+        return { id, success: true };
+      }
+
+      case "insertLog": {
+        driver?.insertLog(payload as RequestLog);
+        return { id, success: true };
+      }
+
+      case "insertLogPending": {
+        driver?.insertLogPending(payload as RequestLog);
+        return { id, success: true };
+      }
+
+      case "updateLogCompleted": {
+        const p = payload as {
+          clientId: string;
+          statusCode: number;
+          responseBody: string | undefined;
+          duration: number;
+          success: boolean;
+          errorMessage: string | undefined;
+          originalResponseBody?: string;
+        };
+        driver?.updateLogCompleted(
+          p.clientId,
+          p.statusCode,
+          p.responseBody,
+          p.duration,
+          p.success,
+          p.errorMessage,
+          p.originalResponseBody
+        );
+        return { id, success: true };
+      }
+
+      case "updateLogStatus": {
+        const p = payload as {
+          clientId: string;
+          status: RequestStatus;
+          statusCode: number;
+          duration: number;
+          errorMessage: string | undefined;
+        };
+        driver?.updateLogStatus(p.clientId, p.status, p.statusCode, p.duration, p.errorMessage);
+        return { id, success: true };
+      }
+
+      case "writeBatch": {
+        await driver?.writeBatch(payload as RequestLog[]);
+        return { id, success: true };
+      }
+
+      case "queryLogs": {
+        const result = await driver?.queryLogs((payload as { filter: LogFilter }).filter);
+        return { id, success: true, data: result ?? { logs: [], total: 0 } };
+      }
+
+      case "getLogById": {
+        const result = await driver?.getLogById((payload as { id: number }).id);
+        return { id, success: true, data: result };
+      }
+
+      case "deleteLogs": {
+        await driver?.deleteLogs((payload as { ids: number[] }).ids);
+        return { id, success: true };
+      }
+
+      case "clearAllLogs": {
+        await driver?.clearAllLogs();
+        return { id, success: true };
+      }
+
+      case "getStats": {
+        const result = await driver?.getStats();
+        return { id, success: true, data: result };
+      }
+
+      case "cleanOldLogs": {
+        await driver?.cleanOldLogs();
+        return { id, success: true };
+      }
+
+      case "forceFlush": {
+        driver?.forceFlush();
+        return { id, success: true };
+      }
+
+      default:
+        return { id, success: false, error: `Unknown message type: ${String(type)}` };
+    }
+  } catch (err) {
+    return {
+      id,
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// Listen for messages from main thread
+parentPort?.on("message", (message: WorkerMessage) => {
+  void handleMessage(message).then(response => {
+    parentPort?.postMessage(response);
+  });
+});

--- a/src/database/drivers/sqlite-cli.ts
+++ b/src/database/drivers/sqlite-cli.ts
@@ -490,7 +490,7 @@ export class SqliteCliDriver implements DatabaseDriver {
       };
 
       this.commandTimer = setTimeout(() => {
-        this.handleError(new Error("sqlite3 initialization timed out"));
+        void this.handleError(new Error("sqlite3 initialization timed out"));
         reject(new Error("sqlite3 initialization timed out"));
       }, this.commandTimeoutMs);
 
@@ -509,7 +509,7 @@ export class SqliteCliDriver implements DatabaseDriver {
     const stderrContent = this.stderrBuffer.trim();
 
     if (stderrContent) {
-      this.handleError(new Error(`sqlite3 error: ${stderrContent}`));
+      void this.handleError(new Error(`sqlite3 error: ${stderrContent}`));
       return;
     }
 
@@ -545,7 +545,7 @@ export class SqliteCliDriver implements DatabaseDriver {
       const rows = this.parseJsonOutput(resultText);
       this.currentQuery.resolve(rows);
     } catch (err) {
-      this.handleError(
+      void this.handleError(
         new Error(`Failed to parse JSON: ${err instanceof Error ? err.message : String(err)}`)
       );
       return;
@@ -555,7 +555,7 @@ export class SqliteCliDriver implements DatabaseDriver {
     void this.processNextCommand();
   }
 
-  private handleError(error: Error): void {
+  private async handleError(error: Error): Promise<void> {
     this.needsRestart = true;
     this.stderrBuffer = "";
     this.stdoutBuffer = "";
@@ -570,7 +570,7 @@ export class SqliteCliDriver implements DatabaseDriver {
       this.currentQuery = null;
     }
 
-    void this.processNextCommand();
+    await this.processNextCommand();
   }
 
   private parseJsonOutput(text: string): Record<string, unknown>[] {
@@ -696,7 +696,7 @@ export class SqliteCliDriver implements DatabaseDriver {
       clearTimeout(this.commandTimer);
     }
     this.commandTimer = setTimeout(() => {
-      this.handleError(new Error(`Command timed out after ${this.commandTimeoutMs}ms`));
+      void this.handleError(new Error(`Command timed out after ${this.commandTimeoutMs}ms`));
     }, this.commandTimeoutMs);
 
     const next = this.commandQueue.shift()!;

--- a/src/database/factory.ts
+++ b/src/database/factory.ts
@@ -5,14 +5,26 @@
 
 import type { DatabaseDriver, DatabaseDriverConfig } from "./types";
 import { SqliteCliDriver, PostgresDriver } from "./drivers";
+import { DatabaseWorkerClient } from "./database-worker-client";
+
+// Check if running in test environment (vitest sets this)
+const isTestEnvironment = process.env.VITEST === "true" || process.env.NODE_ENV === "test";
 
 /**
  * Factory function for creating database driver instances
+ * @param config Database configuration
  */
 export function createDriver(config: DatabaseDriverConfig): DatabaseDriver {
-  switch (config.type) {
-    case "sqlite":
+  // SQLite uses worker thread for event loop isolation (except in test environment)
+  // In tests, we use SqliteCliDriver directly since worker bundle doesn't exist
+  if (config.type === "sqlite") {
+    if (isTestEnvironment) {
       return new SqliteCliDriver(config);
+    }
+    return new DatabaseWorkerClient(config);
+  }
+
+  switch (config.type) {
     case "postgres":
       return new PostgresDriver(config);
     default: {

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -79,7 +79,6 @@ export class LogDatabase {
   private async doInitialize(): Promise<void> {
     try {
       this.log.info(`[LogDatabase] Creating ${this.driverConfig.type} driver...`);
-
       this.driver = createDriver(this.driverConfig);
       await this.driver.initialize();
 
@@ -206,6 +205,7 @@ export function getDatabase(): LogDatabase {
 /**
  * Initialize database with custom configuration
  * Must be called before getDatabase() for custom config to take effect
+ * @param config Database configuration
  */
 export function initializeDatabase(config: DatabaseDriverConfig): LogDatabase {
   if (dbInstance) {


### PR DESCRIPTION
Offload SQLite work to a dedicated worker thread to avoid blocking the main event loop. Added a worker entry (src/database/database-worker.ts) and a main-thread proxy client (src/database/database-worker-client.ts). Updated factory to return DatabaseWorkerClient for sqlite, and extended esbuild config to bundle database-worker.cjs separately. Adjusted sqlite driver error handling (handleError made async and calls to it wrapped with void where fire-and-forget is intended). Updated logger to support non-VSCode environments (worker threads) by falling back to console output. Includes small API/doc tweaks.