### PR TITLE
fix(vscode): code-server web dashboard API URL + CHANGELOG 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2026-04-26 (pre-release)
 
-Pre-release line for 0.2.0. To build a beta VSIX with a timestamped pre-release version, use `npm run package:beta` (extension version `0.2.0-beta.<build>`). For the stable 0.2.0 extension package, use `npm run package:release` when ready.
+This is the **0.2.0** development line until a stable release is tagged. **Packaging:** `npm run package:beta` rewrites the version to `0.2.0-beta.<build>` and runs `package`; `npm run package:release` strips a `-beta…` suffix for a `0.2.0` build, then `package` (see root `package.json` scripts).
+
+### Fixed
+
+- **Web dashboard in browser-backed editors (e.g. code-server)**: sidebar and log-viewer webviews no longer hardcode `http://127.0.0.1:<port>` for API calls, which in a browser targets the user’s local machine. The extension resolves the ccrelay HTTP base with `vscode.env.asExternalUri` so requests use the workbench port proxy (e.g. code-server’s `/proxy/<port>`) and hit the ccrelay server on the same host as the extension. On resolution failure, falls back to the previous local URL. **Follower** mode still uses the leader origin only.
 
 ## [0.1.6] - 2026-04-26
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,7 +118,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.window.showInformationMessage("CCRelay logs cleared");
   });
 
-  const openWebUICommand = vscode.commands.registerCommand("ccrelay.openWebUI", () => {
+  const openWebUICommand = vscode.commands.registerCommand("ccrelay.openWebUI", async () => {
     if (!server || !configManager) {
       vscode.window.showErrorMessage("CCRelay server not initialized");
       return;
@@ -131,7 +131,7 @@ export function activate(context: vscode.ExtensionContext) {
     const port = config.get<number>("port", 7575);
     const host = config.get<string>("host", "127.0.0.1");
 
-    LogViewerPanel.createOrShow(leaderUrl, role, host, port, context.extensionUri);
+    await LogViewerPanel.createOrShow(leaderUrl, role, host, port, context.extensionUri);
   });
 
   context.subscriptions.push(
@@ -191,7 +191,7 @@ async function startServer(): Promise<void> {
     }
 
     statusBar?.update();
-    dashboardProvider?.updateWebview();
+    void dashboardProvider?.updateWebview();
   } catch (err: unknown) {
     logger.error("Failed to start server", err);
     const message = err instanceof Error ? err.message : String(err);
@@ -225,7 +225,7 @@ async function stopServer(): Promise<void> {
     }
 
     statusBar?.update();
-    dashboardProvider?.updateWebview();
+    void dashboardProvider?.updateWebview();
   } catch (err: unknown) {
     logger.error("Failed to stop server", err);
     const message = err instanceof Error ? err.message : String(err);

--- a/src/vscode/dashboardView.ts
+++ b/src/vscode/dashboardView.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
+import { resolveCcrelayApiBaseUrl } from "./resolveCcrelayApiBaseUrl";
 
 export class DashboardWebviewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = "ccrelay.dashboardView";
@@ -29,13 +30,13 @@ export class DashboardWebviewProvider implements vscode.WebviewViewProvider {
       localResourceRoots: [vscode.Uri.joinPath(this._extensionUri, "out", "web")],
     };
 
-    this.updateWebview();
+    void this.updateWebview();
   }
 
-  public updateWebview() {
+  public async updateWebview(): Promise<void> {
     if (this._view) {
       const { leaderUrl, role, host, port } = this._getConfig();
-      this._view.webview.html = this.getWebviewContent(
+      this._view.webview.html = await this.getWebviewContent(
         this._view.webview,
         leaderUrl,
         role,
@@ -45,19 +46,21 @@ export class DashboardWebviewProvider implements vscode.WebviewViewProvider {
     }
   }
 
-  private getWebviewContent(
+  private async getWebviewContent(
     webview: vscode.Webview,
     leaderUrl: string,
     role: string,
     host?: string,
     port?: number
-  ): string {
+  ): Promise<string> {
     const webDistPath = path.join(this._extensionUri.fsPath, "out", "web");
 
-    const apiUrl =
-      role === "follower" && leaderUrl
-        ? new URL("/ccrelay/api", leaderUrl).origin
-        : `http://${host || "127.0.0.1"}:${port || 7575}`;
+    const apiUrl = await resolveCcrelayApiBaseUrl({
+      role,
+      leaderUrl,
+      host,
+      port,
+    });
 
     const assetsPath = path.join(webDistPath, "assets");
     let jsFile = "";

--- a/src/vscode/logViewer.ts
+++ b/src/vscode/logViewer.ts
@@ -6,6 +6,7 @@
 import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
+import { resolveCcrelayApiBaseUrl } from "./resolveCcrelayApiBaseUrl";
 
 let currentPanel: LogViewerPanel | null = null;
 
@@ -14,13 +15,13 @@ export class LogViewerPanel {
   private readonly extensionUri: vscode.Uri;
   private disposables: vscode.Disposable[] = [];
 
-  public static createOrShow(
+  public static async createOrShow(
     leaderUrl: string,
     role: string,
     host?: string,
     port?: number,
     extensionUri?: vscode.Uri
-  ): void {
+  ): Promise<void> {
     const column = vscode.window.activeTextEditor
       ? vscode.window.activeTextEditor.viewColumn
       : undefined;
@@ -36,7 +37,7 @@ export class LogViewerPanel {
     if (currentPanel) {
       currentPanel.panel.reveal(column);
       // Update webview content with new state
-      currentPanel.panel.webview.html = currentPanel.getWebviewContent(leaderUrl, role, host, port);
+      await currentPanel.updateState(leaderUrl, role, host, port);
       return;
     }
 
@@ -55,38 +56,45 @@ export class LogViewerPanel {
       }
     );
 
-    currentPanel = new LogViewerPanel(panel, extUri, leaderUrl, role, host, port);
+    const instance = new LogViewerPanel(panel, extUri);
+    await instance.loadWebview(leaderUrl, role, host, port);
+    currentPanel = instance;
   }
 
-  private constructor(
-    panel: vscode.WebviewPanel,
-    extensionUri: vscode.Uri,
+  private constructor(panel: vscode.WebviewPanel, extensionUri: vscode.Uri) {
+    this.panel = panel;
+    this.extensionUri = extensionUri;
+    this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+  }
+
+  private async loadWebview(
     leaderUrl: string,
     role: string,
     host?: string,
     port?: number
-  ) {
-    this.panel = panel;
-    this.extensionUri = extensionUri;
-    this.panel.webview.html = this.getWebviewContent(leaderUrl, role, host, port);
-
-    // Handle state restore
-    this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+  ): Promise<void> {
+    this.panel.webview.html = await this.getWebviewContent(leaderUrl, role, host, port);
   }
 
-  private updateState(leaderUrl: string, role: string, host?: string, port?: number): void {
-    this.panel.webview.html = this.getWebviewContent(leaderUrl, role, host, port);
+  private async updateState(leaderUrl: string, role: string, host?: string, port?: number): Promise<void> {
+    this.panel.webview.html = await this.getWebviewContent(leaderUrl, role, host, port);
   }
 
-  private getWebviewContent(leaderUrl: string, role: string, host?: string, port?: number): string {
+  private async getWebviewContent(
+    leaderUrl: string,
+    role: string,
+    host?: string,
+    port?: number
+  ): Promise<string> {
     const webview = this.panel.webview;
     const webDistPath = path.join(this.extensionUri.fsPath, "out", "web");
 
-    // Determine the API base URL
-    const apiUrl =
-      role === "follower" && leaderUrl
-        ? new URL("/ccrelay/api", leaderUrl).origin
-        : `http://${host || "127.0.0.1"}:${port || 7575}`;
+    const apiUrl = await resolveCcrelayApiBaseUrl({
+      role,
+      leaderUrl,
+      host,
+      port,
+    });
 
     // Find the actual asset filenames (they have hashes)
     const assetsPath = path.join(webDistPath, "assets");

--- a/src/vscode/resolveCcrelayApiBaseUrl.ts
+++ b/src/vscode/resolveCcrelayApiBaseUrl.ts
@@ -1,0 +1,32 @@
+import * as vscode from "vscode";
+
+/**
+ * Resolves the base URL the webview should use to reach the ccrelay HTTP API.
+ * Uses vscode.env.asExternalUri so code-server and Remote browsers reach the
+ * extension host via the product proxy (e.g. /proxy/7575) instead of 127.0.0.1
+ * on the client machine. Follower mode uses the leader origin unchanged.
+ */
+export async function resolveCcrelayApiBaseUrl(options: {
+  role: string;
+  leaderUrl: string;
+  host?: string;
+  port?: number;
+}): Promise<string> {
+  const { role, leaderUrl, host, port } = options;
+  if (role === "follower" && leaderUrl) {
+    return new URL("/ccrelay/api", leaderUrl).origin;
+  }
+
+  const h = host || "127.0.0.1";
+  const p = port ?? 7575;
+  const fallback = `http://${h}:${p}`;
+
+  try {
+    const localUri = vscode.Uri.parse(fallback);
+    const externalUri = await vscode.env.asExternalUri(localUri);
+    return externalUri.toString().replace(/\/$/, "");
+  } catch (err) {
+    console.error("[CCRelay] asExternalUri failed, using local URL", err);
+    return fallback;
+  }
+}


### PR DESCRIPTION
## Summary

- **Web dashboard / log viewer (code-server and browser webviews):** resolve the ccrelay HTTP API base with `vscode.env.asExternalUri` so fetches go through the workbench port proxy (e.g. code-server `/proxy/<port>`) instead of hardcoded `http://127.0.0.1:<port>` (which targets the user’s machine in the browser). Introduces `src/vscode/resolveCcrelayApiBaseUrl.ts` with fallback on failure; Follower mode unchanged.
- **CHANGELOG:** document the above under `[0.2.0] (pre-release)` and clarify pre-release packaging (`package:beta` / `package:release`).

## Commits

- `fix(vscode): resolve web dashboard API URL for code-server`
- `Update CHANGELOG.md`

Made with [Cursor](https://cursor.com)