### PR TITLE
fix: map client paths to upstream; perf: packaging pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "scripts": {
     "clean": "npx shx rm -rf out web/dist",
-    "vscode:prepublish": "node scripts/build-config.mjs prod && npm run build:web && node scripts/generate-version.mjs && npm run bundle",
+    "vscode:prepublish": "node scripts/build-config.mjs && npm run build:web && node scripts/generate-version.mjs && npm run bundle",
     "dev": "npm run watch",
     "dev:web": "cd web && npm run dev",
     "prebuild": "node scripts/generate-version.mjs",
@@ -131,7 +131,7 @@
     "test:watch": "vitest tests/unit",
     "test:coverage": "vitest run tests/unit --coverage",
     "test:e2e": "node ./out/test/runTest.js",
-    "package": "npm run build:web && node scripts/generate-version.mjs && npm run bundle && npx shx mkdir -p dists && vsce package --out dists",
+    "package": "npm run clean && npx shx mkdir -p dists && vsce package --out dists",
     "package:dev": "./scripts/package.sh dev",
     "package:prod": "./scripts/package.sh prod",
     "package:beta": "node scripts/version-beta.mjs && npm run package",

--- a/scripts/build-config.mjs
+++ b/scripts/build-config.mjs
@@ -24,7 +24,7 @@ const __dirname = path.dirname(__filename);
 const require = createRequire(import.meta.url);
 
 // Parse environment argument
-const env = process.argv[2] || "dev";
+const env = process.env.BUILD_ENV || process.argv[2] || "prod";
 if (!["dev", "prod"].includes(env)) {
   console.error(`Invalid environment: ${env}. Use 'dev' or 'prod'.`);
   process.exit(1);

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -13,6 +13,9 @@ fi
 
 cd "$(dirname "$0")/.."
 
+# Export env so vscode:prepublish (triggered by vsce) uses the correct environment
+export BUILD_ENV="$ENV"
+
 # Generate build config and extract version
 OUTPUT=$(node scripts/build-config.mjs "$ENV")
 PACKAGE_VERSION=$(echo "$OUTPUT" | grep "^PACKAGE_VERSION:" | cut -d: -f2)
@@ -25,8 +28,8 @@ fi
 echo ""
 echo "Packaging with version: $PACKAGE_VERSION"
 
-# Build
-npm run build
+# Clean (vscode:prepublish handles the actual build)
+npm run clean
 
 # Ensure dists directory exists
 mkdir -p dists

--- a/src/converter/chat-completions-streaming-to-responses.ts
+++ b/src/converter/chat-completions-streaming-to-responses.ts
@@ -53,7 +53,9 @@ export interface StreamingConversionState {
 /*  Public API                                                                */
 /* -------------------------------------------------------------------------- */
 
-export function createStreamingState(opts?: { echo?: ResponsesRequestEcho }): StreamingConversionState {
+export function createStreamingState(opts?: {
+  echo?: ResponsesRequestEcho;
+}): StreamingConversionState {
   return {
     responseId: `resp_${randomUUID().replace(/-/g, "")}`,
     reasoningId: `rs_${randomUUID().replace(/-/g, "")}`,
@@ -104,7 +106,8 @@ export function processStreamingChunk(state: StreamingConversionState, line: str
     state.usage = {
       input_tokens: typeof u.prompt_tokens === "number" ? u.prompt_tokens : 0,
       input_tokens_details: {
-        cached_tokens: typeof inputDetails?.cached_tokens === "number" ? inputDetails.cached_tokens : 0,
+        cached_tokens:
+          typeof inputDetails?.cached_tokens === "number" ? inputDetails.cached_tokens : 0,
       },
       output_tokens: typeof u.completion_tokens === "number" ? u.completion_tokens : 0,
       output_tokens_details: {

--- a/src/converter/responses-echo.ts
+++ b/src/converter/responses-echo.ts
@@ -140,8 +140,7 @@ export function mergedResponseShellEcho(echo?: ResponsesRequestEcho): Record<str
     tools: echo?.tools ?? [],
     truncation: echo?.truncation ?? "disabled",
     user: echo?.user !== undefined ? echo.user : null,
-    metadata:
-      echo?.metadata !== undefined ? { ...echo.metadata } : {},
+    metadata: echo?.metadata !== undefined ? { ...echo.metadata } : {},
     instructions: echo?.instructions !== undefined ? echo.instructions : null,
   };
 }

--- a/src/server/proxy/executor.ts
+++ b/src/server/proxy/executor.ts
@@ -1129,7 +1129,7 @@ export class ProxyExecutor {
       const outHeaders: Record<string, string | string[]> = { ...responseHeaders };
       if (
         task.method === "GET" &&
-        (task.requestPath === "/v1/models" || task.requestPath.split("?")[0] === "/v1/models") &&
+        (task.requestPath === "/models" || task.requestPath.split("?")[0] === "/models") &&
         status >= 400
       ) {
         const fallback = buildModelsListFallback(task.provider);
@@ -1148,7 +1148,7 @@ export class ProxyExecutor {
       const upstreamWireFmt: ApiSurface = isOpenAIType(task.provider.providerType) ? "openai" : "anthropic";
       if (
         task.method === "GET" &&
-        (task.requestPath === "/v1/models" || task.requestPath.split("?")[0] === "/v1/models") &&
+        (task.requestPath === "/models" || task.requestPath.split("?")[0] === "/models") &&
         outStatus === 200 &&
         task.clientSurface !== upstreamWireFmt &&
         ctx.responseChunks.length > 0

--- a/src/server/request/routerStage.ts
+++ b/src/server/request/routerStage.ts
@@ -10,6 +10,21 @@ import { detectApiSurface, resolveInboundClientSurface } from "./apiSurfaceDetec
 import { isOpenAIType } from "../../converter";
 
 /**
+ * Internal path mapping: client entry point → upstream endpoint path.
+ * Clients always use /v1/ prefixed paths; upstream providers may differ.
+ * Anthropic paths (/v1/messages) are kept as-is since Anthropic uses the same prefix.
+ */
+const UPSTREAM_PATH_MAP = new Map<string, string>([
+  ["/v1/chat/completions", "/chat/completions"],
+  ["/v1/responses", "/responses"],
+  ["/v1/models", "/models"],
+]);
+
+function resolveUpstreamPath(clientPath: string): string {
+  return UPSTREAM_PATH_MAP.get(clientPath) ?? clientPath;
+}
+
+/**
  * RouterStage processes request routing and blocking
  */
 export class RouterStage {
@@ -67,8 +82,8 @@ export class RouterStage {
 
     // 3. Build target URL
     const targetQuery = typeof parsedUrl.search === "string" ? parsedUrl.search : "";
-    const targetPath = path;
-    let targetUrl = this.router.getTargetUrl(path, provider);
+    const targetPath = resolveUpstreamPath(path);
+    let targetUrl = this.router.getTargetUrl(targetPath, provider);
     if (targetQuery) {
       targetUrl += targetQuery;
     }


### PR DESCRIPTION
## Summary

- **fix**: Map client paths to upstream endpoint paths (`executor` / router stage).
- **perf(build)**: Remove redundant build steps in the packaging pipeline.

## Test plan

- [ ] CI passes
- [ ] Smoke relevant proxy routing if applicable

Made with [Cursor](https://cursor.com)