### PR TITLE
chore: 0.2.0 pre-release version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-26 (pre-release)
+
+Pre-release line for 0.2.0. To build a beta VSIX with a timestamped pre-release version, use `npm run package:beta` (extension version `0.2.0-beta.<build>`). For the stable 0.2.0 extension package, use `npm run package:release` when ready.
+
 ## [0.1.6] - 2026-04-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccrelay-vscode",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccrelay-vscode",
-      "version": "0.1.6",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "CCRelay",
   "icon": "assets/icon-128.png",
   "description": "VSCode extension with built-in API proxy server - switch between AI providers seamlessly",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "publisher": "inflab",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Bump extension version to `0.2.0` and add changelog notes for the 0.2.0 pre-release line.

- `package.json` / `package-lock.json`: `0.1.6` → `0.2.0`
- `CHANGELOG.md`: document `package:beta` / `package:release` for 0.2.0

No release tag: pre-release is tracked by version in branch only.

Made with [Cursor](https://cursor.com)