### PR TITLE
feat(dashboard): Codex "Configure model" button and backend model patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **WebSocket `config_changed` broadcast**: Leader broadcasts config changes to all Follower instances via WebSocket, so Followers reload their local config automatically.
 - **Duplicate provider: editable New provider ID**: the Duplicate dialog now lets you customize the new provider ID instead of being locked to `<sourceId>_copy`.
 - **Codex model input**: applying the Codex CCRelay template now shows a model input dialog before writing `~/.codex/config.toml`, defaulting to `gpt-5.4-mini` when left empty (replaces the previous hardcoded `glm-5-turbo`).
+- **Codex "Configure model" button**: the Codex section of Client configuration now shows the current model value and a "Configure model" button (like Claude Code's "Configure default models") that patches only the `model` field in an existing `~/.codex/config.toml` without replacing the full file. Backend exposes `model` in the GET response and accepts `patchCodexModelOnly` in the apply POST body.
 - **Provider protocol badge**: each provider card now displays a colored protocol label (Anthropic / OpenAI / OpenAI Chat) in the top-right corner for quick identification.
 
 ### Changed

--- a/src/api/clientConfig.ts
+++ b/src/api/clientConfig.ts
@@ -50,6 +50,8 @@ export interface ClientConfigItem {
   currentValue?: string;
   /** For Codex, which model_provider is selected */
   modelProvider?: string;
+  /** For Codex, the current model value from config.toml */
+  model?: string;
   message?: string;
 }
 
@@ -250,18 +252,25 @@ function detectCodex(codexPath: string, port: number): ClientConfigItem {
   const raw = fs.readFileSync(codexPath, "utf-8");
   const toml = parseTomlLite(raw);
   const modelProvider = toml.top.model_provider;
+  const model = toml.top.model;
   if (!modelProvider) {
-    return { status: "missing", filePath, message: "model_provider not set" };
+    return { status: "missing", filePath, model, message: "model_provider not set" };
   }
   const sec = toml.sections[`model_providers.${modelProvider}`];
   const baseUrl = sec?.base_url;
   if (!baseUrl) {
-    return { status: "missing", filePath, modelProvider, message: "base_url not set for provider" };
+    return {
+      status: "missing",
+      filePath,
+      modelProvider,
+      model,
+      message: "base_url not set for provider",
+    };
   }
   if (isLocalProxyCodexBase(baseUrl, port)) {
-    return { status: "ok", filePath, currentValue: baseUrl, modelProvider };
+    return { status: "ok", filePath, currentValue: baseUrl, modelProvider, model };
   }
-  return { status: "wrong_target", filePath, currentValue: baseUrl, modelProvider };
+  return { status: "wrong_target", filePath, currentValue: baseUrl, modelProvider, model };
 }
 
 /**
@@ -313,6 +322,7 @@ export async function handleApplyClientConfig(
       overwrite?: boolean;
       model?: string;
       patchClaudeModelsOnly?: boolean;
+      patchCodexModelOnly?: boolean;
       claudeDefaultModels?: { opus?: string; sonnet?: string; haiku?: string };
     }>(req);
     const target = body.target;
@@ -367,6 +377,22 @@ export async function handleApplyClientConfig(
         status: "ok",
         message: `Updated Claude default model env in ${claudePath}`,
       });
+      return;
+    }
+
+    if (target === "codex" && body.patchCodexModelOnly) {
+      const m = typeof body.model === "string" ? body.model.trim() : "";
+      if (!fs.existsSync(codexPath)) {
+        sendJson(res, 400, {
+          status: "error",
+          message: "Codex config file does not exist yet. Apply the template first.",
+        });
+        return;
+      }
+      const raw = fs.readFileSync(codexPath, "utf-8");
+      const updated = raw.replace(/^model\s*=\s*".*"$/m, `model = "${m || CODEX_DEFAULT_MODEL}"`);
+      fs.writeFileSync(codexPath, updated, "utf-8");
+      sendJson(res, 200, { status: "ok", message: `Updated model in ${codexPath}` });
       return;
     }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -123,6 +123,7 @@ export const api = {
     overwrite?: boolean;
     model?: string;
     patchClaudeModelsOnly?: boolean;
+    patchCodexModelOnly?: boolean;
     claudeDefaultModels?: { opus?: string; sonnet?: string; haiku?: string };
   }) => {
     const response = await fetch(`${API_BASE}/client-config/apply`, {

--- a/web/src/features/dashboard/ClientConfigStatus.tsx
+++ b/web/src/features/dashboard/ClientConfigStatus.tsx
@@ -63,6 +63,7 @@ export default function ClientConfigStatus() {
   const [sonnet, setSonnet] = useState("");
   const [haiku, setHaiku] = useState("");
   const [codexModelModalOpen, setCodexModelModalOpen] = useState(false);
+  const [codexModalMode, setCodexModalMode] = useState<"apply" | "configure">("apply");
   const [codexModel, setCodexModel] = useState("");
   const [pendingCodexModel, setPendingCodexModel] = useState<string | undefined>(undefined);
 
@@ -98,6 +99,19 @@ export default function ClientConfigStatus() {
     },
   });
 
+  const codexModelPatchMutation = useMutation({
+    mutationFn: (model: string) =>
+      api.applyClientConfig({
+        target: "codex",
+        patchCodexModelOnly: true,
+        model,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["clientConfig"] });
+      setCodexModelModalOpen(false);
+    },
+  });
+
   const runApply = (target: "claudeCode" | "codex", overwrite: boolean, model?: string) => {
     setApplyingTo(target);
     applyMutation.mutate({ target, overwrite, ...(model ? { model } : {}) });
@@ -112,6 +126,7 @@ export default function ClientConfigStatus() {
       return;
     }
     if (target === "codex") {
+      setCodexModalMode("apply");
       setCodexModel("");
       setCodexModelModalOpen(true);
       return;
@@ -271,6 +286,39 @@ export default function ClientConfigStatus() {
                     <p className="text-[10px] text-muted-foreground mt-0.5">
                       Expected: <span className="font-mono">{data?.expectedCodexBaseUrl ?? "—"}</span>
                     </p>
+                    <div className="mt-2 pt-2 border-t border-border/50 space-y-1.5">
+                      <p className="text-[10px] text-muted-foreground">
+                        <span className="font-medium text-foreground/90">Model</span>{" "}
+                        (written to <span className="font-mono">model</span> in config.toml)
+                      </p>
+                      {data?.codex?.model ? (
+                        <p className="text-[10px] font-mono text-foreground/80">
+                          {data.codex.model}
+                        </p>
+                      ) : (
+                        <p className="text-[10px] text-muted-foreground">
+                          <span className="italic">Not set.</span> Default:{" "}
+                          <span className="font-mono text-foreground/80">{CODEX_DEFAULT_MODEL}</span>
+                        </p>
+                      )}
+                      <div>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="secondary"
+                          className="h-7 text-xs gap-1"
+                          disabled={applyMutation.isPending || codexModelPatchMutation.isPending}
+                          onClick={() => {
+                            setCodexModalMode("configure");
+                            setCodexModel(data?.codex?.model ?? "");
+                            setCodexModelModalOpen(true);
+                          }}
+                        >
+                          <SlidersHorizontal className="h-3 w-3" />
+                          Configure model
+                        </Button>
+                      </div>
+                    </div>
                   </div>
                 </div>
                 <div className="flex shrink-0 sm:pl-2">
@@ -279,7 +327,7 @@ export default function ClientConfigStatus() {
                     variant={data?.codex.status === "ok" ? "outline" : "default"}
                     className="h-7 text-xs"
                     disabled={
-                      data?.codex.status === "ok" || applyMutation.isPending || modelsMutation.isPending
+                      data?.codex.status === "ok" || applyMutation.isPending || modelsMutation.isPending || codexModelPatchMutation.isPending
                     }
                     onClick={() => onConfigureClick("codex")}
                   >
@@ -386,15 +434,19 @@ export default function ClientConfigStatus() {
                   placeholder={CODEX_DEFAULT_MODEL}
                   onKeyDown={e => {
                     if (e.key === "Enter") {
-                      const effectiveModel = codexModel.trim() || CODEX_DEFAULT_MODEL;
-                      const codexItem = data?.codex;
-                      setCodexModelModalOpen(false);
-                      if (codexItem && needsOverwriteBeforeApply(codexItem)) {
-                        setPendingCodexModel(effectiveModel);
-                        setPendingTarget("codex");
-                        setConfirmOpen(true);
+                      if (codexModalMode === "configure") {
+                        codexModelPatchMutation.mutate(codexModel.trim() || CODEX_DEFAULT_MODEL);
                       } else {
-                        runApply("codex", false, effectiveModel);
+                        const effectiveModel = codexModel.trim() || CODEX_DEFAULT_MODEL;
+                        const codexItem = data?.codex;
+                        setCodexModelModalOpen(false);
+                        if (codexItem && needsOverwriteBeforeApply(codexItem)) {
+                          setPendingCodexModel(effectiveModel);
+                          setPendingTarget("codex");
+                          setConfirmOpen(true);
+                        } else {
+                          runApply("codex", false, effectiveModel);
+                        }
                       }
                     }
                   }}
@@ -403,27 +455,40 @@ export default function ClientConfigStatus() {
               {applyMutation.isError && (
                 <p className="text-[10px] text-destructive">{(applyMutation.error as Error).message}</p>
               )}
+              {codexModelPatchMutation.isError && (
+                <p className="text-[10px] text-destructive">{(codexModelPatchMutation.error as Error).message}</p>
+              )}
             </CardContent>
             <div className="border-t p-3 flex justify-end">
               <Button
                 type="button"
                 size="sm"
                 className="h-7 text-xs"
-                disabled={applyMutation.isPending}
+                disabled={applyMutation.isPending || codexModelPatchMutation.isPending}
                 onClick={() => {
-                  const effectiveModel = codexModel.trim() || CODEX_DEFAULT_MODEL;
-                  const codexItem = data?.codex;
-                  setCodexModelModalOpen(false);
-                  if (codexItem && needsOverwriteBeforeApply(codexItem)) {
-                    setPendingCodexModel(effectiveModel);
-                    setPendingTarget("codex");
-                    setConfirmOpen(true);
+                  if (codexModalMode === "configure") {
+                    codexModelPatchMutation.mutate(codexModel.trim() || CODEX_DEFAULT_MODEL);
                   } else {
-                    runApply("codex", false, effectiveModel);
+                    const effectiveModel = codexModel.trim() || CODEX_DEFAULT_MODEL;
+                    const codexItem = data?.codex;
+                    setCodexModelModalOpen(false);
+                    if (codexItem && needsOverwriteBeforeApply(codexItem)) {
+                      setPendingCodexModel(effectiveModel);
+                      setPendingTarget("codex");
+                      setConfirmOpen(true);
+                    } else {
+                      runApply("codex", false, effectiveModel);
+                    }
                   }
                 }}
               >
-                {applyMutation.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : "Save & Apply"}
+                {applyMutation.isPending || codexModelPatchMutation.isPending ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : codexModalMode === "configure" ? (
+                  "Save"
+                ) : (
+                  "Save & Apply"
+                )}
               </Button>
             </div>
           </Card>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -186,6 +186,7 @@ export interface ClientConfigItem {
   filePath: string;
   currentValue?: string;
   modelProvider?: string;
+  model?: string;
   message?: string;
 }
 


### PR DESCRIPTION
- GET /client-config now returns the current `model` value from ~/.codex/config.toml
- POST /client-config/apply accepts `patchCodexModelOnly: true` to update only the model field in an existing config.toml without replacing the full file (like Claude Code's patchClaudeModelsOnly)
- Codex section in the dashboard now shows the current model and a "Configure model" button that opens a modal to update it; the existing "Apply CCRelay template" flow (full file replace) remains unchanged for initial setup