### PR TITLE
feat: providerType split (openai/openai_chat), config hot-reload, cross-protocol streaming

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,6 +13,11 @@ tests/**
 .gitignore
 .yarnrc
 
+# Dev tooling
+.husky/**
+.claude/**
+CLAUDE.md
+
 # TypeScript configuration
 **/tsconfig.json
 **/.eslintrc.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`providerType` split**: `providerType` now has three values — `"anthropic"` (unchanged), `"openai"` (full passthrough — both Chat Completions and Responses API are forwarded without conversion), `"openai_chat"` (Chat Completions only — Responses API requests are converted to Chat Completions before forwarding). Existing `"openai"` configs are treated as full passthrough; update to `"openai_chat"` to preserve the previous Responses→Chat conversion behavior.
 - **Synthetic SSE for `POST /v1/chat/completions` with `stream: true` (cross-protocol)**: when upstream returns non-streaming but the client requested streaming, ccrelay emits `text/event-stream` with `chat.completion.chunk` deltas (text, thinking, tool calls) and `[DONE]`. Previously this path only existed for `POST /v1/responses`.
 - **Cross-protocol `GET /v1/models` conversion**: when the client's API surface (OpenAI vs Anthropic) differs from the upstream provider type, the response is automatically converted to the client's expected format.
 - **Cross-protocol error format conversion**: error responses (status >= 400) are re-wrapped to match the client's expected API surface — Anthropic `{ type, error: { type, message } }` or OpenAI `{ error: { type, message, code } }` shapes.
@@ -18,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Config change event bus**: `ConfigManager.onConfigChanged` event notifies all subscribers (status bar, server, WebSocket broadcaster) when config is reloaded, whether from file watch or API mutation.
 - **WebSocket `config_changed` broadcast**: Leader broadcasts config changes to all Follower instances via WebSocket, so Followers reload their local config automatically.
 - **Duplicate provider: editable New provider ID**: the Duplicate dialog now lets you customize the new provider ID instead of being locked to `<sourceId>_copy`.
+
+### Changed
+
+- **Converter simplification**: `convertRequestToOpenAI`, `convertOpenAIRequestToAnthropic`, and `convertResponsesRequestToChatCompletions` no longer accept a `provider` parameter for custom path resolution — paths are now deterministic (`/chat/completions` for OpenAI, `/v1/messages` for Anthropic).
+- **Cross-protocol conversion guard**: `needsConversion` and upstream wire detection now correctly distinguish all three provider types (`"anthropic"`, `"openai"`, `"openai_chat"`) instead of treating anything non-Anthropic as full OpenAI passthrough.
+
+### Removed
+
+- **`openaiChatCompletionsPath` provider setting**: the Chat Completions endpoint is always `/chat/completions`; adjust `baseUrl` to include any path prefix (e.g. change `baseUrl: "https://example.com"` + `openaiChatCompletionsPath: "/v1/chat/completions"` to `baseUrl: "https://example.com/v1"`).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cross-protocol error format conversion**: error responses (status >= 400) are re-wrapped to match the client's expected API surface — Anthropic `{ type, error: { type, message } }` or OpenAI `{ error: { type, message, code } }` shapes.
 - **`GET /v1/models`**: model list now shows both pattern names and target model names from `modelMap`, with deduplication when they match.
 - **Converters**: `convertOpenAIModelsToAnthropic` and `convertAnthropicModelsToOpenAI` for bidirectional models list format conversion.
+- **Config hot-reload**: `ConfigManager` now watches the YAML config file with `fs.watch` (300ms debounce). External edits to `~/.ccrelay/config.yaml` are picked up automatically without needing to click Reload.
+- **Config change event bus**: `ConfigManager.onConfigChanged` event notifies all subscribers (status bar, server, WebSocket broadcaster) when config is reloaded, whether from file watch or API mutation.
+- **WebSocket `config_changed` broadcast**: Leader broadcasts config changes to all Follower instances via WebSocket, so Followers reload their local config automatically.
+- **Duplicate provider: editable New provider ID**: the Duplicate dialog now lets you customize the new provider ID instead of being locked to `<sourceId>_copy`.
 
 ### Fixed
 
@@ -23,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Empty choices handling**: `convertChatCompletionToResponses` and `convertResponseToAnthropic` now handle upstream responses with empty `choices` arrays gracefully instead of crashing.
 - **Cross-protocol streaming guard**: `stream: "true"` (string) is now also detected and forced to `false` for cross-protocol conversion, not just `stream: true` (boolean).
 - **Custom auth headers**: router now supports any custom `authHeader` value on a provider, not just `authorization` or `x-api-key`.
+- **Delete active provider**: deleting the currently active provider now automatically switches to the default provider instead of leaving a stale `currentProviderId` that caused incorrect status bar display.
 
 ## [0.2.0] - 2026-04-26 (pre-release)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Synthetic SSE for `POST /v1/chat/completions` with `stream: true` (cross-protocol)**: when upstream returns non-streaming but the client requested streaming, ccrelay emits `text/event-stream` with `chat.completion.chunk` deltas (text, thinking, tool calls) and `[DONE]`. Previously this path only existed for `POST /v1/responses`.
+- **Cross-protocol `GET /v1/models` conversion**: when the client's API surface (OpenAI vs Anthropic) differs from the upstream provider type, the response is automatically converted to the client's expected format.
+- **Cross-protocol error format conversion**: error responses (status >= 400) are re-wrapped to match the client's expected API surface — Anthropic `{ type, error: { type, message } }` or OpenAI `{ error: { type, message, code } }` shapes.
+- **`GET /v1/models`**: model list now shows both pattern names and target model names from `modelMap`, with deduplication when they match.
+- **Converters**: `convertOpenAIModelsToAnthropic` and `convertAnthropicModelsToOpenAI` for bidirectional models list format conversion.
+
+### Fixed
+
+- **Anthropic → OpenAI thinking blocks**: multiple thinking blocks in a single assistant message are now merged (content joined, last non-empty signature used) instead of only using the first one.
+- **Reasoning budget thresholds**: Anthropic `thinking.budget_tokens` 4097–8192 now maps to OpenAI `"high"` effort instead of `"medium"`, avoiding round-trip budget loss (medium → 4096 would reduce the budget).
+- **Orphaned tool messages**: `buildAnthropicMessages` now skips `role: "tool"` messages that don't follow an assistant message with tool calls, preventing upstream 400 errors.
+- **Empty choices handling**: `convertChatCompletionToResponses` and `convertResponseToAnthropic` now handle upstream responses with empty `choices` arrays gracefully instead of crashing.
+- **Cross-protocol streaming guard**: `stream: "true"` (string) is now also detected and forced to `false` for cross-protocol conversion, not just `stream: true` (boolean).
+- **Custom auth headers**: router now supports any custom `authHeader` value on a provider, not just `authorization` or `x-api-key`.
+
 ## [0.2.0] - 2026-04-26 (pre-release)
 
 This is the **0.2.0** development line until a stable release is tagged. **Packaging:** `npm run package:beta` rewrites the version to `0.2.0-beta.<build>` and runs `package`; `npm run package:release` strips a `-beta…` suffix for a `0.2.0` build, then `package` (see root `package.json` scripts).

--- a/src/api/providers.ts
+++ b/src/api/providers.ts
@@ -60,7 +60,6 @@ export function handleListProviders(
     active: p.id === currentId,
     enabled: p.enabled !== false,
     apiKey: maskApiKey(p.apiKey),
-    openaiChatCompletionsPath: p.openaiChatCompletionsPath,
     modelsListFormat: p.modelsListFormat,
     modelMap: p.modelMap,
   }));
@@ -120,7 +119,6 @@ export async function handleAddProvider(
       modelMap: body.modelMap,
       vlModelMap: body.vlModelMap,
       headers: body.headers,
-      openaiChatCompletionsPath: body.openaiChatCompletionsPath,
       modelsListFormat: body.modelsListFormat,
     };
 
@@ -191,7 +189,6 @@ function buildDuplicateConfigFromProvider(source: Provider, name: string): Provi
     providerType: source.providerType,
     apiKey: source.apiKey,
     authHeader: source.authHeader,
-    openaiChatCompletionsPath: source.openaiChatCompletionsPath,
     modelsListFormat: source.modelsListFormat,
     modelMap: source.modelMap,
     vlModelMap: source.vlModelMap,
@@ -316,7 +313,7 @@ interface AddProviderRequest {
   id: string;
   name: string;
   baseUrl: string;
-  providerType: "anthropic" | "openai";
+  providerType: "anthropic" | "openai" | "openai_chat";
   mode: "passthrough" | "inject";
   apiKey?: string;
   authHeader?: string;
@@ -324,6 +321,5 @@ interface AddProviderRequest {
   modelMap?: ModelMapEntry[];
   vlModelMap?: ModelMapEntry[];
   headers?: Record<string, string>;
-  openaiChatCompletionsPath?: string;
   modelsListFormat?: "auto" | "openai" | "anthropic";
 }

--- a/src/api/providers.ts
+++ b/src/api/providers.ts
@@ -167,9 +167,16 @@ export function handleDeleteProvider(
   }
 
   const configManager = serverInstance.getConfig();
+  const router = serverInstance.getRouter();
+  const wasActive = router.getCurrentProviderId() === id;
   const success = configManager.deleteProvider(id);
 
   if (success) {
+    // If the deleted provider was active, switch to the default
+    if (wasActive) {
+      const fallbackId = configManager.defaultProvider;
+      void router.switchProvider(fallbackId);
+    }
     sendJson(res, 200, { status: "ok", message: `Provider "${id}" deleted` });
   } else {
     sendJson(res, 400, { status: "error", message: `Failed to delete provider "${id}"` });

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -44,7 +44,7 @@ providers:
     name: "Claude Official"
     baseUrl: "https://api.anthropic.com"
     mode: "passthrough"         # passthrough | inject
-    providerType: "anthropic"   # anthropic | openai
+    providerType: "anthropic"   # anthropic | openai | openai_chat
     enabled: true
 
   # Example: Custom provider
@@ -250,8 +250,6 @@ function parseProvider(id: string, config: ProviderConfigInput): Provider {
   const modelMap = config.modelMap || config.model_map;
   const vlModelMap = config.vlModelMap || config.vl_model_map;
   const providerType = config.providerType || config.provider_type || "anthropic";
-  const openaiChatCompletionsPath =
-    config.openaiChatCompletionsPath || config.openai_chat_completions_path;
   const modelsListFormat = config.modelsListFormat || config.models_list_format || "auto";
 
   return {
@@ -262,7 +260,6 @@ function parseProvider(id: string, config: ProviderConfigInput): Provider {
     providerType,
     apiKey,
     authHeader: authHeader || "authorization",
-    openaiChatCompletionsPath: openaiChatCompletionsPath || undefined,
     modelsListFormat,
     modelMap: modelMap && modelMap.length > 0 ? modelMap : undefined,
     vlModelMap: vlModelMap && vlModelMap.length > 0 ? vlModelMap : undefined,
@@ -866,9 +863,6 @@ export class ConfigManager {
         vl_model_map: config.vl_model_map,
         headers: config.headers,
         enabled: id === "official" ? true : (config.enabled ?? true),
-        openaiChatCompletionsPath: config.openaiChatCompletionsPath,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        openai_chat_completions_path: config.openai_chat_completions_path,
         modelsListFormat: config.modelsListFormat,
         // eslint-disable-next-line @typescript-eslint/naming-convention
         models_list_format: config.models_list_format,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -376,6 +376,12 @@ export class ConfigManager {
   private context: vscode.ExtensionContext;
   private disposables: vscode.Disposable[] = [];
   private configPath: string;
+  private configChangeCallbacks: Set<() => void> = new Set();
+
+  // File watcher state
+  private fileWatcher: fs.FSWatcher | null = null;
+  private fileWatchDebounce: NodeJS.Timeout | null = null;
+  private saving = false;
 
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
@@ -391,17 +397,63 @@ export class ConfigManager {
     // Load configuration
     this.config = this.loadConfig();
 
-    // Watch for configuration changes
+    // Watch for VS Code setting changes (config path)
     const configWatcher = vscode.workspace.onDidChangeConfiguration(e => {
       if (e.affectsConfiguration("ccrelay.configPath")) {
-        // Config path changed, reload everything
         const newPath = vscodeConfig.get<string>("configPath", "~/.ccrelay/config.yaml");
         this.configPath = expandPath(newPath);
         this.ensureConfigFile();
         this.config = this.loadConfig();
+        this.startFileWatcher();
       }
     });
     this.disposables.push(configWatcher);
+
+    // Watch the YAML config file for external edits
+    this.startFileWatcher();
+  }
+
+  /**
+   * Start watching the config YAML file for external changes
+   */
+  private startFileWatcher(): void {
+    this.stopFileWatcher();
+
+    if (!fs.existsSync(this.configPath)) {
+      return;
+    }
+
+    try {
+      this.fileWatcher = fs.watch(this.configPath, () => {
+        if (this.saving) {
+          return;
+        }
+        if (this.fileWatchDebounce) {
+          clearTimeout(this.fileWatchDebounce);
+        }
+        this.fileWatchDebounce = setTimeout(() => {
+          this.fileWatchDebounce = null;
+          console.log("[ConfigManager] Config file changed externally, reloading...");
+          this.reload();
+        }, 300);
+      });
+    } catch {
+      // fs.watch may fail on some platforms; non-critical
+    }
+  }
+
+  /**
+   * Stop watching the config YAML file
+   */
+  private stopFileWatcher(): void {
+    if (this.fileWatchDebounce) {
+      clearTimeout(this.fileWatchDebounce);
+      this.fileWatchDebounce = null;
+    }
+    if (this.fileWatcher) {
+      this.fileWatcher.close();
+      this.fileWatcher = null;
+    }
   }
 
   /**
@@ -620,12 +672,40 @@ export class ConfigManager {
   }
 
   /**
+   * Register a callback for config changes
+   */
+  onConfigChanged(callback: () => void): void {
+    this.configChangeCallbacks.add(callback);
+  }
+
+  /**
+   * Unregister a config change callback
+   */
+  offConfigChanged(callback: () => void): void {
+    this.configChangeCallbacks.delete(callback);
+  }
+
+  /**
+   * Notify all registered config change listeners
+   */
+  private notifyConfigChanged(): void {
+    for (const callback of this.configChangeCallbacks) {
+      try {
+        callback();
+      } catch {
+        // Ignore callback errors
+      }
+    }
+  }
+
+  /**
    * Reload configuration from file
    */
   reload(): void {
     console.log("[ConfigManager] Reloading configuration...");
     this.ensureConfigFile();
     this.config = this.loadConfig();
+    this.notifyConfigChanged();
   }
 
   get configValue(): RouterConfig {
@@ -804,13 +884,16 @@ export class ConfigManager {
         quotingType: '"',
         forceQuotes: false,
       });
+      this.saving = true;
       fs.writeFileSync(this.configPath, yamlContent, "utf-8");
+      this.saving = false;
 
       // Reload in-memory config
       this.reload();
 
       return true;
     } catch (err) {
+      this.saving = false;
       console.error("[ConfigManager] Failed to add provider:", err);
       return false;
     }
@@ -867,19 +950,23 @@ export class ConfigManager {
         lineWidth: -1,
         noRefs: true,
       });
+      this.saving = true;
       fs.writeFileSync(this.configPath, yamlContent, "utf-8");
+      this.saving = false;
 
       // Reload in-memory config
       this.reload();
 
       return true;
     } catch (err) {
+      this.saving = false;
       console.error("[ConfigManager] Failed to delete provider:", err);
       return false;
     }
   }
 
   dispose(): void {
+    this.stopFileWatcher();
     for (const d of this.disposables) {
       d.dispose();
     }

--- a/src/converter/anthropic-to-openai.ts
+++ b/src/converter/anthropic-to-openai.ts
@@ -12,8 +12,6 @@
 // External API fields use snake_case (max_tokens, tool_choice, etc.)
 
 import type { MessageParam, ContentBlockParam } from "../types";
-import type { OpenAIPathProvider } from "./openaiPath";
-import { getOpenAIChatCompletionsPath } from "./openaiPath";
 
 /**
  * Anthropic Messages API request format
@@ -178,8 +176,7 @@ export interface ConversionResult {
  */
 export function convertRequestToOpenAI(
   anthropic: AnthropicMessageRequest,
-  originalPath: string,
-  provider?: OpenAIPathProvider | null
+  originalPath: string
 ): ConversionResult {
   const openai: OpenAIMessageRequest = {
     model: anthropic.model,
@@ -266,10 +263,10 @@ export function convertRequestToOpenAI(
     };
   }
 
-  // Convert path: /v1/messages -> configured OpenAI Chat Completions path
+  // Convert path: /v1/messages -> /chat/completions
   let newPath = originalPath;
   if (originalPath === "/v1/messages" || originalPath === "/messages") {
-    newPath = getOpenAIChatCompletionsPath(provider);
+    newPath = "/chat/completions";
   }
 
   return {

--- a/src/converter/anthropic-to-openai.ts
+++ b/src/converter/anthropic-to-openai.ts
@@ -290,9 +290,11 @@ function getThinkLevel(budgetTokens?: number): string {
   if (budgetTokens <= 1024) {
     return "low";
   }
-  if (budgetTokens <= 8192) {
+  if (budgetTokens <= 4096) {
     return "medium";
   }
+  // 4097–8192+ maps to "high" to avoid round-trip loss
+  // (medium → 4096 would reduce budget; high → 16000 preserves or increases it)
   return "high";
 }
 
@@ -422,13 +424,23 @@ function convertAssistantMessage(content: ContentBlockParam[], targetModel: stri
 
   const gemini = isGeminiModel(targetModel);
 
-  // Extract thinking block signature first (needed for both paths)
+  // Extract thinking blocks (may be multiple; merge content, use last non-empty signature)
   let thoughtSignature: string | undefined;
-  const thinkingPart = content.find(c => c.type === "thinking");
-  if (thinkingPart) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- Type narrowing after find
-    const thinking = thinkingPart as Extract<ContentBlockParam, { type: "thinking" }>;
-    thoughtSignature = thinking.signature;
+  let combinedThinkingContent: string | undefined;
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- filter does not narrow generic unions
+  const thinkingParts = content.filter(c => c.type === "thinking") as Extract<
+    ContentBlockParam,
+    { type: "thinking" }
+  >[];
+  if (thinkingParts.length > 0) {
+    combinedThinkingContent = thinkingParts.map(t => t.thinking).join("\n\n");
+    // Use the last non-empty signature
+    for (let i = thinkingParts.length - 1; i >= 0; i--) {
+      if (thinkingParts[i].signature) {
+        thoughtSignature = thinkingParts[i].signature;
+        break;
+      }
+    }
   }
 
   // Extract text blocks → join into single string
@@ -473,12 +485,10 @@ function convertAssistantMessage(content: ContentBlockParam[], targetModel: stri
 
   // For non-Gemini: keep thinking as standalone field
   // For Gemini: signature is already attached to tool_calls above
-  if (!gemini && thinkingPart && thoughtSignature) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- Type narrowing after find
-    const thinking = thinkingPart as Extract<ContentBlockParam, { type: "thinking" }>;
+  if (!gemini && combinedThinkingContent && thoughtSignature) {
     assistantMessage.thinking = {
-      content: thinking.thinking,
-      signature: thinking.signature,
+      content: combinedThinkingContent,
+      signature: thoughtSignature,
     };
   }
 

--- a/src/converter/chat-completions-to-responses.ts
+++ b/src/converter/chat-completions-to-responses.ts
@@ -1,5 +1,6 @@
 /**
  * Chat Completions (non-streaming) JSON -> OpenAI Responses API JSON shape
+ * + Chat Completions synthetic SSE (cross-protocol streaming)
  */
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -195,10 +196,147 @@ function pushFunctionCallOutputItemSse(
   });
 }
 
+/**
+ * Synthesize OpenAI Chat Completions SSE for clients that sent `stream: true` during
+ * cross-protocol conversion (upstream returned non-streaming JSON).
+ *
+ * Emits:
+ * 1. Initial chunk with role: "assistant" and empty content
+ * 2. Content text delta chunks (SSE_TEXT_CHUNK chars each)
+ * 3. Thinking delta chunks (if present)
+ * 4. Tool call chunks: first chunk has name + empty arguments, subsequent chunks have argument deltas
+ * 5. Final chunk with finish_reason and usage
+ * 6. [DONE]
+ */
+export function formatOpenAIChatCompletionsSse(response: OpenAIChatCompletionResponse): string {
+  const choice = response.choices?.[0];
+  if (!choice) {
+    return `data: ${JSON.stringify({
+      id: response.id,
+      object: "chat.completion.chunk",
+      created: response.created,
+      model: response.model,
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+    })}\n\ndata: [DONE]\n\n`;
+  }
+
+  const message = choice.message;
+  const lines: string[] = [];
+  const baseChunk = {
+    id: response.id,
+    object: "chat.completion.chunk" as const,
+    created: response.created,
+    model: response.model,
+  };
+
+  const push = (delta: Record<string, unknown>, finishReason: string | null = null): void => {
+    lines.push(
+      `data: ${JSON.stringify({
+        ...baseChunk,
+        choices: [{ index: 0, delta, finish_reason: finishReason }],
+      })}\n\n`
+    );
+  };
+
+  // 1. Initial chunk with role
+  push({ role: "assistant", content: "" });
+
+  // 2. Text content deltas
+  const text = typeof message.content === "string" ? message.content : "";
+  if (text.length > 0) {
+    for (let i = 0; i < text.length; i += SSE_TEXT_CHUNK) {
+      push({ content: text.slice(i, i + SSE_TEXT_CHUNK) });
+    }
+  }
+
+  // 3. Thinking deltas
+  if (message.thinking?.content) {
+    const thinkingText = message.thinking.content;
+    for (let i = 0; i < thinkingText.length; i += SSE_TEXT_CHUNK) {
+      push({
+        thinking: {
+          content: thinkingText.slice(i, i + SSE_TEXT_CHUNK),
+          ...(i === 0 && message.thinking.signature
+            ? { signature: message.thinking.signature }
+            : {}),
+        },
+      });
+    }
+  }
+
+  // 4. Tool call deltas
+  const toolCalls = message.tool_calls ?? [];
+  for (let tcIndex = 0; tcIndex < toolCalls.length; tcIndex++) {
+    const tc = toolCalls[tcIndex];
+    const fullArgs = tc.function.arguments ?? "";
+
+    // First chunk: tool call metadata with empty arguments
+    push({
+      tool_calls: [
+        {
+          index: tcIndex,
+          id: tc.id,
+          type: "function",
+          function: { name: tc.function.name, arguments: "" },
+          ...(tc.extra_content ? { extra_content: tc.extra_content } : {}),
+        },
+      ],
+    });
+
+    // Argument deltas
+    if (fullArgs.length > 0) {
+      for (let i = 0; i < fullArgs.length; i += SSE_TEXT_CHUNK) {
+        push({
+          tool_calls: [
+            {
+              index: tcIndex,
+              function: { arguments: fullArgs.slice(i, i + SSE_TEXT_CHUNK) },
+            },
+          ],
+        });
+      }
+    }
+  }
+
+  // 5. Final chunk with finish_reason
+  const finishReason = choice.finish_reason === "tool_calls" ? "tool_calls" : "stop";
+  push({}, finishReason);
+
+  // 6. Usage chunk (as a separate final data event)
+  if (response.usage) {
+    lines.push(
+      `data: ${JSON.stringify({
+        ...baseChunk,
+        choices: [],
+        usage: {
+          prompt_tokens: response.usage.prompt_tokens,
+          completion_tokens: response.usage.completion_tokens,
+          total_tokens: response.usage.total_tokens,
+        },
+      })}\n\n`
+    );
+  }
+
+  // 7. DONE
+  lines.push("data: [DONE]\n\n");
+  return lines.join("");
+}
+
 export function convertChatCompletionToResponses(
   chat: OpenAIChatCompletionResponse,
   _originalModel: string
 ): OpenAIResponsesApiObject {
+  if (!chat.choices || chat.choices.length === 0) {
+    return {
+      id: `resp_${randomUUID().replace(/-/g, "")}`,
+      object: "response",
+      created_at: chat.created || Math.floor(Date.now() / 1000),
+      model: chat.model || "",
+      status: "completed",
+      output: [],
+      usage: undefined,
+    };
+  }
   const choice = chat.choices[0];
   const message = choice?.message;
   const output: unknown[] = [];

--- a/src/converter/index.ts
+++ b/src/converter/index.ts
@@ -21,12 +21,7 @@ export {
   isOpenAIChatCompletionsRequest,
 } from "./openai-to-anthropic-request";
 
-export {
-  getOpenAIChatCompletionsPath,
-  isOpenAIChatCompletionsWirePath,
-  DEFAULT_OPENAI_CHAT_COMPLETIONS_PATH,
-  type OpenAIPathProvider,
-} from "./openaiPath";
+export { isOpenAIChatCompletionsWirePath, isOpenAIType } from "./openaiPath";
 
 export {
   convertAnthropicResponseToOpenAI,

--- a/src/converter/index.ts
+++ b/src/converter/index.ts
@@ -38,6 +38,8 @@ export {
   buildOpenAIModelsListFromProvider,
   buildAnthropicModelsListFromProvider,
   buildModelsListFallback,
+  convertOpenAIModelsToAnthropic,
+  convertAnthropicModelsToOpenAI,
   type OpenAIModelsListResponse,
   type AnthropicModelsListResponse,
 } from "./modelsFallback";
@@ -51,5 +53,6 @@ export {
 export {
   convertChatCompletionToResponses,
   formatOpenAIResponsesSse,
+  formatOpenAIChatCompletionsSse,
   type OpenAIResponsesApiObject,
 } from "./chat-completions-to-responses";

--- a/src/converter/modelsFallback.ts
+++ b/src/converter/modelsFallback.ts
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/naming-convention -- API wire uses snake_case */
 
 import type { ModelsListFormat, Provider } from "../types";
+import { isOpenAIType } from "./openaiPath";
 
 export interface OpenAIModelsListResponse {
   object: "list";
@@ -137,7 +138,7 @@ export function buildModelsListFallback(
   if (fmt === "anthropic") {
     return buildAnthropicModelsListFromProvider(provider);
   }
-  return provider.providerType === "openai"
+  return isOpenAIType(provider.providerType)
     ? buildOpenAIModelsListFromProvider(provider)
     : buildAnthropicModelsListFromProvider(provider);
 }

--- a/src/converter/modelsFallback.ts
+++ b/src/converter/modelsFallback.ts
@@ -37,14 +37,29 @@ export interface AnthropicModelsListResponse {
 export function buildOpenAIModelsListFromProvider(provider: Provider): OpenAIModelsListResponse {
   const data: OpenAIModelEntry[] = [];
   const now = Math.floor(Date.now() / 1000);
+  const seen = new Set<string>();
 
   for (const entry of provider.modelMap ?? []) {
-    data.push({
-      id: entry.model,
-      object: "model",
-      created: now,
-      owned_by: "ccrelay",
-    });
+    // Always show the pattern name (what clients should use)
+    if (!seen.has(entry.pattern)) {
+      seen.add(entry.pattern);
+      data.push({
+        id: entry.pattern,
+        object: "model",
+        created: now,
+        owned_by: "ccrelay",
+      });
+    }
+    // Also show the target model name if different
+    if (entry.pattern !== entry.model && !seen.has(entry.model)) {
+      seen.add(entry.model);
+      data.push({
+        id: entry.model,
+        object: "model",
+        created: now,
+        owned_by: "ccrelay",
+      });
+    }
   }
 
   if (data.length === 0) {
@@ -66,13 +81,27 @@ export function buildAnthropicModelsListFromProvider(
   provider: Provider
 ): AnthropicModelsListResponse {
   const data: AnthropicModelInfo[] = [];
+  const seen = new Set<string>();
 
   for (const entry of provider.modelMap ?? []) {
-    data.push({
-      id: entry.model,
-      type: "model",
-      display_name: entry.model,
-    });
+    // Always show the pattern name (what clients should use)
+    if (!seen.has(entry.pattern)) {
+      seen.add(entry.pattern);
+      data.push({
+        id: entry.pattern,
+        type: "model",
+        display_name: entry.pattern,
+      });
+    }
+    // Also show the target model name if different
+    if (entry.pattern !== entry.model && !seen.has(entry.model)) {
+      seen.add(entry.model);
+      data.push({
+        id: entry.model,
+        type: "model",
+        display_name: entry.model,
+      });
+    }
   }
 
   if (data.length === 0) {
@@ -114,3 +143,38 @@ export function buildModelsListFallback(
 }
 
 export { buildOpenAIModelsListFromProvider as buildModelsListFromProvider };
+
+/**
+ * Convert an OpenAI-format models list response to Anthropic format
+ */
+export function convertOpenAIModelsToAnthropic(
+  openai: OpenAIModelsListResponse
+): AnthropicModelsListResponse {
+  const data: AnthropicModelInfo[] = (openai.data ?? []).map(entry => ({
+    id: entry.id,
+    type: "model" as const,
+    display_name: entry.id,
+  }));
+  return {
+    data,
+    first_id: data.length > 0 ? data[0].id : null,
+    has_more: false,
+    last_id: data.length > 0 ? data[data.length - 1].id : null,
+  };
+}
+
+/**
+ * Convert an Anthropic-format models list response to OpenAI format
+ */
+export function convertAnthropicModelsToOpenAI(
+  anthropic: AnthropicModelsListResponse
+): OpenAIModelsListResponse {
+  const now = Math.floor(Date.now() / 1000);
+  const data: OpenAIModelEntry[] = (anthropic.data ?? []).map(entry => ({
+    id: entry.id,
+    object: "model" as const,
+    created: now,
+    owned_by: "ccrelay",
+  }));
+  return { object: "list", data };
+}

--- a/src/converter/openai-to-anthropic-request.ts
+++ b/src/converter/openai-to-anthropic-request.ts
@@ -14,7 +14,6 @@ import type {
   OpenAIMessageRequest,
   OpenAITool,
 } from "./anthropic-to-openai";
-import type { OpenAIPathProvider } from "./openaiPath";
 import { isOpenAIChatCompletionsWirePath } from "./openaiPath";
 
 export interface OpenAIToAnthropicRequestResult {
@@ -28,8 +27,7 @@ export interface OpenAIToAnthropicRequestResult {
  */
 export function convertOpenAIRequestToAnthropic(
   openai: OpenAIMessageRequest,
-  originalPath: string,
-  provider?: OpenAIPathProvider | null
+  originalPath: string
 ): OpenAIToAnthropicRequestResult {
   const messages = openai.messages || [];
   const { systemText, systemBlocks, restMessages } = extractSystem(messages);
@@ -76,7 +74,7 @@ export function convertOpenAIRequestToAnthropic(
   }
 
   let newPath = originalPath;
-  if (isOpenAIChatCompletionsWirePath(originalPath, provider)) {
+  if (isOpenAIChatCompletionsWirePath(originalPath)) {
     newPath = "/v1/messages";
   }
 

--- a/src/converter/openai-to-anthropic-request.ts
+++ b/src/converter/openai-to-anthropic-request.ts
@@ -175,13 +175,16 @@ function extractSystem(messages: OpenAIMessage[]): {
 function buildAnthropicMessages(messages: OpenAIMessage[]): MessageParam[] {
   const out: MessageParam[] = [];
   let i = 0;
+  let lastAssistantHadToolCalls = false;
   while (i < messages.length) {
     const m = messages[i];
     if (m.role === "user") {
       out.push({ role: "user", content: convertUserContent(m) });
       i++;
+      lastAssistantHadToolCalls = false;
     } else if (m.role === "assistant") {
       out.push({ role: "assistant", content: convertAssistantContent(m) });
+      lastAssistantHadToolCalls = Boolean(m.tool_calls && m.tool_calls.length > 0);
       i++;
       const toolResults: ContentBlockParam[] = [];
       while (i < messages.length && messages[i].role === "tool") {
@@ -198,6 +201,11 @@ function buildAnthropicMessages(messages: OpenAIMessage[]): MessageParam[] {
         out.push({ role: "user", content: toolResults });
       }
     } else if (m.role === "tool") {
+      // Skip orphaned tool messages (no preceding assistant message with tool_calls)
+      if (!lastAssistantHadToolCalls) {
+        i++;
+        continue;
+      }
       const toolResults: ContentBlockParam[] = [];
       while (i < messages.length && messages[i].role === "tool") {
         const t = messages[i];

--- a/src/converter/openai-to-anthropic.ts
+++ b/src/converter/openai-to-anthropic.ts
@@ -198,6 +198,18 @@ export function convertResponseToAnthropic(
   openai: OpenAIChatCompletionResponse,
   originalModel: string
 ): AnthropicMessageResponse {
+  if (!openai.choices || openai.choices.length === 0) {
+    return {
+      id: openai.id || `msg_${randomUUID().replace(/-/g, "")}`,
+      type: "message",
+      role: "assistant",
+      content: [{ type: "text", text: "" }],
+      model: originalModel,
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0 },
+    };
+  }
   const choice = openai.choices[0];
   const message = choice.message;
 

--- a/src/converter/openaiPath.ts
+++ b/src/converter/openaiPath.ts
@@ -1,35 +1,19 @@
 /**
- * Resolves the upstream path for OpenAI Chat Completions after protocol conversion
- * (Anthropic → OpenAI, OpenAI Responses → Chat Completions).
+ * OpenAI path utilities for protocol detection and type checks.
  */
 
-import type { Provider } from "../types";
+import type { ProviderType } from "../types";
 
-export const DEFAULT_OPENAI_CHAT_COMPLETIONS_PATH = "/chat/completions" as const;
-
-export type OpenAIPathProvider = Pick<Provider, "openaiChatCompletionsPath">;
-
-export function getOpenAIChatCompletionsPath(provider?: OpenAIPathProvider | null): string {
-  const p = provider?.openaiChatCompletionsPath;
-  if (p && p.length > 0) {
-    return p.trim();
-  }
-  return DEFAULT_OPENAI_CHAT_COMPLETIONS_PATH;
+/**
+ * True if `originalPath` is a recognized OpenAI Chat Completions endpoint.
+ */
+export function isOpenAIChatCompletionsWirePath(originalPath: string): boolean {
+  return originalPath === "/chat/completions" || originalPath === "/v1/chat/completions";
 }
 
 /**
- * True if `originalPath` is the OpenAI Chat Completions endpoint for this provider
- * (including legacy literals when provider is unknown).
+ * True if the provider type is any OpenAI variant (full or chat-only).
  */
-export function isOpenAIChatCompletionsWirePath(
-  originalPath: string,
-  provider?: OpenAIPathProvider | null
-): boolean {
-  if (originalPath === "/v1/chat/completions" || originalPath === "/chat/completions") {
-    return true;
-  }
-  if (provider && originalPath === getOpenAIChatCompletionsPath(provider)) {
-    return true;
-  }
-  return false;
+export function isOpenAIType(providerType: ProviderType): boolean {
+  return providerType === "openai" || providerType === "openai_chat";
 }

--- a/src/converter/responses-to-chat-completions.ts
+++ b/src/converter/responses-to-chat-completions.ts
@@ -12,8 +12,6 @@ import type {
   OpenAIToolChoice,
 } from "./anthropic-to-openai";
 import { isOpenAIChatCompletionsRequest } from "./openai-to-anthropic-request";
-import type { OpenAIPathProvider } from "./openaiPath";
-import { getOpenAIChatCompletionsPath } from "./openaiPath";
 
 const log = new ScopedLogger("ResponsesToChat");
 
@@ -54,8 +52,7 @@ export function isOpenAIResponsesRequest(data: Record<string, unknown>): boolean
  */
 export function convertResponsesRequestToChatCompletions(
   raw: Record<string, unknown>,
-  _originalPath: string,
-  provider?: OpenAIPathProvider | null
+  _originalPath: string
 ): ResponsesToChatResult {
   const messages: OpenAIMessage[] = [];
   const instructions = raw.instructions;
@@ -135,7 +132,7 @@ export function convertResponsesRequestToChatCompletions(
 
   return {
     request: out,
-    newPath: getOpenAIChatCompletionsPath(provider),
+    newPath: "/chat/completions",
   };
 }
 

--- a/src/server/handler.ts
+++ b/src/server/handler.ts
@@ -84,6 +84,12 @@ export class ProxyServer {
       this.handleProviderChangeFromRouter(providerId);
     });
 
+    // Listen to config changes (provider add/delete/edit, file watch, etc.)
+    // - For Leader: broadcasts to Followers so they reload local config
+    config.onConfigChanged(() => {
+      this.handleConfigChanged();
+    });
+
     // Listen for role changes if election is enabled
     if (leaderElection) {
       leaderElection.onRoleChanged((info: RoleChangeInfo) => {
@@ -218,6 +224,9 @@ export class ProxyServer {
         // Update local Router - UI will be updated via Router's callback
         this.router.setCurrentProviderId(providerId);
       },
+      onConfigChanged: () => {
+        // Leader's own config_changed — already reloaded locally, skip
+      },
       onServerStopping: () => {
         this.log.info("[Server] Local WebSocket connection closing");
         this.disconnectFromLeader();
@@ -254,6 +263,10 @@ export class ProxyServer {
         // Update local Router - this will trigger UI update via Router's callback
         this.router.setCurrentProviderId(providerId);
       },
+      onConfigChanged: () => {
+        // Leader's config changed — reload local config so providers/routes stay in sync
+        this.config.reload();
+      },
       onServerStopping: () => {
         this.log.info("[Server] Leader is stopping, waiting for re-election");
         this.disconnectFromLeader();
@@ -274,6 +287,16 @@ export class ProxyServer {
       this.wsClient.disconnect();
       this.wsClient = null;
       this.log.info("[Server] Disconnected from Leader's WebSocket");
+    }
+  }
+
+  /**
+   * Handle config change from ConfigManager
+   * - Leader: Broadcast to Followers so they reload local config
+   */
+  private handleConfigChanged(): void {
+    if (this.wsBroadcaster) {
+      this.wsBroadcaster.broadcastConfigChanged();
     }
   }
 
@@ -537,6 +560,13 @@ export class ProxyServer {
 
   getConfig(): ConfigManager {
     return this.config;
+  }
+
+  /**
+   * Reload configuration from file (used by follower on config_changed WS message)
+   */
+  reloadConfig(): void {
+    this.config.reload();
   }
 
   /**

--- a/src/server/proxy/executor.ts
+++ b/src/server/proxy/executor.ts
@@ -14,7 +14,10 @@ import {
   convertAnthropicResponseToOpenAI,
   convertChatCompletionToResponses,
   formatOpenAIResponsesSse,
+  formatOpenAIChatCompletionsSse,
   convertResponseToAnthropic,
+  convertOpenAIModelsToAnthropic,
+  convertAnthropicModelsToOpenAI,
 } from "../../converter";
 import { isAnthropicMessageResponse } from "../../converter/anthropic-to-openai-response";
 import type { OpenAIChatCompletionResponse } from "../../converter/openai-to-anthropic";
@@ -537,24 +540,49 @@ export class ProxyExecutor {
           parsed,
           originalModel || (parsed as { model?: string }).model || "none"
         );
-        const outJson = JSON.stringify(openaiResponse);
-        ctx.responseChunks.push(Buffer.from(outJson, "utf-8"));
-        this.responseLogger.logResponse(
-          clientId,
-          duration,
-          status,
-          ctx.responseChunks,
-          undefined,
-          ctx.originalResponseBody
-        );
-        resolve({
-          statusCode: status,
-          headers: responseHeaders,
-          body: outJson,
-          duration,
-          responseBodyChunks: ctx.responseChunks,
-          originalResponseBody: ctx.originalResponseBody,
-        });
+
+        if (task.streamRequested) {
+          const sse = formatOpenAIChatCompletionsSse(openaiResponse);
+          log.info(
+            `[A->ChatCompletions] synthetic SSE: bytes=${sse.length}`
+          );
+          ctx.responseChunks.push(Buffer.from(sse, "utf-8"));
+          this.responseLogger.logResponse(
+            clientId,
+            duration,
+            status,
+            ctx.responseChunks,
+            undefined,
+            ctx.originalResponseBody
+          );
+          resolve({
+            statusCode: status,
+            headers: headersForResponsesSse(responseHeaders),
+            body: sse,
+            duration,
+            responseBodyChunks: ctx.responseChunks,
+            originalResponseBody: ctx.originalResponseBody,
+          });
+        } else {
+          const outJson = JSON.stringify(openaiResponse);
+          ctx.responseChunks.push(Buffer.from(outJson, "utf-8"));
+          this.responseLogger.logResponse(
+            clientId,
+            duration,
+            status,
+            ctx.responseChunks,
+            undefined,
+            ctx.originalResponseBody
+          );
+          resolve({
+            statusCode: status,
+            headers: responseHeaders,
+            body: outJson,
+            duration,
+            responseBodyChunks: ctx.responseChunks,
+            originalResponseBody: ctx.originalResponseBody,
+          });
+        }
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);
         log.warn(`[A->O response] Conversion failed for ${provider.id}: ${errMsg}`);
@@ -953,6 +981,85 @@ export class ProxyExecutor {
           delete outHeaders["Content-Length"];
         }
         log.info(`[${clientId}] GET /v1/models upstream returned ${status}; using config model list fallback`);
+      }
+
+      // Cross-protocol: convert /v1/models response format to match client's expected API surface
+      const upstreamWireFmt: ApiSurface = task.provider.providerType === "openai" ? "openai" : "anthropic";
+      if (
+        task.method === "GET" &&
+        (task.requestPath === "/v1/models" || task.requestPath.split("?")[0] === "/v1/models") &&
+        outStatus === 200 &&
+        task.clientSurface !== upstreamWireFmt &&
+        ctx.responseChunks.length > 0
+      ) {
+        try {
+          const bodyStr = Buffer.concat(ctx.responseChunks).toString("utf-8");
+          const parsed = JSON.parse(bodyStr) as Record<string, unknown>;
+          const clientWantsAnthropic = task.clientSurface === "anthropic";
+          const upstreamIsOpenAI =
+            Array.isArray(parsed.data) &&
+            (parsed.data as unknown[]).length > 0 &&
+            ((parsed.data as Record<string, unknown>[])[0] as { object?: string })?.object === "model";
+          const upstreamIsAnthropic =
+            Array.isArray(parsed.data) &&
+            (parsed.data as unknown[]).length > 0 &&
+            ((parsed.data as Record<string, unknown>[])[0] as { type?: string })?.type === "model";
+
+          if (upstreamIsOpenAI && clientWantsAnthropic) {
+            const anthropicList = convertOpenAIModelsToAnthropic(
+              parsed as unknown as Parameters<typeof convertOpenAIModelsToAnthropic>[0]
+            );
+            const buf = Buffer.from(JSON.stringify(anthropicList), "utf-8");
+            ctx.responseChunks = [buf];
+            outHeaders["content-type"] = "application/json";
+            log.info(`[${clientId}] GET /v1/models: converted OpenAI -> Anthropic format`);
+          } else if (upstreamIsAnthropic && !clientWantsAnthropic) {
+            const openaiList = convertAnthropicModelsToOpenAI(
+              parsed as unknown as Parameters<typeof convertAnthropicModelsToOpenAI>[0]
+            );
+            const buf = Buffer.from(JSON.stringify(openaiList), "utf-8");
+            ctx.responseChunks = [buf];
+            outHeaders["content-type"] = "application/json";
+            log.info(`[${clientId}] GET /v1/models: converted Anthropic -> OpenAI format`);
+          }
+        } catch {
+          // Parse failed; keep original response
+        }
+      }
+
+      // Cross-protocol: convert error response format to match client's expected API surface
+      const upstreamWire: ApiSurface = task.provider.providerType === "openai" ? "openai" : "anthropic";
+      if (outStatus >= 400 && task.clientSurface !== upstreamWire && ctx.responseChunks.length > 0) {
+        try {
+          const errorBody = Buffer.concat(ctx.responseChunks).toString("utf-8");
+          const parsed = JSON.parse(errorBody) as Record<string, unknown>;
+          let wrappedError: string;
+          if (task.clientSurface === "anthropic") {
+            const message =
+              ((parsed.error as Record<string, unknown>)?.message as string) ||
+              (parsed.message as string) ||
+              errorBody;
+            const type =
+              ((parsed.error as Record<string, unknown>)?.type as string) || "api_error";
+            wrappedError = JSON.stringify({ type: "error", error: { type, message } });
+          } else {
+            const message =
+              ((parsed.error as Record<string, unknown>)?.message as string) ||
+              (parsed.message as string) ||
+              errorBody;
+            const type =
+              ((parsed.error as Record<string, unknown>)?.type as string) || "server_error";
+            wrappedError = JSON.stringify({ error: { type, message, code: String(outStatus) } });
+          }
+          const wrappedBuf = Buffer.from(wrappedError, "utf-8");
+          ctx.responseChunks = [wrappedBuf];
+          outHeaders["content-type"] = "application/json";
+          log.info(
+            `[${clientId}] Cross-protocol error format converted: ${upstreamWire} -> ${task.clientSurface}`
+          );
+        } catch {
+          // Parse failed; keep original error body
+        }
       }
 
       this.responseLogger.logResponse(clientId, totalDuration, outStatus, ctx.responseChunks, undefined);

--- a/src/server/proxy/executor.ts
+++ b/src/server/proxy/executor.ts
@@ -18,6 +18,7 @@ import {
   convertResponseToAnthropic,
   convertOpenAIModelsToAnthropic,
   convertAnthropicModelsToOpenAI,
+  isOpenAIType,
 } from "../../converter";
 import { isAnthropicMessageResponse } from "../../converter/anthropic-to-openai-response";
 import type { OpenAIChatCompletionResponse } from "../../converter/openai-to-anthropic";
@@ -243,8 +244,14 @@ export class ProxyExecutor {
     _reject: (reason: unknown) => void
   ): void {
     const { clientId, provider, originalModel, res: clientRes, clientSurface } = task;
-    const upstreamWire: ApiSurface = provider.providerType === "openai" ? "openai" : "anthropic";
-    const needsResponseConversion = clientSurface !== upstreamWire;
+    const pt = provider.providerType;
+    const upstreamWire: ApiSurface = pt === "anthropic" ? "anthropic" : "openai";
+    const needsResponseConversion =
+      pt === "anthropic"
+        ? clientSurface !== "anthropic"
+        : pt === "openai_chat"
+          ? clientSurface !== "openai"
+          : clientSurface !== "openai" && clientSurface !== "openai_responses";
 
     const ttfb = Date.now() - ctx.requestSentTime;
     const duration = Date.now() - ctx.startTime;
@@ -984,7 +991,7 @@ export class ProxyExecutor {
       }
 
       // Cross-protocol: convert /v1/models response format to match client's expected API surface
-      const upstreamWireFmt: ApiSurface = task.provider.providerType === "openai" ? "openai" : "anthropic";
+      const upstreamWireFmt: ApiSurface = isOpenAIType(task.provider.providerType) ? "openai" : "anthropic";
       if (
         task.method === "GET" &&
         (task.requestPath === "/v1/models" || task.requestPath.split("?")[0] === "/v1/models") &&
@@ -1028,7 +1035,7 @@ export class ProxyExecutor {
       }
 
       // Cross-protocol: convert error response format to match client's expected API surface
-      const upstreamWire: ApiSurface = task.provider.providerType === "openai" ? "openai" : "anthropic";
+      const upstreamWire: ApiSurface = isOpenAIType(task.provider.providerType) ? "openai" : "anthropic";
       if (outStatus >= 400 && task.clientSurface !== upstreamWire && ctx.responseChunks.length > 0) {
         try {
           const errorBody = Buffer.concat(ctx.responseChunks).toString("utf-8");

--- a/src/server/request/apiSurfaceDetector.ts
+++ b/src/server/request/apiSurfaceDetector.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ApiSurface, Provider } from "../../types";
+import { isOpenAIType } from "../../converter";
 
 function normalizePath(path: string): string {
   const noQuery = path.split("?")[0] || path;
@@ -29,7 +30,7 @@ export function resolveInboundClientSurface(
     if (fmt === "anthropic") {
       return "anthropic";
     }
-    return provider.providerType === "openai" ? "openai" : "anthropic";
+    return isOpenAIType(provider.providerType) ? "openai" : "anthropic";
   }
   return detectApiSurface(method, path) ?? "anthropic";
 }

--- a/src/server/request/bodyProcessor.ts
+++ b/src/server/request/bodyProcessor.ts
@@ -31,7 +31,7 @@ function forceDisableStreamInBody(body: Buffer, label: string): Buffer {
   }
   try {
     const data = JSON.parse(body.toString("utf-8")) as Record<string, unknown>;
-    if (data.stream === true) {
+    if (data.stream === true || data.stream === "true") {
       data.stream = false;
       log.info(`[${label}] stream=true is not supported for cross-protocol conversion; forcing stream=false`);
       return Buffer.from(JSON.stringify(data), "utf-8");
@@ -92,10 +92,17 @@ export class BodyProcessor {
     let body = applyModelMapping(rawBody, routing.provider);
 
     let responsesStreamRequested = false;
-    if (needsConversion && clientSurface === "openai_responses" && body.length > 0) {
+    let streamRequested = false;
+    if (needsConversion && (clientSurface === "openai_responses" || clientSurface === "openai") && body.length > 0) {
       try {
         const d = JSON.parse(body.toString("utf-8")) as Record<string, unknown>;
-        responsesStreamRequested = d.stream === true;
+        if (d.stream === true) {
+          if (clientSurface === "openai_responses") {
+            responsesStreamRequested = true;
+          } else {
+            streamRequested = true;
+          }
+        }
       } catch {
         // ignore
       }
@@ -190,6 +197,7 @@ export class BodyProcessor {
       originalRequestBody,
       requestBodyLog,
       ...(responsesStreamRequested ? { responsesStreamRequested: true } : {}),
+      ...(streamRequested ? { streamRequested: true } : {}),
     };
   }
 

--- a/src/server/request/bodyProcessor.ts
+++ b/src/server/request/bodyProcessor.ts
@@ -67,9 +67,14 @@ export class BodyProcessor {
     }
 
     const clientSurface: ApiSurface = routing.clientSurface;
-    const upstreamWire: ApiSurface =
-      routing.provider.providerType === "openai" ? "openai" : "anthropic";
-    const needsConversion = clientSurface !== upstreamWire;
+    const pt = routing.provider.providerType;
+    const upstreamWire: ApiSurface = pt === "anthropic" ? "anthropic" : "openai";
+    const needsConversion =
+      pt === "anthropic"
+        ? clientSurface !== "anthropic"
+        : pt === "openai_chat"
+          ? clientSurface !== "openai"
+          : clientSurface !== "openai" && clientSurface !== "openai_responses";
 
     // GET (e.g. /v1/models): no body conversion
     if (routing.method === "GET" || !rawBody || rawBody.length === 0) {
@@ -150,8 +155,7 @@ export class BodyProcessor {
     } else if (clientSurface === "anthropic" && upstreamWire === "openai") {
       const result = this.convertAnthropicToOpenAIRequest(
         body,
-        routing.targetPath,
-        routing.provider
+        routing.targetPath
       );
       if (result) {
         body = result.body;
@@ -203,8 +207,7 @@ export class BodyProcessor {
 
   private convertAnthropicToOpenAIRequest(
     body: Buffer,
-    path: string,
-    provider: RoutingContext["provider"]
+    path: string
   ): { body: Buffer; newPath: string; originalModel: string | undefined } | null {
     try {
       const bodyStr = body.toString("utf-8");
@@ -214,8 +217,7 @@ export class BodyProcessor {
       }
       const conversionResult = convertRequestToOpenAI(
         anthropicRequest as unknown as Parameters<typeof convertRequestToOpenAI>[0],
-        path,
-        provider
+        path
       );
       let originalModel: string | undefined;
       try {
@@ -247,8 +249,7 @@ export class BodyProcessor {
       }
       const c = convertResponsesRequestToChatCompletions(
         raw,
-        routing.targetPath,
-        routing.provider
+        routing.targetPath
       );
       const originalModel = typeof raw.model === "string" ? raw.model : undefined;
       return {
@@ -274,13 +275,11 @@ export class BodyProcessor {
       }
       const chat = convertResponsesRequestToChatCompletions(
         raw,
-        routing.path,
-        routing.provider
+        routing.path
       );
       const c = convertOpenAIRequestToAnthropic(
         chat.request,
-        chat.newPath,
-        routing.provider
+        chat.newPath
       );
       const originalModel = typeof raw.model === "string" ? raw.model : undefined;
       return {
@@ -307,8 +306,7 @@ export class BodyProcessor {
       const originalModel = typeof oai.model === "string" ? oai.model : undefined;
       const c = convertOpenAIRequestToAnthropic(
         oai as unknown as Parameters<typeof convertOpenAIRequestToAnthropic>[0],
-        routing.targetPath,
-        routing.provider
+        routing.targetPath
       );
       return {
         body: Buffer.from(JSON.stringify(c.request), "utf-8"),

--- a/src/server/request/context.ts
+++ b/src/server/request/context.ts
@@ -40,8 +40,10 @@ export interface BodyProcessResult {
   originalModel: string | undefined;
   originalRequestBody: string | undefined;
   requestBodyLog: string | undefined;
-  /** True if client POST /v1/responses had `stream: true` before we forced `stream: false` for conversion */
+  /** True if client had `stream: true` before we forced `stream: false` for cross-protocol conversion (both /v1/chat/completions and /v1/responses) */
   responsesStreamRequested?: boolean;
+  /** True if client sent `stream: true` on a cross-protocol Chat Completions request */
+  streamRequested?: boolean;
 }
 
 /**

--- a/src/server/request/routerStage.ts
+++ b/src/server/request/routerStage.ts
@@ -7,6 +7,7 @@ import type * as url from "url";
 import type { Router } from "../router";
 import type { ApiSurface, RoutingContext } from "./context";
 import { detectApiSurface, resolveInboundClientSurface } from "./apiSurfaceDetector";
+import { isOpenAIType } from "../../converter";
 
 /**
  * RouterStage processes request routing and blocking
@@ -48,7 +49,7 @@ export class RouterStage {
     // 2. Get target provider
     const provider = this.router.getTargetProvider(path);
     const isRouted = this.router.shouldRoute(path);
-    const isOpenAIProvider = provider.providerType === "openai";
+    const isOpenAIProvider = isOpenAIType(provider.providerType);
 
     // 3. Prepare headers
     const originalHeaders: Record<string, string> = {};

--- a/src/server/request/taskExecutor.ts
+++ b/src/server/request/taskExecutor.ts
@@ -74,6 +74,7 @@ export class TaskExecutor {
       priority: 0,
       res,
       ...(bodyResult.responsesStreamRequested ? { responsesStreamRequested: true } : {}),
+      ...(bodyResult.streamRequested ? { streamRequested: true } : {}),
     };
   }
 

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -5,6 +5,7 @@
 import { Provider } from "../types";
 import { ConfigManager } from "../config";
 import { minimatch } from "../utils/helpers";
+import { isOpenAIType } from "../converter";
 
 // Callback type for provider changes
 type ProviderChangeCallback = (providerId: string) => void;
@@ -99,7 +100,7 @@ export class Router {
     }
 
     // Check OpenAI block patterns if current provider is OpenAI
-    if (provider.providerType === "openai") {
+    if (isOpenAIType(provider.providerType)) {
       for (const pattern of this.config.openaiBlockPatterns) {
         if (minimatch(normalizedPath, pattern.path)) {
           return { blocked: true, response: pattern.response, responseCode: pattern.code };

--- a/src/server/router.ts
+++ b/src/server/router.ts
@@ -200,8 +200,10 @@ export class Router {
         const authHeader = provider.authHeader || "authorization";
         if (authHeader.toLowerCase() === "authorization") {
           headers["authorization"] = `Bearer ${provider.apiKey}`;
-        } else {
+        } else if (authHeader.toLowerCase() === "x-api-key") {
           headers["x-api-key"] = provider.apiKey;
+        } else {
+          headers[authHeader] = provider.apiKey;
         }
       }
     }

--- a/src/server/websocket/client.ts
+++ b/src/server/websocket/client.ts
@@ -13,6 +13,7 @@ import {
   ProviderChangeCallback,
   ServerStoppingCallback,
   ConnectionStateCallback,
+  ConfigChangedCallback,
 } from "./types";
 
 // Reconnection settings
@@ -41,6 +42,7 @@ export class WsFollowerClient {
   private onProviderChange: ProviderChangeCallback | null = null;
   private onServerStopping: ServerStoppingCallback | null = null;
   private onConnectionStateChange: ConnectionStateCallback | null = null;
+  private onConfigChanged: ConfigChangedCallback | null = null;
 
   constructor(leaderUrl: string) {
     this.leaderUrl = leaderUrl;
@@ -53,6 +55,7 @@ export class WsFollowerClient {
     onProviderChange?: ProviderChangeCallback;
     onServerStopping?: ServerStoppingCallback;
     onConnectionStateChange?: ConnectionStateCallback;
+    onConfigChanged?: ConfigChangedCallback;
   }): void {
     if (callbacks.onProviderChange) {
       this.onProviderChange = callbacks.onProviderChange;
@@ -62,6 +65,9 @@ export class WsFollowerClient {
     }
     if (callbacks.onConnectionStateChange) {
       this.onConnectionStateChange = callbacks.onConnectionStateChange;
+    }
+    if (callbacks.onConfigChanged) {
+      this.onConfigChanged = callbacks.onConfigChanged;
     }
   }
 
@@ -242,6 +248,11 @@ export class WsFollowerClient {
           this.onProviderChange?.(payload.providerId, payload.providerName);
           break;
         }
+
+        case "config_changed":
+          this.log.info(`[WsClient] Received config change notification`);
+          this.onConfigChanged?.();
+          break;
 
         case "server_stopping":
           this.log.info(`[WsClient] Leader is stopping`);

--- a/src/server/websocket/server.ts
+++ b/src/server/websocket/server.ts
@@ -9,6 +9,7 @@ import { ScopedLogger } from "../../utils/logger";
 import {
   WsMessage,
   WsProviderChangedMessage,
+  WsConfigChangedMessage,
   WsServerStoppingMessage,
   WsSwitchProviderMessage,
 } from "./types";
@@ -126,6 +127,19 @@ export class WsBroadcaster {
     this.log.info(
       `[WsServer] Broadcasting provider change: ${providerId} (${providerName}) to ${this.clients.size} clients`
     );
+    this.broadcast(message);
+  }
+
+  /**
+   * Broadcast config changed to all connected clients (so followers reload)
+   */
+  broadcastConfigChanged(): void {
+    const message: WsConfigChangedMessage = {
+      type: "config_changed",
+      timestamp: Date.now(),
+    };
+
+    this.log.info(`[WsServer] Broadcasting config changed to ${this.clients.size} clients`);
     this.broadcast(message);
   }
 

--- a/src/server/websocket/types.ts
+++ b/src/server/websocket/types.ts
@@ -6,6 +6,7 @@
 export type WsMessageType =
   | "connected" // Server -> Client: Connection established
   | "provider_changed" // Server -> Client: Provider changed
+  | "config_changed" // Server -> Client: Config file changed (provider add/delete/edit)
   | "server_stopping" // Server -> Client: Leader is stopping
   | "switch_provider" // Client -> Server: Request to switch provider
   | "switch_result" // Server -> Client: Result of switch request
@@ -32,6 +33,8 @@ export interface WsProviderChangedMessage extends WsMessage<"provider_changed"> 
     providerName: string;
   };
 }
+
+export type WsConfigChangedMessage = WsMessage<"config_changed">;
 
 export type WsServerStoppingMessage = WsMessage<"server_stopping">;
 
@@ -63,6 +66,7 @@ export type WsConnectionState = "connecting" | "connected" | "disconnected" | "e
 export type ProviderChangeCallback = (providerId: string, providerName: string) => void;
 export type ServerStoppingCallback = () => void;
 export type ConnectionStateCallback = (state: WsConnectionState) => void;
+export type ConfigChangedCallback = () => void;
 
 /**
  * WebSocket ready states (mirrors ws library's WebSocket.readyState)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -505,6 +505,8 @@ export interface RequestTask {
   startedAt?: number;
   /** Client had `stream: true` on POST /v1/responses; response may be synthesized as SSE */
   responsesStreamRequested?: boolean;
+  /** Client had `stream: true` on cross-protocol POST /v1/chat/completions; response may be synthesized as SSE */
+  streamRequested?: boolean;
   /** Optional response object for streaming support in queue mode */
   res?: http.ServerResponse;
   /** Whether the task has been cancelled */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 
 export type ProviderMode = "passthrough" | "inject";
 
-export type ProviderType = "anthropic" | "openai";
+export type ProviderType = "anthropic" | "openai" | "openai_chat";
 
 /**
  * Wire format to assume for GET /v1/models (no request body; cannot detect client protocol).
@@ -29,7 +29,7 @@ export type ApiSurface = "anthropic" | "openai" | "openai_responses";
 export const ProviderModeSchema = z.enum(["passthrough", "inject"]);
 
 // Provider type enum schema
-export const ProviderTypeSchema = z.enum(["anthropic", "openai"]);
+export const ProviderTypeSchema = z.enum(["anthropic", "openai", "openai_chat"]);
 
 export const ModelsListFormatSchema = z.enum(["auto", "openai", "anthropic"]);
 
@@ -40,15 +40,6 @@ export const ModelMapEntrySchema = z.object({
 });
 
 export type ModelMapEntry = z.infer<typeof ModelMapEntrySchema>;
-
-/** Per-provider path appended to baseUrl for OpenAI Chat Completions (A→O, Responses→Chat, etc.) */
-const OpenaiChatCompletionsPathSchema = z
-  .string()
-  .min(1)
-  .refine(
-    s => s === s.trim() && s.startsWith("/") && !s.includes("//"),
-    "openaiChatCompletionsPath must start with /, have no leading/trailing spaces, and must not contain //"
-  );
 
 // Provider configuration schema (from YAML/VSCode settings)
 export const ProviderConfigSchema = z.object({
@@ -62,8 +53,6 @@ export const ProviderConfigSchema = z.object({
   api_key: z.string().optional(),
   authHeader: z.string().optional(),
   auth_header: z.string().optional(),
-  openaiChatCompletionsPath: OpenaiChatCompletionsPathSchema.optional(),
-  openai_chat_completions_path: OpenaiChatCompletionsPathSchema.optional(),
   modelsListFormat: ModelsListFormatSchema.optional(),
   models_list_format: ModelsListFormatSchema.optional(),
   modelMap: z.array(ModelMapEntrySchema).optional(),
@@ -219,8 +208,6 @@ export interface Provider {
   providerType: ProviderType;
   apiKey?: string;
   authHeader?: string;
-  /** When set, used as the path for OpenAI Chat Completions after A→O / Responses→Chat (default: /chat/completions). */
-  openaiChatCompletionsPath?: string;
   /** GET /v1/models only: effective client wire; default `auto` matches providerType. */
   modelsListFormat?: ModelsListFormat;
   modelMap?: ModelMapEntry[];
@@ -271,7 +258,6 @@ export interface ProviderInfo {
   enabled: boolean;
   baseUrl?: string;
   apiKey?: string;
-  openaiChatCompletionsPath?: string;
   modelsListFormat?: ModelsListFormat;
   modelMap?: ModelMapEntry[];
 }

--- a/src/vscode/statusBar.ts
+++ b/src/vscode/statusBar.ts
@@ -27,6 +27,9 @@ export class StatusBarManager implements vscode.Disposable {
     // Router is updated by WebSocket client for all instances (Leader + Followers)
     const router = this.server.getRouter();
     router.onProviderChanged(this.handleProviderChange);
+
+    // Subscribe to config changes (provider list, settings, etc.)
+    this.config.onConfigChanged(this.handleConfigChange);
   }
 
   /**
@@ -40,6 +43,13 @@ export class StatusBarManager implements vscode.Disposable {
    * Handle provider change events from Router
    */
   private handleProviderChange = (_providerId: string): void => {
+    this.update();
+  };
+
+  /**
+   * Handle config changes (provider list, settings, etc.)
+   */
+  private handleConfigChange = (): void => {
     this.update();
   };
 
@@ -324,6 +334,7 @@ export class StatusBarManager implements vscode.Disposable {
     this.server.offRoleChanged(this.handleRoleChange);
     const router = this.server.getRouter();
     router.offProviderChanged(this.handleProviderChange);
+    this.config.offConfigChanged(this.handleConfigChange);
     this.statusBarItem.dispose();
   }
 }

--- a/tests/unit/converter/anthropic-to-openai.test.ts
+++ b/tests/unit/converter/anthropic-to-openai.test.ts
@@ -653,7 +653,7 @@ describe("converter: anthropic-to-openai", () => {
       const result = convertRequestToOpenAI(request, basePath);
 
       expect(result.request.reasoning).toEqual({
-        effort: "medium",
+        effort: "high",
         enabled: true,
       });
     });
@@ -682,7 +682,7 @@ describe("converter: anthropic-to-openai", () => {
       const result = convertRequestToOpenAI(request, basePath);
 
       expect(result.request.reasoning).toEqual({
-        effort: "medium",
+        effort: "high",
         enabled: true,
       });
     });

--- a/tests/unit/converter/anthropic-to-openai.test.ts
+++ b/tests/unit/converter/anthropic-to-openai.test.ts
@@ -359,20 +359,6 @@ describe("converter: anthropic-to-openai", () => {
       expect(result.newPath).toBe("/chat/completions");
     });
 
-    it("should use openaiChatCompletionsPath from provider when set", () => {
-      const request: AnthropicMessageRequest = {
-        model: "claude-3-5-sonnet-20241022",
-        max_tokens: 4096,
-        messages: [],
-      };
-
-      const result = convertRequestToOpenAI(request, "/v1/messages", {
-        openaiChatCompletionsPath: "/v1/chat/completions",
-      });
-
-      expect(result.newPath).toBe("/v1/chat/completions");
-    });
-
     it("should not modify path for non-matching paths", () => {
       const request: AnthropicMessageRequest = {
         model: "claude-3-5-sonnet-20241022",

--- a/tests/unit/converter/modelsFallback.test.ts
+++ b/tests/unit/converter/modelsFallback.test.ts
@@ -39,7 +39,7 @@ describe("buildModelsListFallback", () => {
 });
 
 describe("buildOpenAIModelsListFromProvider", () => {
-  it("uses modelMap ids", () => {
+  it("shows pattern and model ids", () => {
     const j = buildOpenAIModelsListFromProvider(
       prov({
         id: "p",
@@ -47,7 +47,21 @@ describe("buildOpenAIModelsListFromProvider", () => {
         modelMap: [{ pattern: "*", model: "m1" }],
       })
     );
-    expect(j.data[0].id).toBe("m1");
+    expect(j.data[0].id).toBe("*");
+    expect(j.data[1].id).toBe("m1");
+    expect(j.data).toHaveLength(2);
+  });
+
+  it("deduplicates when pattern equals model", () => {
+    const j = buildOpenAIModelsListFromProvider(
+      prov({
+        id: "p",
+        providerType: "openai",
+        modelMap: [{ pattern: "gpt-4o", model: "gpt-4o" }],
+      })
+    );
+    expect(j.data).toHaveLength(1);
+    expect(j.data[0].id).toBe("gpt-4o");
   });
 });
 
@@ -56,8 +70,9 @@ describe("buildAnthropicModelsListFromProvider", () => {
     const j = buildAnthropicModelsListFromProvider(
       prov({ id: "p", providerType: "anthropic", modelMap: [{ pattern: "*", model: "claude-x" }] })
     );
-    expect(j.first_id).toBe("claude-x");
+    expect(j.first_id).toBe("*");
     expect(j.last_id).toBe("claude-x");
     expect(j.has_more).toBe(false);
+    expect(j.data).toHaveLength(2);
   });
 });

--- a/tests/unit/converter/openai-to-anthropic-request.test.ts
+++ b/tests/unit/converter/openai-to-anthropic-request.test.ts
@@ -69,15 +69,6 @@ describe("convertOpenAIRequestToAnthropic", () => {
     expect(isOpenAIChatCompletionsRequest({ model: "x" })).toBe(false);
   });
 
-  it("maps custom openaiChatCompletionsPath to /v1/messages", () => {
-    const { newPath } = convertOpenAIRequestToAnthropic(
-      { model: "m", max_tokens: 1, messages: [{ role: "user", content: "x" }] },
-      "/custom/chat/completions",
-      { openaiChatCompletionsPath: "/custom/chat/completions" }
-    );
-    expect(newPath).toBe("/v1/messages");
-  });
-
   const sampleFunctionTool = {
     type: "function" as const,
     function: {

--- a/tests/unit/converter/openaiPath.test.ts
+++ b/tests/unit/converter/openaiPath.test.ts
@@ -1,32 +1,35 @@
 import { describe, it, expect } from "vitest";
 import {
-  getOpenAIChatCompletionsPath,
   isOpenAIChatCompletionsWirePath,
-  DEFAULT_OPENAI_CHAT_COMPLETIONS_PATH,
+  isOpenAIType,
 } from "../../../src/converter/openaiPath";
 
-describe("getOpenAIChatCompletionsPath", () => {
-  it("returns default when provider omits the field", () => {
-    expect(getOpenAIChatCompletionsPath({})).toBe(DEFAULT_OPENAI_CHAT_COMPLETIONS_PATH);
-    expect(getOpenAIChatCompletionsPath(undefined)).toBe(DEFAULT_OPENAI_CHAT_COMPLETIONS_PATH);
-  });
-
-  it("uses provider.openaiChatCompletionsPath when set", () => {
-    expect(
-      getOpenAIChatCompletionsPath({ openaiChatCompletionsPath: "/v1/chat/completions" })
-    ).toBe("/v1/chat/completions");
-  });
-});
-
 describe("isOpenAIChatCompletionsWirePath", () => {
-  it("accepts legacy literal paths", () => {
+  it("accepts /v1/chat/completions", () => {
     expect(isOpenAIChatCompletionsWirePath("/v1/chat/completions")).toBe(true);
+  });
+
+  it("accepts /chat/completions", () => {
     expect(isOpenAIChatCompletionsWirePath("/chat/completions")).toBe(true);
   });
 
-  it("accepts custom path when it matches getOpenAIChatCompletionsPath(provider)", () => {
-    const provider = { openaiChatCompletionsPath: "/paas/v4/chat/completions" };
-    expect(isOpenAIChatCompletionsWirePath("/paas/v4/chat/completions", provider)).toBe(true);
-    expect(isOpenAIChatCompletionsWirePath("/v1/chat/completions", provider)).toBe(true);
+  it("rejects other paths", () => {
+    expect(isOpenAIChatCompletionsWirePath("/v1/messages")).toBe(false);
+    expect(isOpenAIChatCompletionsWirePath("/v1/responses")).toBe(false);
+    expect(isOpenAIChatCompletionsWirePath("/paas/v4/chat/completions")).toBe(false);
+  });
+});
+
+describe("isOpenAIType", () => {
+  it("returns true for 'openai'", () => {
+    expect(isOpenAIType("openai")).toBe(true);
+  });
+
+  it("returns true for 'openai_chat'", () => {
+    expect(isOpenAIType("openai_chat")).toBe(true);
+  });
+
+  it("returns false for 'anthropic'", () => {
+    expect(isOpenAIType("anthropic")).toBe(false);
   });
 });

--- a/tests/unit/converter/responses-to-chat-completions.test.ts
+++ b/tests/unit/converter/responses-to-chat-completions.test.ts
@@ -48,15 +48,6 @@ describe("convertResponsesRequestToChatCompletions", () => {
     expect(request.messages[1]).toEqual({ role: "user", content: "q" });
   });
 
-  it("uses openaiChatCompletionsPath from provider when set", () => {
-    const { newPath } = convertResponsesRequestToChatCompletions(
-      { model: "gpt-4o", input: "x" },
-      "/v1/responses",
-      { openaiChatCompletionsPath: "/v1/chat/completions" }
-    );
-    expect(newPath).toBe("/v1/chat/completions");
-  });
-
   it("maps tool_choice 'required' to OpenAI 'required' for downstream O-to-A", () => {
     const { request } = convertResponsesRequestToChatCompletions(
       // OpenAI Responses API uses snake_case fields

--- a/web/src/features/providers/Providers.tsx
+++ b/web/src/features/providers/Providers.tsx
@@ -22,7 +22,6 @@ const DEFAULT_FORM: AddProviderRequest = {
   modelMap: undefined,
   vlModelMap: undefined,
   headers: undefined,
-  openaiChatCompletionsPath: undefined,
   modelsListFormat: "auto",
 };
 
@@ -157,7 +156,6 @@ export default function Providers() {
       modelMap,
       vlModelMap: undefined,
       headers: undefined,
-      openaiChatCompletionsPath: provider.openaiChatCompletionsPath,
       modelsListFormat: provider.modelsListFormat ?? "auto",
     });
     setModelMapText(modelMap ? yaml.dump(modelMap, { indent: 2, lineWidth: -1 }) : "");
@@ -207,7 +205,6 @@ export default function Providers() {
     if (!formData.id || !formData.name || !formData.baseUrl) {
       return;
     }
-    const trimmedPath = formData.openaiChatCompletionsPath?.trim();
     // When editing, use the provider we opened (ids stay in sync) and never send apiKey.
     const isOfficial = editingProvider?.id === "official" || formData.id === "official";
     const dataToSubmit = editingProvider
@@ -215,12 +212,10 @@ export default function Providers() {
           ...formData,
           id: editingProvider.id,
           apiKey: undefined,
-          openaiChatCompletionsPath: trimmedPath || undefined,
           enabled: isOfficial ? true : formData.enabled,
         }
       : {
           ...formData,
-          openaiChatCompletionsPath: trimmedPath || undefined,
           enabled: isOfficial ? true : formData.enabled,
         };
     addMutation.mutate(dataToSubmit);
@@ -372,14 +367,6 @@ export default function Providers() {
                       </span>
                     </div>
                   )}
-                  {provider.openaiChatCompletionsPath && (
-                    <div className="flex items-center justify-between text-xs">
-                      <span className="text-muted-foreground">Chat path</span>
-                      <span className="font-mono text-[10px] truncate max-w-[140px]">
-                        {provider.openaiChatCompletionsPath}
-                      </span>
-                    </div>
-                  )}
                 </CardContent>
               </Card>
             </ContextMenuWrapper>
@@ -513,22 +500,6 @@ export default function Providers() {
               </div>
 
               <div className="space-y-1">
-                <label className="text-xs font-medium">OpenAI Chat Completions path</label>
-                <input
-                  type="text"
-                  className="w-full h-8 px-2 text-xs border rounded-md bg-background font-mono"
-                  placeholder="e.g. /chat/completions (default) or /v1/chat/completions"
-                  value={formData.openaiChatCompletionsPath ?? ""}
-                  onChange={e => updateForm("openaiChatCompletionsPath", e.target.value || undefined)}
-                />
-                <p className="text-[10px] text-muted-foreground">
-                  Appended to base URL for A→O and Responses→Chat. Use when the upstream has no
-                  &quot;v1&quot; segment in the path (e.g. some Z.AI base URLs). Leave empty for the
-                  default.
-                </p>
-              </div>
-
-              <div className="space-y-1">
                 <label className="text-xs font-medium">GET /v1/models wire</label>
                 <Select
                   value={formData.modelsListFormat ?? "auto"}
@@ -556,9 +527,10 @@ export default function Providers() {
                     value={formData.providerType}
                     options={[
                       { value: "anthropic", label: "Anthropic" },
-                      { value: "openai", label: "OpenAI" },
+                      { value: "openai", label: "OpenAI (Full)" },
+                      { value: "openai_chat", label: "OpenAI (Chat Only)" },
                     ]}
-                    onChange={v => updateForm("providerType", v as "anthropic" | "openai")}
+                    onChange={v => updateForm("providerType", v as "anthropic" | "openai" | "openai_chat")}
                     className="h-8 text-xs"
                   />
                 </div>

--- a/web/src/features/providers/Providers.tsx
+++ b/web/src/features/providers/Providers.tsx
@@ -34,6 +34,7 @@ export default function Providers() {
   const [showDuplicateModal, setShowDuplicateModal] = useState(false);
   const [duplicateSource, setDuplicateSource] = useState<Provider | null>(null);
   const [dupName, setDupName] = useState("");
+  const [dupNewId, setDupNewId] = useState("");
   // Raw text states for YAML fields (allow editing invalid YAML temporarily)
   const [modelMapText, setModelMapText] = useState("");
   const [modelMapError, setModelMapError] = useState<string | null>(null);
@@ -175,6 +176,7 @@ export default function Providers() {
   const openDuplicateModal = (provider: Provider) => {
     setDuplicateSource(provider);
     setDupName(`${provider.name} (copy)`);
+    setDupNewId(`${provider.id}_copy`);
     setShowDuplicateModal(true);
   };
 
@@ -182,6 +184,7 @@ export default function Providers() {
     setShowDuplicateModal(false);
     setDuplicateSource(null);
     setDupName("");
+    setDupNewId("");
   };
 
   const handleDuplicateSubmit = () => {
@@ -189,8 +192,8 @@ export default function Providers() {
       return;
     }
     const name = dupName.trim();
-    const newId = `${duplicateSource.id}_copy`;
-    if (!name || !/^[a-zA-Z0-9_-]+$/.test(newId)) {
+    const newId = dupNewId.trim();
+    if (!name || !newId || !/^[a-zA-Z0-9_-]+$/.test(newId)) {
       return;
     }
     duplicateMutation.mutate({
@@ -704,14 +707,16 @@ export default function Providers() {
               </div>
               <div className="space-y-1">
                 <label className="text-xs font-medium">New provider ID</label>
-                <div className="w-full h-8 px-2 text-xs border rounded-md bg-muted font-mono flex items-center">
-                  {duplicateSource
-                    ? `${duplicateSource.id}_copy`
-                    : "—"}
-                </div>
+                <input
+                  type="text"
+                  className="w-full h-8 px-2 text-xs border rounded-md bg-background font-mono"
+                  value={dupNewId}
+                  onChange={e => setDupNewId(e.target.value)}
+                  placeholder="e.g. my-provider_copy"
+                />
                 <p className="text-[10px] text-muted-foreground">
-                  The source id is suffixed with <span className="font-mono">_copy</span> (no other spelling). If
-                  that key already exists, the request will fail; remove or rename the other entry first.
+                  Only alphanumeric, underscore, and hyphen. If that key already exists, the request
+                  will fail; remove or rename the other entry first.
                 </p>
               </div>
             </CardContent>
@@ -728,7 +733,7 @@ export default function Providers() {
                 size="sm"
                 className="h-7 text-xs"
                 onClick={handleDuplicateSubmit}
-                disabled={duplicateMutation.isPending || !dupName.trim() || !duplicateSource}
+                disabled={duplicateMutation.isPending || !dupName.trim() || !dupNewId.trim() || !duplicateSource}
               >
                 {duplicateMutation.isPending ? (
                   <Loader2 className="h-3 w-3 animate-spin" />

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -10,12 +10,11 @@ export interface Provider {
   id: string;
   name: string;
   mode: "inject" | "passthrough";
-  providerType: "anthropic" | "openai";
+  providerType: "anthropic" | "openai" | "openai_chat";
   baseUrl?: string;
   active: boolean;
   enabled: boolean;
   apiKey?: string;
-  openaiChatCompletionsPath?: string;
   /** GET /v1/models wire when protocol cannot be detected (default: auto) */
   modelsListFormat?: "auto" | "openai" | "anthropic";
   modelMap?: ModelMapEntry[];
@@ -52,7 +51,7 @@ export interface AddProviderRequest {
   id: string;
   name: string;
   baseUrl: string;
-  providerType: "anthropic" | "openai";
+  providerType: "anthropic" | "openai" | "openai_chat";
   mode: "passthrough" | "inject";
   apiKey?: string;
   enabled?: boolean;
@@ -61,7 +60,6 @@ export interface AddProviderRequest {
   modelMap?: ModelMapEntry[];
   vlModelMap?: ModelMapEntry[];
   headers?: Record<string, string>;
-  openaiChatCompletionsPath?: string;
   modelsListFormat?: "auto" | "openai" | "anthropic";
 }
 


### PR DESCRIPTION
## Summary

- **`providerType` split**: added `"openai_chat"` alongside `"anthropic"` and `"openai"` — `"openai"` = full passthrough (Chat Completions + Responses API forwarded without conversion), `"openai_chat"` = Chat Completions only (Responses API converted before forwarding). Existing `"openai"` configs are treated as full passthrough; update to `"openai_chat"` to preserve prior Responses→Chat behavior.
- **Removed `openaiChatCompletionsPath`**: the Chat Completions endpoint is now always `/chat/completions`. Adjust `baseUrl` to include any path prefix (e.g. change `baseUrl: "https://example.com"` + `openaiChatCompletionsPath: "/v1/chat/completions"` to `baseUrl: "https://example.com/v1"`).
- **Config hot-reload**: `ConfigManager` watches the YAML config file with `fs.watch` (300ms debounce). External edits to `~/.ccrelay/config.yaml` are picked up automatically without clicking Reload.
- **Config change event bus**: `ConfigManager.onConfigChanged` notifies all subscribers (status bar, server, WebSocket broadcaster) on config reload.
- **WebSocket `config_changed` broadcast**: Leader broadcasts config changes to all Follower instances so they reload their local config automatically.
- **Duplicate provider: editable ID**: the Duplicate dialog now lets you customize the new provider ID instead of being locked to `<sourceId>_copy`.
- **Cross-protocol `GET /v1/models` conversion** and **cross-protocol error format conversion**: models list and error responses are automatically converted to match the client's expected API surface.
- **Synthetic SSE for `POST /v1/chat/completions` with `stream: true` (cross-protocol)**: when upstream returns non-streaming but the client requested streaming, ccrelay emits `text/event-stream` with `chat.completion.chunk` deltas.
- **Converter simplification**: converter functions no longer accept a `provider` parameter — paths are deterministic. Added `isOpenAIType()` utility for consistent OpenAI variant checks.
- **Various fixes**: thinking block merging, reasoning budget thresholds, orphaned tool messages, empty choices handling, cross-protocol stream guard, custom auth headers, and delete-active-provider behavior.

## Test plan

- [ ] Add a provider with `providerType: "openai"` and verify both Chat Completions and Responses API are forwarded without conversion
- [ ] Add a provider with `providerType: "openai_chat"` and verify Responses API requests are converted to Chat Completions before forwarding
- [ ] Edit `~/.ccrelay/config.yaml` externally and confirm the dashboard updates without clicking Reload
- [ ] Duplicate a provider and verify the new ID field is editable
- [ ] Test cross-protocol `GET /v1/models` with an Anthropic provider and OpenAI client (and vice versa)
- [ ] Run the existing unit test suite (`npm run test:unit` — all 385 tests should pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)