### PR TITLE
fix(converter): cross-protocol mappings and 0.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ This is the **0.2.0** development line until a stable release is tagged. **Packa
 ### Fixed
 
 - **Web dashboard in browser-backed editors (e.g. code-server)**: sidebar and log-viewer webviews no longer hardcode `http://127.0.0.1:<port>` for API calls, which in a browser targets the user’s local machine. The extension resolves the ccrelay HTTP base with `vscode.env.asExternalUri` so requests use the workbench port proxy (e.g. code-server’s `/proxy/<port>`) and hit the ccrelay server on the same host as the extension. On resolution failure, falls back to the previous local URL. **Follower** mode still uses the leader origin only.
+- **Converters (cross-protocol)**
+  - Anthropic `tool_choice` with `type: "any"` now maps to OpenAI `"required"` (matches “must use a tool”), not `"auto"`.
+  - Responses → Chat Completions: `namespace` tools are expanded to nested `function` tools; they were previously counted as stripped and never reached the expansion branch.
+  - Anthropic `stop_reason: "stop_sequence"` maps to OpenAI `finish_reason: "stop"` (not `"content_filter"`). OpenAI `finish_reason: "content_filter"` maps to Anthropic `stop_reason: "end_turn"` (not `"stop_sequence"`).
+  - Anthropic → OpenAI user images: incomplete `base64` sources (missing `media_type` or `data`) yield an empty `image_url` URL instead of `data:undefined;base64,...`.
+  - OpenAI → Anthropic requests: when system messages mix plain string and array `content`, string parts are merged into the Anthropic `system` block list instead of being dropped.
+
+### Changed
+
+- **Converters**: `parseFunctionArguments` simplified (removed unreachable branch); tool message `content` serialization uses a shared helper; Anthropic → OpenAI request conversion no longer deep-clones messages or keeps an unreachable post-`user`/`assistant` fallback in `convertMessage`.
 
 ## [0.1.6] - 2026-04-26
 

--- a/src/api/clientConfig.ts
+++ b/src/api/clientConfig.ts
@@ -191,10 +191,7 @@ export function parseTomlLite(content: string): ParsedTomlLite {
     }
     const key = t.slice(0, eq).trim();
     let val = t.slice(eq + 1).trim();
-    if (
-      (val.startsWith('"') && val.endsWith('"')) ||
-      (val.startsWith("'") && val.endsWith("'"))
-    ) {
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
       val = val.slice(1, -1);
     }
     if (current) {
@@ -268,10 +265,7 @@ function detectCodex(codexPath: string, port: number): ClientConfigItem {
 /**
  * GET /ccrelay/api/client-config
  */
-export function handleGetClientConfig(
-  _req: http.IncomingMessage,
-  res: http.ServerResponse
-): void {
+export function handleGetClientConfig(_req: http.IncomingMessage, res: http.ServerResponse): void {
   if (!serverInstance) {
     sendJson(res, 503, { error: "Server not initialized" });
     return;
@@ -366,7 +360,10 @@ export async function handleApplyClientConfig(
       }
       root.env = env;
       fs.writeFileSync(claudePath, `${JSON.stringify(root, null, 2)}\n`, "utf-8");
-      sendJson(res, 200, { status: "ok", message: `Updated Claude default model env in ${claudePath}` });
+      sendJson(res, 200, {
+        status: "ok",
+        message: `Updated Claude default model env in ${claudePath}`,
+      });
       return;
     }
 

--- a/src/api/providers.ts
+++ b/src/api/providers.ts
@@ -188,8 +188,7 @@ function buildDuplicateConfigFromProvider(source: Provider, name: string): Provi
     modelsListFormat: source.modelsListFormat,
     modelMap: source.modelMap,
     vlModelMap: source.vlModelMap,
-    headers:
-      source.headers && Object.keys(source.headers).length > 0 ? source.headers : undefined,
+    headers: source.headers && Object.keys(source.headers).length > 0 ? source.headers : undefined,
     enabled: source.enabled,
   };
 }
@@ -223,8 +222,7 @@ export async function handleDuplicateProvider(
     if (!/^[a-zA-Z0-9_-]+$/.test(body.newId)) {
       sendJson(res, 400, {
         status: "error",
-        message:
-          "Invalid newId format. Only alphanumeric, underscore, and hyphen are allowed.",
+        message: "Invalid newId format. Only alphanumeric, underscore, and hyphen are allowed.",
       });
       return;
     }
@@ -246,7 +244,10 @@ export async function handleDuplicateProvider(
 
     const source = configManager.getProvider(body.sourceId);
     if (!source) {
-      sendJson(res, 404, { status: "error", message: `Source provider "${body.sourceId}" not found` });
+      sendJson(res, 404, {
+        status: "error",
+        message: `Source provider "${body.sourceId}" not found`,
+      });
       return;
     }
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -161,10 +161,7 @@ function expandEnvVars(value: string): string {
  *   those keys are provider **ids** (e.g. `minimax-m2-5_copy`). The previous behavior mangled
  *   `_copy` into `Copy` by turning `_c` into `C`.
  */
-export function expandEnvVarsInObject<T>(
-  obj: T,
-  options?: { isProvidersMap?: boolean }
-): T {
+export function expandEnvVarsInObject<T>(obj: T, options?: { isProvidersMap?: boolean }): T {
   if (!obj) {
     return obj;
   }
@@ -252,11 +249,10 @@ function parseProvider(id: string, config: ProviderConfigInput): Provider {
   const authHeader = config.authHeader || config.auth_header;
   const modelMap = config.modelMap || config.model_map;
   const vlModelMap = config.vlModelMap || config.vl_model_map;
-  const providerType = (config.providerType || config.provider_type || "anthropic");
+  const providerType = config.providerType || config.provider_type || "anthropic";
   const openaiChatCompletionsPath =
     config.openaiChatCompletionsPath || config.openai_chat_completions_path;
-  const modelsListFormat =
-    config.modelsListFormat || config.models_list_format || "auto";
+  const modelsListFormat = config.modelsListFormat || config.models_list_format || "auto";
 
   return {
     id,
@@ -336,10 +332,7 @@ export function isDuplicateStyleProviderId(id: string): boolean {
  * Also matches duplicate variants: e.g. `local-hysp-llm-routerCopy` in the URL
  * to YAML key `local-hysp-llm-router_copy` when the fuzzy base is unique in the file.
  */
-export function resolveProviderKeyInMap(
-  mapKeys: string[],
-  requestedId: string
-): string | null {
+export function resolveProviderKeyInMap(mapKeys: string[], requestedId: string): string | null {
   let q: string;
   try {
     q = decodeURIComponent(requestedId).trim();
@@ -856,8 +849,7 @@ export class ConfigManager {
       // If deleted provider was default, update default to official
       const dfp = rawConfig.defaultProvider;
       if (dfp !== undefined && dfp !== null) {
-        const dfpStr =
-          typeof dfp === "string" || typeof dfp === "number" ? String(dfp) : null;
+        const dfpStr = typeof dfp === "string" || typeof dfp === "number" ? String(dfp) : null;
         if (dfpStr) {
           const defKey =
             resolveProviderKeyInMap(keys, dfpStr) ?? (keys.includes(dfpStr) ? dfpStr : null);

--- a/src/converter/anthropic-to-openai-response.ts
+++ b/src/converter/anthropic-to-openai-response.ts
@@ -57,7 +57,7 @@ function mapAnthropicStopReasonToOpenAI(reason: string): string {
     end_turn: "stop",
     max_tokens: "length",
     tool_use: "tool_calls",
-    stop_sequence: "content_filter",
+    stop_sequence: "stop",
   };
   return mapping[reason] || "stop";
 }

--- a/src/converter/anthropic-to-openai.ts
+++ b/src/converter/anthropic-to-openai.ts
@@ -212,7 +212,7 @@ export function convertRequestToOpenAI(
   }
 
   // Convert each message - a single Anthropic message may produce multiple OpenAI messages
-  const requestMessages = JSON.parse(JSON.stringify(anthropic.messages || [])) as MessageParam[];
+  const requestMessages = anthropic.messages || [];
   const targetModel = openai.model;
   for (const msg of requestMessages) {
     const converted = convertMessage(msg, targetModel);
@@ -340,17 +340,7 @@ function convertMessage(msg: MessageParam, targetModel: string): OpenAIMessage[]
   }
 
   // === ASSISTANT MESSAGES ===
-  if (msg.role === "assistant") {
-    return [convertAssistantMessage(content, targetModel)];
-  }
-
-  // Fallback for any other role
-  return [
-    {
-      role: msg.role,
-      content: convertContentBlocksToString(content),
-    },
-  ];
+  return [convertAssistantMessage(content, targetModel)];
 }
 
 /**
@@ -496,16 +486,6 @@ function convertAssistantMessage(content: ContentBlockParam[], targetModel: stri
 }
 
 /**
- * Convert content blocks to a plain string (fallback)
- */
-function convertContentBlocksToString(blocks: ContentBlockParam[]): string {
-  return blocks
-    .filter((b): b is Extract<ContentBlockParam, { type: "text" }> => b.type === "text")
-    .map(b => b.text)
-    .join("\n");
-}
-
-/**
  * Convert image source from Anthropic to OpenAI format
  */
 function convertImageSource(source: {
@@ -515,9 +495,10 @@ function convertImageSource(source: {
   url?: string;
 }): string {
   if (source.type === "base64") {
-    const mediaType = source.media_type ?? undefined;
-    const data = source.data ?? undefined;
-    return `data:${mediaType};base64,${data}`;
+    if (!source.media_type || !source.data) {
+      return "";
+    }
+    return `data:${source.media_type};base64,${source.data}`;
   }
   if (source.type === "url") {
     return source.url ?? "";
@@ -552,7 +533,7 @@ function convertToolChoice(choice: AnthropicToolChoice): OpenAIToolChoice {
     };
   }
   if (choice.type === "any") {
-    return "auto";
+    return "required";
   }
   if (choice.type === "auto") {
     return "auto";

--- a/src/converter/chat-completions-to-responses.ts
+++ b/src/converter/chat-completions-to-responses.ts
@@ -157,7 +157,8 @@ function pushFunctionCallOutputItemSse(
     call_id?: string;
     status?: string;
   };
-  const itemId = typeof fc.id === "string" && fc.id.length > 0 ? fc.id : `fc_${randomUUID().replace(/-/g, "")}`;
+  const itemId =
+    typeof fc.id === "string" && fc.id.length > 0 ? fc.id : `fc_${randomUUID().replace(/-/g, "")}`;
   const fullArgs = typeof fc.arguments === "string" ? fc.arguments : "";
   const inProgress = {
     type: "function_call" as const,

--- a/src/converter/modelsFallback.ts
+++ b/src/converter/modelsFallback.ts
@@ -62,7 +62,9 @@ export function buildOpenAIModelsListFromProvider(provider: Provider): OpenAIMod
 /**
  * Build a minimal Anthropic-style model list from provider.modelMap
  */
-export function buildAnthropicModelsListFromProvider(provider: Provider): AnthropicModelsListResponse {
+export function buildAnthropicModelsListFromProvider(
+  provider: Provider
+): AnthropicModelsListResponse {
   const data: AnthropicModelInfo[] = [];
 
   for (const entry of provider.modelMap ?? []) {

--- a/src/converter/openai-to-anthropic-request.ts
+++ b/src/converter/openai-to-anthropic-request.ts
@@ -117,6 +117,13 @@ function effortToBudgetTokens(effort?: string): number | undefined {
   return 2048;
 }
 
+function stringifyToolContent(rawContent: OpenAIMessage["content"]): string {
+  if (typeof rawContent === "string") {
+    return rawContent;
+  }
+  return JSON.stringify(rawContent ?? "");
+}
+
 function extractSystem(messages: OpenAIMessage[]): {
   systemText?: string;
   systemBlocks?: Array<{
@@ -135,18 +142,6 @@ function extractSystem(messages: OpenAIMessage[]): {
       rest.push(m);
       continue;
     }
-    if (m.role === "developer") {
-      if (typeof m.content === "string") {
-        systemParts.push(m.content);
-      } else if (Array.isArray(m.content)) {
-        for (const part of m.content) {
-          if (part.type === "text" && "text" in part) {
-            systemBlockParts.push({ type: "text", text: part.text });
-          }
-        }
-      }
-      continue;
-    }
     if (typeof m.content === "string") {
       systemParts.push(m.content);
     } else if (Array.isArray(m.content)) {
@@ -159,8 +154,12 @@ function extractSystem(messages: OpenAIMessage[]): {
   }
 
   if (systemBlockParts.length > 0) {
+    const mergedBlocks = [
+      ...systemParts.map(text => ({ type: "text" as const, text })),
+      ...systemBlockParts,
+    ];
     return {
-      systemBlocks: systemBlockParts,
+      systemBlocks: mergedBlocks,
       restMessages: rest,
     };
   }
@@ -187,13 +186,7 @@ function buildAnthropicMessages(messages: OpenAIMessage[]): MessageParam[] {
       const toolResults: ContentBlockParam[] = [];
       while (i < messages.length && messages[i].role === "tool") {
         const t = messages[i];
-        const rawContent = t.content;
-        const text =
-          typeof rawContent === "string"
-            ? rawContent
-            : Array.isArray(rawContent)
-              ? JSON.stringify(rawContent)
-              : JSON.stringify(rawContent ?? "");
+        const text = stringifyToolContent(t.content);
         toolResults.push({
           type: "tool_result",
           tool_use_id: t.tool_call_id || "",
@@ -208,11 +201,10 @@ function buildAnthropicMessages(messages: OpenAIMessage[]): MessageParam[] {
       const toolResults: ContentBlockParam[] = [];
       while (i < messages.length && messages[i].role === "tool") {
         const t = messages[i];
-        const text = typeof t.content === "string" ? t.content : JSON.stringify(t.content ?? "");
         toolResults.push({
           type: "tool_result",
           tool_use_id: t.tool_call_id || "",
-          content: text,
+          content: stringifyToolContent(t.content),
         });
         i++;
       }

--- a/src/converter/openai-to-anthropic.ts
+++ b/src/converter/openai-to-anthropic.ts
@@ -312,7 +312,7 @@ function convertFinishReason(reason: string): string {
     stop: "end_turn",
     length: "max_tokens",
     tool_calls: "tool_use",
-    content_filter: "stop_sequence",
+    content_filter: "end_turn",
   };
   return mapping[reason] || "end_turn";
 }
@@ -322,14 +322,10 @@ function convertFinishReason(reason: string): string {
  */
 function parseFunctionArguments(args: string): Record<string, unknown> {
   try {
-    const argumentsStr = args || "{}";
-    if (typeof argumentsStr === "object") {
-      return argumentsStr;
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- JSON.parse returns any
-    const parsed = JSON.parse(argumentsStr);
-
-    return typeof parsed === "object" ? (parsed as Record<string, unknown>) : { text: args || "" };
+    const parsed = JSON.parse(args || "{}") as unknown;
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : { text: args || "" };
   } catch {
     return { text: args || "" };
   }

--- a/src/converter/openaiPath.ts
+++ b/src/converter/openaiPath.ts
@@ -9,9 +9,7 @@ export const DEFAULT_OPENAI_CHAT_COMPLETIONS_PATH = "/chat/completions" as const
 
 export type OpenAIPathProvider = Pick<Provider, "openaiChatCompletionsPath">;
 
-export function getOpenAIChatCompletionsPath(
-  provider?: OpenAIPathProvider | null
-): string {
+export function getOpenAIChatCompletionsPath(provider?: OpenAIPathProvider | null): string {
   const p = provider?.openaiChatCompletionsPath;
   if (p && p.length > 0) {
     return p.trim();

--- a/src/converter/responses-to-chat-completions.ts
+++ b/src/converter/responses-to-chat-completions.ts
@@ -5,7 +5,12 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
 import { ScopedLogger } from "../utils/logger";
-import type { OpenAIMessage, OpenAIMessageRequest, OpenAITool, OpenAIToolChoice } from "./anthropic-to-openai";
+import type {
+  OpenAIMessage,
+  OpenAIMessageRequest,
+  OpenAITool,
+  OpenAIToolChoice,
+} from "./anthropic-to-openai";
 import { isOpenAIChatCompletionsRequest } from "./openai-to-anthropic-request";
 import type { OpenAIPathProvider } from "./openaiPath";
 import { getOpenAIChatCompletionsPath } from "./openaiPath";
@@ -23,7 +28,6 @@ const STRIPPED_TOOL_TYPES = new Set([
   "local_shell",
   "shell",
   "tool_search",
-  "namespace",
 ]);
 
 export interface ResponsesToChatResult {
@@ -149,8 +153,7 @@ function mapResponsesToolChoice(tc: unknown): OpenAIToolChoice | undefined {
     const t = (tc as { type?: string; name?: string; function?: { name?: string } }).type;
     if (t === "function") {
       const n =
-        (tc as { function?: { name?: string } }).function?.name ??
-        (tc as { name?: string }).name;
+        (tc as { function?: { name?: string } }).function?.name ?? (tc as { name?: string }).name;
       if (n) {
         return { type: "function", function: { name: n } };
       }
@@ -159,9 +162,7 @@ function mapResponsesToolChoice(tc: unknown): OpenAIToolChoice | undefined {
   return undefined;
 }
 
-function mapResponsesTools(
-  tools: unknown
-): { tools: OpenAITool[]; stripped: number } {
+function mapResponsesTools(tools: unknown): { tools: OpenAITool[]; stripped: number } {
   if (!Array.isArray(tools)) {
     return { tools: [], stripped: 0 };
   }
@@ -180,21 +181,31 @@ function mapResponsesTools(
         function: {
           name: fnName,
           description: typeof o.description === "string" ? o.description : undefined,
-          parameters: (o.parameters as Record<string, unknown>) ?? { type: "object", properties: {} },
+          parameters: (o.parameters as Record<string, unknown>) ?? {
+            type: "object",
+            properties: {},
+          },
         },
       });
     } else if (typeof typ === "string" && STRIPPED_TOOL_TYPES.has(typ)) {
       stripped += 1;
     } else if (typ === "namespace" && Array.isArray(o.tools)) {
       for (const inner of o.tools as unknown[]) {
-        if (inner && typeof inner === "object" && (inner as { type?: string }).type === "function") {
+        if (
+          inner &&
+          typeof inner === "object" &&
+          (inner as { type?: string }).type === "function"
+        ) {
           const f = inner as { name?: string; description?: string; parameters?: unknown };
           out.push({
             type: "function",
             function: {
               name: String(f.name ?? ""),
               description: typeof f.description === "string" ? f.description : undefined,
-              parameters: (f.parameters as Record<string, unknown>) ?? { type: "object", properties: {} },
+              parameters: (f.parameters as Record<string, unknown>) ?? {
+                type: "object",
+                properties: {},
+              },
             },
           });
         }
@@ -255,9 +266,17 @@ function appendInputItemsToMessages(items: unknown[], messages: OpenAIMessage[])
       const role = o.role;
       const r = typeof role === "string" ? role : "user";
       if (r === "user" || r === "system" || r === "developer" || r === "assistant") {
-        const text = mapEasyMessageContentToText(o.content) ?? (typeof o.content === "string" ? o.content : "");
+        const text =
+          mapEasyMessageContentToText(o.content) ??
+          (typeof o.content === "string" ? o.content : "");
         const oaiRole: OpenAIMessage["role"] =
-          r === "developer" ? "developer" : r === "system" ? "system" : r === "assistant" ? "assistant" : "user";
+          r === "developer"
+            ? "developer"
+            : r === "system"
+              ? "system"
+              : r === "assistant"
+                ? "assistant"
+                : "user";
         if (oaiRole === "assistant" && !text && !Array.isArray(o.content)) {
           continue;
         }

--- a/src/vscode/logViewer.ts
+++ b/src/vscode/logViewer.ts
@@ -76,7 +76,12 @@ export class LogViewerPanel {
     this.panel.webview.html = await this.getWebviewContent(leaderUrl, role, host, port);
   }
 
-  private async updateState(leaderUrl: string, role: string, host?: string, port?: number): Promise<void> {
+  private async updateState(
+    leaderUrl: string,
+    role: string,
+    host?: string,
+    port?: number
+  ): Promise<void> {
     this.panel.webview.html = await this.getWebviewContent(leaderUrl, role, host, port);
   }
 

--- a/tests/unit/converter/anthropic-to-openai-response.test.ts
+++ b/tests/unit/converter/anthropic-to-openai-response.test.ts
@@ -37,4 +37,12 @@ describe("convertAnthropicResponseToOpenAI", () => {
     expect(isAnthropicMessageResponse(base)).toBe(true);
     expect(isAnthropicMessageResponse({ type: "error" })).toBe(false);
   });
+
+  it("maps stop_reason stop_sequence to OpenAI finish_reason stop", () => {
+    const o = convertAnthropicResponseToOpenAI(
+      { ...base, stop_reason: "stop_sequence" },
+      "claude-3"
+    );
+    expect(o.choices[0].finish_reason).toBe("stop");
+  });
 });

--- a/tests/unit/converter/anthropic-to-openai.test.ts
+++ b/tests/unit/converter/anthropic-to-openai.test.ts
@@ -559,7 +559,7 @@ describe("converter: anthropic-to-openai", () => {
       expect(result.request.tool_choice).toBe("auto");
     });
 
-    it("should convert { type: 'any' } to 'auto'", () => {
+    it("should convert { type: 'any' } to 'required'", () => {
       const request: AnthropicMessageRequest = {
         model: "claude-3-5-sonnet-20241022",
         max_tokens: 4096,
@@ -569,7 +569,7 @@ describe("converter: anthropic-to-openai", () => {
 
       const result = convertRequestToOpenAI(request, basePath);
 
-      expect(result.request.tool_choice).toBe("auto");
+      expect(result.request.tool_choice).toBe("required");
     });
 
     it("should convert { type: 'none' } to 'none'", () => {
@@ -932,14 +932,14 @@ describe("converter: anthropic-to-openai", () => {
 
       const result = convertRequestToOpenAI(request, basePath);
 
-      // When media_type is missing, should still convert to base64 URL
+      // Incomplete base64 (missing media_type) → empty URL, no invalid data: URL
       expect(result.request.messages[0]).toEqual({
         role: "user",
         content: [
           {
             type: "image_url",
             image_url: {
-              url: "data:undefined;base64,iVBORw0KGgoAAAANSUhEUgAA",
+              url: "",
             },
           },
         ],
@@ -976,7 +976,7 @@ describe("converter: anthropic-to-openai", () => {
           {
             type: "image_url",
             image_url: {
-              url: "data:image/png;base64,undefined",
+              url: "",
             },
           },
         ],

--- a/tests/unit/converter/openai-to-anthropic-request.test.ts
+++ b/tests/unit/converter/openai-to-anthropic-request.test.ts
@@ -40,6 +40,30 @@ describe("convertOpenAIRequestToAnthropic", () => {
     expect(request.messages[0].content).toBe("Hi");
   });
 
+  it("merges string and array system messages into system blocks without dropping strings", () => {
+    const { request } = convertOpenAIRequestToAnthropic(
+      {
+        model: "m",
+        max_tokens: 100,
+        messages: [
+          { role: "system", content: "Prefix from string." },
+          {
+            role: "system",
+            content: [{ type: "text", text: "From array block." }],
+          },
+          { role: "user", content: "Hi" },
+        ],
+      },
+      "/v1/chat/completions"
+    );
+    expect(request.system).toEqual([
+      { type: "text", text: "Prefix from string." },
+      { type: "text", text: "From array block." },
+    ]);
+    expect(request.messages).toHaveLength(1);
+    expect(request.messages[0].content).toBe("Hi");
+  });
+
   it("isOpenAIChatCompletionsRequest returns true when messages array present", () => {
     expect(isOpenAIChatCompletionsRequest({ messages: [], model: "x" })).toBe(true);
     expect(isOpenAIChatCompletionsRequest({ model: "x" })).toBe(false);

--- a/tests/unit/converter/openai-to-anthropic.test.ts
+++ b/tests/unit/converter/openai-to-anthropic.test.ts
@@ -773,7 +773,7 @@ describe("converter: openai-to-anthropic", () => {
   });
 
   describe("finish_reason mapping edge cases", () => {
-    it("should map 'content_filter' to 'stop_sequence'", () => {
+    it("should map 'content_filter' to 'end_turn'", () => {
       const openai: OpenAIChatCompletionResponse = {
         id: "chatcmpl-abc123",
         object: "chat.completion",
@@ -790,7 +790,7 @@ describe("converter: openai-to-anthropic", () => {
 
       const result = convertResponseToAnthropic(openai, originalModel);
 
-      expect(result.stop_reason).toBe("stop_sequence");
+      expect(result.stop_reason).toBe("end_turn");
     });
 
     it("should map empty string finish_reason to 'end_turn'", () => {

--- a/tests/unit/converter/responses-to-chat-completions.test.ts
+++ b/tests/unit/converter/responses-to-chat-completions.test.ts
@@ -66,4 +66,38 @@ describe("convertResponsesRequestToChatCompletions", () => {
     );
     expect(request.tool_choice).toBe("required");
   });
+
+  it("expands namespace tools with nested function tools", () => {
+    const { request } = convertResponsesRequestToChatCompletions(
+      {
+        model: "m",
+        input: "x",
+        tools: [
+          {
+            type: "namespace",
+            name: "ns",
+            tools: [
+              {
+                type: "function",
+                name: "inner_tool",
+                description: "d",
+                parameters: { type: "object", properties: {} },
+              },
+            ],
+          },
+        ],
+      },
+      "/v1/responses"
+    );
+    expect(request.tools).toEqual([
+      {
+        type: "function",
+        function: {
+          name: "inner_tool",
+          description: "d",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

Corrects several cross-protocol converter bugs and documents them under **0.2.0** in the changelog.

## Changes

- **Anthropic → OpenAI**: `tool_choice` type `any` maps to OpenAI `required` (not `auto`).
- **Responses → Chat Completions**: `namespace` tools are expanded to nested `function` tools (no longer blocked by the strip set).
- **Stop / finish reasons**: `stop_sequence` ↔ `stop`; OpenAI `content_filter` maps to Anthropic `end_turn` (not `stop_sequence`).
- **Images**: incomplete base64 sources yield an empty `image_url` instead of invalid `data:undefined;...` URLs.
- **OpenAI → Anthropic**: string + array system messages are merged into the Anthropic `system` block list without dropping strings.
- **Internals**: simplified `parseFunctionArguments`, shared tool `content` stringify helper, removed redundant message deep copy and dead `convertMessage` fallback.

## Testing

- `npm run lint` and `npm test` (unit) pass locally.

## Changelog

Updates [CHANGELOG.md](CHANGELOG.md) under **[0.2.0]**.

Made with [Cursor](https://cursor.com)