### PR TITLE
fix(db, packaging): stabilize SQLite CLI IPC; chore: IPC lifecycle log levels

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,69 +1,45 @@
-# VS Code configuration
-.vscode**
-.vscode-test/**
+# -----------------------------------------------------------------------------
+# VSIX whitelist packaging
+#
+# Ignore everything first, then un-ignore only paths required at runtime.
+# New repo folders (internal-docs/, docs/, etc.) are NOT packaged unless added
+# below — avoids accidentally shipping large or sensitive files.
+#
+# vsce expands folder-only lines (see @vscode/vsce collectFiles). Never use bare `!node_modules/` — it becomes `!node_modules/**`
+# and pulls in every production dependency (js-yaml, ws, zod, …).
+# https://code.visualstudio.com/api/working-with-extensions/publishing-extension#.vscodeignore
+# -----------------------------------------------------------------------------
 
-# GitHub configuration
-.github/**
+**/*
 
-# Source code
-src/**
-tests/**
+# Extension manifest & marketplace metadata
+!package.json
+!README.md
+!README_CN.md
+!CHANGELOG.md
+!LICENSE
 
-# Git
-.gitignore
-.yarnrc
+# Icons / activity bar (paths referenced from package.json & contributes)
+!assets/
 
-# Dev tooling
-.husky/**
-.claude/**
-CLAUDE.md
+# Bundled extension entrypoints + webview build output
+!out/
+!out/dist/
+!out/web/
 
-# TypeScript configuration
-**/tsconfig.json
-**/.eslintrc.json
-**/*.map
-**/*.ts
-
-# Web source directory
-web/**
-!out/web/**
-
-# Web node_modules
-web/node_modules/**
-
-# Scripts
-scripts/**
-
-# Compiled output
-out/src/**
-out/tests/**
-
-# Dev config files
-.tool-versions
-eslint.config.js
-eslint.config.mjs
-.prettierrc
-vsc-extension-quickstart.md
-
-# Documentation
-docs/**
-
-# Exclude all node_modules
-node_modules/**
-
-# Only keep runtime dependencies
-!out/dist/**
-!node_modules/pg/**
-!node_modules/pg-*/
-!node_modules/pg-protocol/**
-!node_modules/pg-pool/**
-!node_modules/pg-types/**
-!node_modules/postgres-array/**
-!node_modules/postgres-bytea/**
-!node_modules/postgres-date/**
-!node_modules/postgres-interval/**
-!node_modules/pgpass/**
-!node_modules/pg-int8/**
-!node_modules/pg-cloudflare/**
-!node_modules/split2/**
-!node_modules/xtend/**
+# Runtime deps kept external by esbuild (scripts/esbuild.config.mjs).
+# One line per package (trailing `/` → vsce adds /**); keep in sync when pg changes.
+!node_modules/pg/
+!node_modules/pg-cloudflare/
+!node_modules/pg-connection-string/
+!node_modules/pg-int8/
+!node_modules/pg-pool/
+!node_modules/pg-protocol/
+!node_modules/pg-types/
+!node_modules/pgpass/
+!node_modules/postgres-array/
+!node_modules/postgres-bytea/
+!node_modules/postgres-date/
+!node_modules/postgres-interval/
+!node_modules/split2/
+!node_modules/xtend/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Delete provider confirmation**: deleting a provider now requires confirmation via a dialog showing the provider name and ID.
 - **`response.completed` usage on streaming conversions**: emits final completion and `[DONE]` only after upstream `[DONE]` (or EOF fallback) so a trailing usage-only chunk is merged when upstream sends `finish_reason` before `usage` (MiMo-style split chunks).
 - **Database worker client**: restarts the worker thread automatically with exponential backoff after an unexpected exit; outer RPC timeout is slightly longer than the CLI driver command timeout; read APIs (`queryLogs`, `getLogById`, `getStats`) degrade to empty or null results on transient failures instead of always surfacing errors to callers.
+- **SQLite CLI IPC logging**: INFO for subprocess spawn, sentinel handshake, and channel close; WARN for recoverable faults (health check failure, unexpected exit, channel faults/timeouts, rebuild); ERROR for spawn errors (`proc` `"error"`), restart failure, and max-restart exhaustion.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Model Map field**: no longer marked as required; empty means models are passed through without remapping.
 - **Delete provider confirmation**: deleting a provider now requires confirmation via a dialog showing the provider name and ID.
 - **`response.completed` usage on streaming conversions**: emits final completion and `[DONE]` only after upstream `[DONE]` (or EOF fallback) so a trailing usage-only chunk is merged when upstream sends `finish_reason` before `usage` (MiMo-style split chunks).
+- **Database worker client**: restarts the worker thread automatically with exponential backoff after an unexpected exit; outer RPC timeout is slightly longer than the CLI driver command timeout; read APIs (`queryLogs`, `getLogById`, `getStats`) degrade to empty or null results on transient failures instead of always surfacing errors to callers.
 
 ### Removed
 
@@ -44,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **SQLite log database (CLI driver)**: eliminated the race between manual `restart()` and the subprocess `exit` handler spawning overlapping sqlite3 processes (which broke sentinel framing on the stdin/stdout pipe); stale I/O is ignored via a process generation counter and listeners are stripped before kill. Stdin writes respect pipe backpressure; list queries use explicit columns plus a short `request_body` preview to shrink IPC traffic; pragma cache/mmap limits tightened for extension RAM.
+- **VSIX packaging**: `.vscodeignore` is now an explicit whitelist (`**/*` plus selective `!` entries). Documents vsce’s rule expansion for trailing `/` (never use bare `!node_modules/` — it becomes `!node_modules/**` and pulled in every prod dependency). Stray trees such as `internal-docs/` are excluded unless explicitly listed.
 - **Anthropic → OpenAI thinking blocks**: multiple thinking blocks in a single assistant message are now merged (content joined, last non-empty signature used) instead of only using the first one.
 - **Reasoning budget thresholds**: Anthropic `thinking.budget_tokens` 4097–8192 now maps to OpenAI `"high"` effort instead of `"medium"`, avoiding round-trip budget loss (medium → 4096 would reduce the budget).
 - **Orphaned tool messages**: `buildAnthropicMessages` now skips `role: "tool"` messages that don't follow an assistant message with tool calls, preventing upstream 400 errors.

--- a/src/database/database-worker-client.ts
+++ b/src/database/database-worker-client.ts
@@ -48,12 +48,12 @@ interface WorkerResponse {
   error?: string;
 }
 
-// Default timeout for worker operations (30 seconds)
-const DEFAULT_TIMEOUT_MS = 30_000;
-
 /**
- * Generate unique request ID
+ * Outer timeout must be larger than CliConnection.commandTimeoutMs (15s)
+ * to give the inner layer time to detect and recover from errors.
  */
+const DEFAULT_TIMEOUT_MS = 25_000;
+
 function generateRequestId(): string {
   return `${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
 }
@@ -74,21 +74,24 @@ export class DatabaseWorkerClient implements DatabaseDriver {
   private log = Logger.getInstance();
   private _enabled: boolean = false;
   private config: DatabaseDriverConfig;
+  private isClosing = false;
+
+  private workerRestartCount = 0;
+  private readonly maxWorkerRestarts = 5;
+  private workerRestartTimer: NodeJS.Timeout | null = null;
 
   constructor(config: DatabaseDriverConfig) {
     this.config = config;
   }
 
   /**
-   * Start the worker thread
+   * Start the worker thread and wire up event handlers
    */
   private startWorker(): void {
     if (this.worker) {
       return;
     }
 
-    // Worker is bundled separately by esbuild to out/dist/database-worker.cjs
-    // __dirname points to out/dist/ after bundling
     const workerPath = path.join(__dirname, "database-worker.cjs");
     this.worker = new Worker(workerPath);
 
@@ -108,7 +111,6 @@ export class DatabaseWorkerClient implements DatabaseDriver {
 
     this.worker.on("error", err => {
       this.log.error("[DatabaseWorker] Worker error:", err);
-      // Reject all pending requests
       for (const [id, pending] of this.pendingRequests) {
         clearTimeout(pending.timeout);
         pending.reject(err);
@@ -120,7 +122,55 @@ export class DatabaseWorkerClient implements DatabaseDriver {
       this.log.info(`[DatabaseWorker] Worker exited with code ${code}`);
       this.worker = null;
       this._enabled = false;
+
+      if (!this.isClosing) {
+        void this.restartWorker();
+      }
     });
+  }
+
+  /**
+   * Automatically restart the worker thread with exponential backoff.
+   * Resets the restart counter on success so transient crashes don't
+   * permanently disable the database.
+   */
+  private async restartWorker(): Promise<void> {
+    if (this.isClosing) {
+      return;
+    }
+
+    if (this.workerRestartCount >= this.maxWorkerRestarts) {
+      this.log.error(
+        "[DatabaseWorker] Max worker restarts exceeded, database permanently disabled"
+      );
+      return;
+    }
+
+    this.workerRestartCount++;
+    const delay = Math.min(1000 * Math.pow(2, this.workerRestartCount - 1), 30_000);
+    this.log.warn(
+      `[DatabaseWorker] Scheduling worker restart in ${delay}ms (attempt ${this.workerRestartCount}/${this.maxWorkerRestarts})`
+    );
+
+    await new Promise<void>(resolve => {
+      this.workerRestartTimer = setTimeout(resolve, delay);
+    });
+    this.workerRestartTimer = null;
+
+    if (this.isClosing) {
+      return;
+    }
+
+    try {
+      this.startWorker();
+      await this.send("init", this.config);
+      this._enabled = true;
+      this.workerRestartCount = 0;
+      this.log.info("[DatabaseWorker] Worker restarted successfully");
+    } catch (err) {
+      this.log.error("[DatabaseWorker] Worker restart failed:", err);
+      // The exit handler will trigger another attempt if the worker crashed
+    }
   }
 
   /**
@@ -159,6 +209,7 @@ export class DatabaseWorkerClient implements DatabaseDriver {
    * Initialize the database
    */
   async initialize(): Promise<void> {
+    this.isClosing = false;
     this.startWorker();
     await this.send("init", this.config);
     this._enabled = true;
@@ -169,9 +220,24 @@ export class DatabaseWorkerClient implements DatabaseDriver {
    * Close the database and terminate worker
    */
   async close(): Promise<void> {
+    this.isClosing = true;
+
+    if (this.workerRestartTimer) {
+      clearTimeout(this.workerRestartTimer);
+      this.workerRestartTimer = null;
+    }
+
     if (this.worker) {
-      await this.send("close");
-      await this.worker.terminate();
+      try {
+        await this.send("close");
+      } catch {
+        // Worker may already be dead
+      }
+      try {
+        await this.worker.terminate();
+      } catch {
+        // ignore
+      }
       this.worker = null;
     }
     this._enabled = false;
@@ -256,17 +322,31 @@ export class DatabaseWorkerClient implements DatabaseDriver {
   }
 
   /**
-   * Query logs with filter
+   * Query logs with filter — returns empty on failure for graceful degradation
    */
   async queryLogs(filter: LogFilter): Promise<LogQueryResult> {
-    return this.send<LogQueryResult>("queryLogs", { filter });
+    try {
+      return await this.send<LogQueryResult>("queryLogs", { filter });
+    } catch (err) {
+      this.log.warn(
+        `[DatabaseWorker] queryLogs failed, returning empty: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return { logs: [], total: 0 };
+    }
   }
 
   /**
-   * Get a single log by ID
+   * Get a single log by ID — returns null on failure
    */
   async getLogById(id: number): Promise<RequestLog | null> {
-    return this.send<RequestLog | null>("getLogById", { id });
+    try {
+      return await this.send<RequestLog | null>("getLogById", { id });
+    } catch (err) {
+      this.log.warn(
+        `[DatabaseWorker] getLogById failed: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return null;
+    }
   }
 
   /**
@@ -284,10 +364,23 @@ export class DatabaseWorkerClient implements DatabaseDriver {
   }
 
   /**
-   * Get database statistics
+   * Get database statistics — returns zeroed stats on failure
    */
   async getStats(): Promise<DatabaseStats> {
-    return this.send<DatabaseStats>("getStats");
+    try {
+      return await this.send<DatabaseStats>("getStats");
+    } catch (err) {
+      this.log.warn(
+        `[DatabaseWorker] getStats failed, returning empty: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return {
+        totalLogs: 0,
+        successCount: 0,
+        errorCount: 0,
+        avgDuration: 0,
+        byProvider: {},
+      };
+    }
   }
 
   /**

--- a/src/database/drivers/sqlite-cli.ts
+++ b/src/database/drivers/sqlite-cli.ts
@@ -1,7 +1,7 @@
 /**
  * SQLite CLI Driver
- * Manages a long-lived sqlite3 CLI process via stdin/stdout pipes.
- * Eliminates WASM memory overhead by delegating all DB operations to a native subprocess.
+ * Manages TWO long-lived sqlite3 CLI processes (read + write) via stdin/stdout pipes.
+ * WAL mode enables concurrent reads while a write connection is busy.
  * Implements DatabaseDriver interface with business-level methods.
  */
 
@@ -19,8 +19,9 @@ import type {
   RequestStatus,
 } from "../types";
 
-// Maximum database file size (50MB)
-const MAX_DB_FILE_SIZE = 50 * 1024 * 1024;
+// Cleanup thresholds
+const MAX_LOG_ROWS = 10000;
+const MAX_LOG_AGE_DAYS = 30;
 
 /**
  * Base64 encoding helpers for storage
@@ -65,7 +66,6 @@ function escapeValue(value: string | number | boolean | null | undefined): strin
     }
     return value.toString();
   }
-  // String: wrap in single quotes, escape internal single quotes
   const escaped = value.replace(/\u0000/g, "").replace(/'/g, "''");
   return `'${escaped}'`;
 }
@@ -239,101 +239,16 @@ interface PendingQuery {
   isExec: boolean;
 }
 
-/**
- * Async write queue for database operations
- */
-class WriteQueue {
-  private queue: RequestLog[] = [];
-  private driver: SqliteCliDriver | null = null;
-  private isProcessing: boolean = false;
-  private flushTimer: NodeJS.Timeout | null = null;
-  private readonly batchSize = 50;
-  private readonly flushInterval = 1000;
-  private isEnabled: boolean = false;
+// ---------------------------------------------------------------------------
+// CliConnection — manages a single sqlite3 CLI subprocess
+// ---------------------------------------------------------------------------
 
-  setDriver(driver: SqliteCliDriver | null): void {
-    this.driver = driver;
-  }
-
-  setEnabled(enabled: boolean): void {
-    this.isEnabled = enabled;
-    if (!enabled) {
-      this.clear();
-    }
-  }
-
-  add(log: RequestLog): void {
-    if (!this.isEnabled || !this.driver) {
-      return;
-    }
-    this.queue.push(log);
-
-    if (this.queue.length >= this.batchSize) {
-      this.flush();
-    } else {
-      this.scheduleFlush();
-    }
-  }
-
-  private scheduleFlush(): void {
-    if (!this.flushTimer) {
-      this.flushTimer = setTimeout(() => {
-        this.flush();
-      }, this.flushInterval);
-    }
-  }
-
-  private flush(): void {
-    if (this.flushTimer) {
-      clearTimeout(this.flushTimer);
-      this.flushTimer = null;
-    }
-
-    if (this.isProcessing || this.queue.length === 0 || !this.driver) {
-      return;
-    }
-
-    this.isProcessing = true;
-    const itemsToWrite = this.queue.splice(0);
-
-    this.driver
-      .writeBatch(itemsToWrite)
-      .catch(err => {
-        console.error("[WriteQueue] Failed to write logs:", err);
-      })
-      .finally(() => {
-        this.isProcessing = false;
-        if (this.queue.length > 0) {
-          this.flush();
-        }
-      });
-  }
-
-  clear(): void {
-    if (this.flushTimer) {
-      clearTimeout(this.flushTimer);
-      this.flushTimer = null;
-    }
-    this.queue = [];
-  }
-
-  get size(): number {
-    return this.queue.length;
-  }
-
-  forceFlush(): void {
-    this.flush();
-  }
-}
-
-/**
- * SqliteCliDriver: SQLite driver implementation using CLI subprocess
- */
-export class SqliteCliDriver implements DatabaseDriver {
+class CliConnection {
   private process: ChildProcess | null = null;
   private readonly config: SqliteDriverConfig;
-  private readonly log = Logger.getInstance();
-  private sqlite3Path: string | null = null;
+  private readonly sqlite3Path: string;
+  private readonly log: Logger;
+  private readonly label: string;
 
   private readonly commandQueue: Array<() => void> = [];
   private isProcessingCommand = false;
@@ -343,88 +258,162 @@ export class SqliteCliDriver implements DatabaseDriver {
 
   private isClosing = false;
   private restartCount = 0;
-  private readonly maxRestarts = 3;
+  private readonly maxRestarts = 10;
   private isStarted = false;
   private needsRestart = false;
-  private readonly commandTimeoutMs = 10000;
+  private readonly commandTimeoutMs = 15_000;
   private commandTimer: NodeJS.Timeout | null = null;
 
-  private readonly writeQueue: WriteQueue = new WriteQueue();
-  private isEnabled = false;
+  /** Guards against exit handler spawning a duplicate process during restart */
+  private isRestarting = false;
+  /** Monotonic generation counter to ignore stale exit/data events */
+  private processGeneration = 0;
+  /** Timestamp of last successful command — used to decay restartCount */
+  private lastSuccessTime = 0;
 
-  constructor(config: SqliteDriverConfig) {
+  private healthCheckInterval: NodeJS.Timeout | null = null;
+  private static readonly healthCheckIntervalMs = 30_000;
+
+  constructor(
+    config: SqliteDriverConfig,
+    sqlite3Path: string,
+    log: Logger,
+    label: string
+  ) {
     this.config = config;
+    this.sqlite3Path = sqlite3Path;
+    this.log = log;
+    this.label = label;
   }
 
-  /**
-   * Initialize the database
-   */
-  async initialize(): Promise<void> {
-    const dbPath = this.config.path;
-    const dir = path.dirname(dbPath);
+  get started(): boolean {
+    return this.isStarted;
+  }
 
-    if (!fsSync.existsSync(dir)) {
-      fsSync.mkdirSync(dir, { recursive: true });
-    }
+  // ---- Lifecycle ----------------------------------------------------------
 
-    // Find sqlite3 binary
-    this.sqlite3Path = this.findSqlite3();
-    if (!this.sqlite3Path) {
-      throw new Error("sqlite3 CLI not found. Please install SQLite3.");
-    }
-
-    this.log.info(`[SqliteCli] Database path: ${dbPath}`);
-
+  async start(): Promise<void> {
     await this.spawnProcess();
-    await this.createSchema();
-
-    this.writeQueue.setDriver(this);
-    this.isEnabled = true;
-    this.writeQueue.setEnabled(true);
-
-    // Clean old logs in background
-    setTimeout(() => {
-      this.cleanOldLogs().catch(err => {
-        this.log.error("[SqliteCli] Background cleanup failed:", err);
-      });
-    }, 0);
   }
 
-  private findSqlite3(): string | null {
-    try {
-      const result = execSync("which sqlite3", { encoding: "utf-8" }).trim();
-      return result || null;
-    } catch {
-      return null;
+  async close(): Promise<void> {
+    this.stopHealthCheck();
+    this.isClosing = true;
+    this.isStarted = false;
+
+    if (!this.process) { return; }
+
+    const proc = this.process;
+    return new Promise<void>(resolve => {
+      const timeout = setTimeout(() => {
+        if (this.process === proc) {
+          try { proc.kill("SIGKILL"); } catch { /* ignore */ }
+          this.process = null;
+        }
+        resolve();
+      }, 5000);
+
+      proc.once("exit", () => {
+        clearTimeout(timeout);
+        if (this.process === proc) {
+          this.process = null;
+        }
+        resolve();
+      });
+
+      try {
+        proc.stdin?.write(".quit\n");
+        proc.stdin?.end();
+      } catch {
+        clearTimeout(timeout);
+        if (this.process === proc) {
+          this.process = null;
+        }
+        resolve();
+      }
+    });
+  }
+
+  // ---- Health check -------------------------------------------------------
+
+  startHealthCheck(): void {
+    if (this.healthCheckInterval) { return; }
+    this.healthCheckInterval = setInterval(() => {
+      if (!this.isStarted || this.isClosing) { return; }
+      this.queryScalar<number>("SELECT 1").catch(() => {
+        this.log.warn(`[SqliteCli:${this.label}] Health check failed, triggering restart`);
+        this.needsRestart = true;
+        void this.processNextCommand();
+      });
+    }, CliConnection.healthCheckIntervalMs);
+  }
+
+  stopHealthCheck(): void {
+    if (this.healthCheckInterval) {
+      clearInterval(this.healthCheckInterval);
+      this.healthCheckInterval = null;
     }
   }
+
+  // ---- SQL helpers --------------------------------------------------------
+
+  async exec(sql: string, params?: (string | number | boolean | null | undefined)[]): Promise<void> {
+    const interpolated = interpolateSql(sql, params);
+    await this.sendCommand(interpolated, true);
+  }
+
+  async query(sql: string, params?: (string | number | boolean | null | undefined)[]): Promise<Record<string, unknown>[]> {
+    const interpolated = interpolateSql(sql, params);
+    return this.sendCommand(interpolated, false);
+  }
+
+  async queryScalar<T = number>(sql: string, params?: (string | number | boolean | null | undefined)[]): Promise<T | null> {
+    const rows = await this.query(sql, params);
+    if (rows.length === 0) { return null; }
+    const firstRow = rows[0];
+    const keys = Object.keys(firstRow);
+    if (keys.length === 0) { return null; }
+    return firstRow[keys[0]] as T;
+  }
+
+  async transaction(sqls: string[]): Promise<void> {
+    const combined = ["BEGIN TRANSACTION", ...sqls, "COMMIT"]
+      .map(s => (s.trim().endsWith(";") ? s : s + ";"))
+      .join("\n");
+    await this.sendCommand(combined, true);
+  }
+
+  // ---- Private: process management ----------------------------------------
 
   private spawnProcess(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      if (!this.sqlite3Path) {
-        reject(new Error("sqlite3 path not set"));
-        return;
-      }
+      const generation = ++this.processGeneration;
 
-      this.process = spawn(this.sqlite3Path, [this.config.path], {
+      const proc = spawn(this.sqlite3Path, [this.config.path], {
         stdio: ["pipe", "pipe", "pipe"],
         env: { ...process.env },
       });
+      this.process = proc;
 
       this.stdoutBuffer = "";
       this.stderrBuffer = "";
 
-      this.process.stdout!.on("data", (data: Buffer) => {
+      proc.stdout.on("data", (data: Buffer) => {
+        if (generation !== this.processGeneration) { return; }
         this.stdoutBuffer += data.toString();
         this.checkForSentinel();
       });
 
-      this.process.stderr!.on("data", (data: Buffer) => {
+      proc.stderr.on("data", (data: Buffer) => {
+        if (generation !== this.processGeneration) { return; }
         this.stderrBuffer += data.toString();
         this.checkForSentinel();
       });
 
-      this.process.on("exit", (code: number | null, signal: NodeJS.Signals | null) => {
+      proc.on("exit", (code: number | null, signal: NodeJS.Signals | null) => {
+        // Ignore stale exit events from a previous generation
+        if (generation !== this.processGeneration) { return; }
+
         this.process = null;
 
         if (this.commandTimer) {
@@ -439,19 +428,26 @@ export class SqliteCliDriver implements DatabaseDriver {
           this.currentQuery = null;
         }
 
-        if (!this.isClosing && this.restartCount < this.maxRestarts) {
+        // If restart() is driving the respawn, let it handle everything
+        if (this.isRestarting || this.isClosing) { return; }
+
+        if (this.restartCount < this.maxRestarts) {
           this.restartCount++;
+          this.log.warn(`[SqliteCli:${this.label}] Process exited unexpectedly (code=${code}, signal=${signal}), restarting (${this.restartCount}/${this.maxRestarts})`);
           this.spawnProcess()
             .then(() => void this.processNextCommand())
             .catch((err: unknown) => {
               this.drainQueueWithError(err instanceof Error ? err : new Error(String(err)));
             });
-        } else if (!this.isClosing) {
+        } else {
+          this.log.error(`[SqliteCli:${this.label}] Max restarts exceeded, draining queue`);
+          this.isStarted = false;
           this.drainQueueWithError(new Error("sqlite3 crashed and max restarts exceeded"));
         }
       });
 
-      this.process.on("error", (err: Error) => {
+      proc.on("error", (err: Error) => {
+        if (generation !== this.processGeneration) { return; }
         reject(err);
       });
 
@@ -460,7 +456,10 @@ export class SqliteCliDriver implements DatabaseDriver {
         ".headers on",
         "PRAGMA journal_mode=WAL;",
         "PRAGMA synchronous=NORMAL;",
-        "PRAGMA busy_timeout=5000;",
+        "PRAGMA busy_timeout=30000;",
+        "PRAGMA cache_size=-8000;",
+        "PRAGMA temp_store=MEMORY;",
+        "PRAGMA mmap_size=16777216;",
       ].join("\n");
 
       const initSentinel = this.generateSentinelId();
@@ -471,6 +470,7 @@ export class SqliteCliDriver implements DatabaseDriver {
         resolve: () => {
           this.currentQuery = null;
           this.restartCount = 0;
+          this.lastSuccessTime = Date.now();
           if (this.commandTimer) {
             clearTimeout(this.commandTimer);
             this.commandTimer = null;
@@ -494,7 +494,7 @@ export class SqliteCliDriver implements DatabaseDriver {
         reject(new Error("sqlite3 initialization timed out"));
       }, this.commandTimeoutMs);
 
-      this.process.stdin!.write(initSql);
+      this.writeToStdin(initSql);
     });
   }
 
@@ -506,13 +506,6 @@ export class SqliteCliDriver implements DatabaseDriver {
     if (!this.currentQuery) { return; }
 
     const sentinel = this.currentQuery.sentinelId;
-    const stderrContent = this.stderrBuffer.trim();
-
-    if (stderrContent) {
-      void this.handleError(new Error(`sqlite3 error: ${stderrContent}`));
-      return;
-    }
-
     const sentinelIdIndex = this.stdoutBuffer.indexOf(sentinel);
     if (sentinelIdIndex === -1) { return; }
 
@@ -529,10 +522,22 @@ export class SqliteCliDriver implements DatabaseDriver {
     const resultText = this.stdoutBuffer.substring(0, prefixIndex).trim();
     this.stdoutBuffer = this.stdoutBuffer.substring(sentinelEndIndex).trimStart();
 
+    const stderrContent = this.stderrBuffer.trim();
+    if (stderrContent) {
+      this.log.warn(`[SqliteCli:${this.label}] stderr during successful command: ${stderrContent}`);
+    }
+    this.stderrBuffer = "";
+
     if (this.commandTimer) {
       clearTimeout(this.commandTimer);
       this.commandTimer = null;
     }
+
+    // Decay restart count after sustained healthy operation (>60s since last success)
+    if (this.restartCount > 0 && Date.now() - this.lastSuccessTime > 60_000) {
+      this.restartCount = Math.max(0, this.restartCount - 1);
+    }
+    this.lastSuccessTime = Date.now();
 
     if (this.currentQuery.isExec || !resultText) {
       this.currentQuery.resolve([]);
@@ -604,8 +609,7 @@ export class SqliteCliDriver implements DatabaseDriver {
             );
             results.push(...objects);
           } catch {
-            // Warn about malformed array to avoid silent failures
-            this.log.warn(`[SqliteCli] Skipped malformed JSON array chunk: ${currentArray.trim()}`);
+            this.log.warn(`[SqliteCli:${this.label}] Skipped malformed JSON array chunk: ${currentArray.trim()}`);
           }
           inArray = false;
           currentArray = "";
@@ -618,30 +622,20 @@ export class SqliteCliDriver implements DatabaseDriver {
     return results;
   }
 
-  private async exec(sql: string, params?: (string | number | boolean | null | undefined)[]): Promise<void> {
-    const interpolated = interpolateSql(sql, params);
-    await this.sendCommand(interpolated, true);
-  }
-
-  private async query(sql: string, params?: (string | number | boolean | null | undefined)[]): Promise<Record<string, unknown>[]> {
-    const interpolated = interpolateSql(sql, params);
-    return this.sendCommand(interpolated, false);
-  }
-
-  private async queryScalar<T = number>(sql: string, params?: (string | number | boolean | null | undefined)[]): Promise<T | null> {
-    const rows = await this.query(sql, params);
-    if (rows.length === 0) { return null; }
-    const firstRow = rows[0];
-    const keys = Object.keys(firstRow);
-    if (keys.length === 0) { return null; }
-    return firstRow[keys[0]] as T;
-  }
-
-  private async transaction(sqls: string[]): Promise<void> {
-    const combined = ["BEGIN TRANSACTION", ...sqls, "COMMIT"]
-      .map(s => (s.trim().endsWith(";") ? s : s + ";"))
-      .join("\n");
-    await this.sendCommand(combined, true);
+  /**
+   * Write data to stdin with backpressure awareness.
+   * The command timer still guards against a total hang if the pipe stays full.
+   */
+  private writeToStdin(data: string): void {
+    if (!this.process?.stdin || this.process.stdin.destroyed) {
+      return;
+    }
+    const ok = this.process.stdin.write(data);
+    if (!ok) {
+      this.process.stdin.once("drain", () => {
+        // Pipe drained — sentinel callback will drive the next step
+      });
+    }
   }
 
   private sendCommand(sql: string, isExec: boolean): Promise<Record<string, unknown>[]> {
@@ -669,7 +663,7 @@ export class SqliteCliDriver implements DatabaseDriver {
         const command = `${finalSql}\nSELECT '${sentinelId}' as _s;\n`;
         const safeCommand = this.validateAndSanitize(command);
 
-        this.process.stdin.write(safeCommand);
+        this.writeToStdin(safeCommand);
       };
 
       this.commandQueue.push(task);
@@ -696,7 +690,10 @@ export class SqliteCliDriver implements DatabaseDriver {
       clearTimeout(this.commandTimer);
     }
     this.commandTimer = setTimeout(() => {
-      void this.handleError(new Error(`Command timed out after ${this.commandTimeoutMs}ms`));
+      const stderrInfo = this.stderrBuffer.trim();
+      void this.handleError(
+        new Error(`Command timed out after ${this.commandTimeoutMs}ms${stderrInfo ? `: ${stderrInfo}` : ""}`)
+      );
     }, this.commandTimeoutMs);
 
     const next = this.commandQueue.shift()!;
@@ -711,79 +708,291 @@ export class SqliteCliDriver implements DatabaseDriver {
   }
 
   private drainQueueWithError(_err: Error): void {
-    while (this.commandQueue.length > 0) {
-      const task = this.commandQueue.shift()!;
+    const pending = this.commandQueue.splice(0);
+    this.isProcessingCommand = false;
+    for (const task of pending) {
       try {
         task();
       } catch {
-        // ignore
+        // task's reject will fire with "process not running"
       }
-    }
-    this.isProcessingCommand = false;
-  }
-
-  private async restart(): Promise<void> {
-    if (this.needsRestart) {
-      this.needsRestart = false;
-
-      if (this.process) {
-        try {
-          this.process.kill("SIGKILL");
-        } catch {
-          // ignore
-        }
-        this.process = null;
-      }
-
-      this.stdoutBuffer = "";
-      this.stderrBuffer = "";
-      this.currentQuery = null;
-
-      await this.spawnProcess();
     }
   }
 
   /**
-   * Close the database connection
+   * Kill the current process safely and respawn.
+   * Uses isRestarting flag + processGeneration counter to prevent the
+   * exit handler from spawning a duplicate process.
    */
+  private async restart(): Promise<void> {
+    if (!this.needsRestart) { return; }
+    this.needsRestart = false;
+    this.isRestarting = true;
+
+    if (this.process) {
+      const oldProc = this.process;
+      this.process = null;
+
+      // Detach all listeners so the old process's exit event
+      // does not interfere with the new process.
+      oldProc.removeAllListeners("exit");
+      oldProc.removeAllListeners("error");
+      oldProc.stdout?.removeAllListeners("data");
+      oldProc.stderr?.removeAllListeners("data");
+
+      try { oldProc.kill("SIGKILL"); } catch { /* ignore */ }
+    }
+
+    this.stdoutBuffer = "";
+    this.stderrBuffer = "";
+    this.currentQuery = null;
+
+    try {
+      await this.spawnProcess();
+      this.log.info(`[SqliteCli:${this.label}] Restarted successfully`);
+    } catch (err) {
+      this.log.error(`[SqliteCli:${this.label}] Restart failed:`, err);
+      this.isStarted = false;
+    } finally {
+      this.isRestarting = false;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// WriteQueue — async batching with retry and failure persistence
+// ---------------------------------------------------------------------------
+
+class WriteQueue {
+  private queue: RequestLog[] = [];
+  private conn: CliConnection | null = null;
+  private failedWritesPath: string | null = null;
+  private isProcessing = false;
+  private flushTimer: NodeJS.Timeout | null = null;
+  private readonly batchSize = 50;
+  private readonly flushInterval = 1000;
+  private isEnabled = false;
+
+  setConnection(conn: CliConnection, failedWritesPath: string): void {
+    this.conn = conn;
+    this.failedWritesPath = failedWritesPath;
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.isEnabled = enabled;
+    if (!enabled) {
+      this.clear();
+    }
+  }
+
+  add(log: RequestLog): void {
+    if (!this.isEnabled || !this.conn) {
+      return;
+    }
+    this.queue.push(log);
+
+    if (this.queue.length >= this.batchSize) {
+      this.flush();
+    } else {
+      this.scheduleFlush();
+    }
+  }
+
+  private scheduleFlush(): void {
+    if (!this.flushTimer) {
+      this.flushTimer = setTimeout(() => {
+        this.flush();
+      }, this.flushInterval);
+    }
+  }
+
+  private flush(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+
+    if (this.isProcessing || this.queue.length === 0 || !this.conn) {
+      return;
+    }
+
+    this.isProcessing = true;
+    const itemsToWrite = this.queue.splice(0);
+
+    void this.flushWithRetry(itemsToWrite)
+      .finally(() => {
+        this.isProcessing = false;
+        if (this.queue.length > 0) {
+          this.flush();
+        }
+      });
+  }
+
+  private async flushWithRetry(items: RequestLog[]): Promise<void> {
+    const maxRetries = 3;
+    const delays = [1000, 2000, 4000];
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        await this.writeBatch(items);
+        return;
+      } catch (err) {
+        if (attempt < maxRetries) {
+          await new Promise(r => setTimeout(r, delays[attempt]));
+        } else {
+          this.persistFailedWrites(items);
+          console.error("[WriteQueue] Failed to write logs after retries, saved to disk:", err);
+        }
+      }
+    }
+  }
+
+  private async writeBatch(logs: RequestLog[]): Promise<void> {
+    if (!this.conn) { return; }
+    const stmts = logs.map(log => {
+      const { sql, params } = buildInsertSql(log);
+      return interpolateSql(sql, params);
+    });
+    await this.conn.transaction(stmts);
+  }
+
+  private persistFailedWrites(items: RequestLog[]): void {
+    if (!this.failedWritesPath) { return; }
+    try {
+      const lines = items.map(log => JSON.stringify(log)).join("\n") + "\n";
+      fsSync.appendFileSync(this.failedWritesPath, lines);
+    } catch (err) {
+      console.error("[WriteQueue] Failed to persist writes to disk:", err);
+    }
+  }
+
+  async replayFailedWrites(): Promise<void> {
+    if (!this.failedWritesPath || !this.conn) { return; }
+    if (!fsSync.existsSync(this.failedWritesPath)) { return; }
+
+    const content = fsSync.readFileSync(this.failedWritesPath, "utf-8");
+    const lines = content.trim().split("\n").filter(Boolean);
+    if (lines.length === 0) { return; }
+
+    const logs: RequestLog[] = lines.map(line => JSON.parse(line) as RequestLog);
+    try {
+      await this.writeBatch(logs);
+      fsSync.unlinkSync(this.failedWritesPath);
+    } catch {
+      console.error("[WriteQueue] Failed to replay persisted writes");
+    }
+  }
+
+  clear(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    this.queue = [];
+  }
+
+  get size(): number {
+    return this.queue.length;
+  }
+
+  forceFlush(): void {
+    this.flush();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SqliteCliDriver — DatabaseDriver implementation using two CLI processes
+// ---------------------------------------------------------------------------
+
+export class SqliteCliDriver implements DatabaseDriver {
+  private readonly config: SqliteDriverConfig;
+  private readonly log = Logger.getInstance();
+  private sqlite3Path: string | null = null;
+
+  private writeConn: CliConnection | null = null;
+  private readConn: CliConnection | null = null;
+
+  private readonly writeQueue: WriteQueue = new WriteQueue();
+  private isEnabled = false;
+
+  constructor(config: SqliteDriverConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Initialize the database with dual read/write connections
+   */
+  async initialize(): Promise<void> {
+    const dbPath = this.config.path;
+    const dir = path.dirname(dbPath);
+
+    if (!fsSync.existsSync(dir)) {
+      fsSync.mkdirSync(dir, { recursive: true });
+    }
+
+    this.sqlite3Path = this.findSqlite3();
+    if (!this.sqlite3Path) {
+      throw new Error("sqlite3 CLI not found. Please install SQLite3.");
+    }
+
+    this.log.info(`[SqliteCli] Database path: ${dbPath}`);
+
+    this.writeConn = new CliConnection(this.config, this.sqlite3Path, this.log, "write");
+    await this.writeConn.start();
+    await this.createSchema();
+
+    this.readConn = new CliConnection(this.config, this.sqlite3Path, this.log, "read");
+    try {
+      await this.readConn.start();
+      this.readConn.startHealthCheck();
+    } catch (err) {
+      this.log.warn(`[SqliteCli] Read connection failed to start, operating in write-only mode: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    const failedWritesPath = path.join(path.dirname(dbPath), "failed-writes.jsonl");
+    this.writeQueue.setConnection(this.writeConn, failedWritesPath);
+    await this.writeQueue.replayFailedWrites();
+
+    this.isEnabled = true;
+    this.writeQueue.setEnabled(true);
+
+    this.writeConn.startHealthCheck();
+
+    setTimeout(() => {
+      this.cleanOldLogs().catch(err => {
+        this.log.error("[SqliteCli] Background cleanup failed:", err);
+      });
+    }, 0);
+  }
+
+  private findSqlite3(): string | null {
+    try {
+      const result = execSync("which sqlite3", { encoding: "utf-8" }).trim();
+      return result || null;
+    } catch {
+      return null;
+    }
+  }
+
   async close(): Promise<void> {
-    this.isClosing = true;
-    this.isStarted = false;
     this.isEnabled = false;
     this.writeQueue.setEnabled(false);
     this.writeQueue.forceFlush();
 
-    if (!this.process) { return; }
-
-    const proc = this.process;
-    return new Promise<void>(resolve => {
-      const timeout = setTimeout(() => {
-        if (this.process) {
-          this.process.kill("SIGKILL");
-          this.process = null;
-        }
-        resolve();
-      }, 5000);
-
-      proc.once("exit", () => {
-        clearTimeout(timeout);
-        this.process = null;
-        resolve();
-      });
-
-      try {
-        proc.stdin?.write(".quit\n");
-        proc.stdin?.end();
-      } catch {
-        clearTimeout(timeout);
-        this.process = null;
-        resolve();
-      }
-    });
+    if (this.readConn) {
+      await this.readConn.close();
+      this.readConn = null;
+    }
+    if (this.writeConn) {
+      await this.writeConn.close();
+      this.writeConn = null;
+    }
   }
 
   private async createSchema(): Promise<void> {
-    await this.exec(`
+    if (!this.writeConn) { return; }
+
+    await this.writeConn.exec(`
       CREATE TABLE IF NOT EXISTS request_logs (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         timestamp INTEGER NOT NULL,
@@ -816,12 +1025,11 @@ export class SqliteCliDriver implements DatabaseDriver {
     ];
 
     for (const sql of indexes) {
-      await this.exec(sql);
+      await this.writeConn.exec(sql);
     }
 
-    // Run migrations
     try {
-      const columns = await this.query("PRAGMA table_info(request_logs)");
+      const columns = await this.writeConn.query("PRAGMA table_info(request_logs)");
       const columnNames = columns.map(c => c.name as string);
 
       const migrations: Array<{ column: string; sql: string }> = [
@@ -835,7 +1043,7 @@ export class SqliteCliDriver implements DatabaseDriver {
 
       for (const migration of migrations) {
         if (!columnNames.includes(migration.column)) {
-          await this.exec(migration.sql);
+          await this.writeConn.exec(migration.sql);
         }
       }
     } catch {
@@ -843,29 +1051,22 @@ export class SqliteCliDriver implements DatabaseDriver {
     }
   }
 
-  /**
-   * Insert a log entry (async via write queue)
-   */
+  // ---- Write operations (writeConn) --------------------------------------
+
   insertLog(log: RequestLog): void {
     if (!this.isEnabled) { return; }
     this.writeQueue.add(log);
   }
 
-  /**
-   * Insert a log entry with "pending" status immediately
-   */
   insertLogPending(log: RequestLog): void {
-    if (!this.isEnabled) { return; }
+    if (!this.isEnabled || !this.writeConn?.started) { return; }
 
     const { sql, params } = buildInsertSql(log, "pending");
-    this.exec(sql, params).catch(err => {
+    this.writeConn.exec(sql, params).catch(err => {
       this.log.error("[SqliteCli] Failed to insert pending log:", err);
     });
   }
 
-  /**
-   * Update a log entry by clientId
-   */
   updateLogCompleted(
     clientId: string,
     statusCode: number,
@@ -875,9 +1076,9 @@ export class SqliteCliDriver implements DatabaseDriver {
     errorMessage: string | undefined,
     originalResponseBody?: string
   ): void {
-    if (!this.isEnabled) { return; }
+    if (!this.isEnabled || !this.writeConn?.started) { return; }
 
-    this.exec(
+    this.writeConn.exec(
       `UPDATE request_logs
        SET status_code = ?,
            response_body = ?,
@@ -901,9 +1102,6 @@ export class SqliteCliDriver implements DatabaseDriver {
     });
   }
 
-  /**
-   * Update a log entry by clientId with custom status
-   */
   updateLogStatus(
     clientId: string,
     status: RequestStatus,
@@ -911,9 +1109,9 @@ export class SqliteCliDriver implements DatabaseDriver {
     duration: number,
     errorMessage: string | undefined
   ): void {
-    if (!this.isEnabled) { return; }
+    if (!this.isEnabled || !this.writeConn?.started) { return; }
 
-    this.exec(
+    this.writeConn.exec(
       `UPDATE request_logs
        SET status_code = ?,
            duration = ?,
@@ -924,7 +1122,7 @@ export class SqliteCliDriver implements DatabaseDriver {
       [
         statusCode,
         duration,
-        0, // success is always false for cancelled/timeout
+        0,
         encodeForStorage(errorMessage),
         status,
         clientId,
@@ -934,11 +1132,8 @@ export class SqliteCliDriver implements DatabaseDriver {
     });
   }
 
-  /**
-   * Batch insert logs
-   */
   async writeBatch(logs: RequestLog[]): Promise<void> {
-    if (logs.length === 0) { return; }
+    if (!this.writeConn?.started || logs.length === 0) { return; }
 
     const stmts: string[] = [];
     for (const log of logs) {
@@ -946,14 +1141,40 @@ export class SqliteCliDriver implements DatabaseDriver {
       stmts.push(interpolateSql(sql, params));
     }
 
-    await this.transaction(stmts);
+    await this.writeConn.transaction(stmts);
   }
 
-  /**
-   * Query logs with filter
-   */
+  async deleteLogs(ids: number[]): Promise<void> {
+    if (!this.writeConn?.started || ids.length === 0) { return; }
+
+    const placeholders = ids.map(() => "?").join(",");
+    await this.writeConn.exec(`DELETE FROM request_logs WHERE id IN (${placeholders})`, ids);
+  }
+
+  async clearAllLogs(): Promise<void> {
+    if (!this.writeConn?.started) { return; }
+    await this.writeConn.exec("DELETE FROM request_logs");
+    await this.writeConn.exec("VACUUM");
+  }
+
+  async cleanOldLogs(): Promise<void> {
+    if (!this.isEnabled || !this.writeConn?.started) { return; }
+
+    const cutoff = Date.now() - MAX_LOG_AGE_DAYS * 24 * 60 * 60 * 1000;
+    await this.writeConn.exec("DELETE FROM request_logs WHERE timestamp < ?", [cutoff]);
+
+    await this.writeConn.exec(`
+      DELETE FROM request_logs
+      WHERE id NOT IN (
+        SELECT id FROM request_logs ORDER BY timestamp DESC LIMIT ${MAX_LOG_ROWS}
+      )
+    `);
+  }
+
+  // ---- Read operations (readConn) ----------------------------------------
+
   async queryLogs(filter: LogFilter = {}): Promise<LogQueryResult> {
-    if (!this.isStarted) {
+    if (!this.readConn?.started) {
       return { logs: [], total: 0 };
     }
 
@@ -1002,7 +1223,7 @@ export class SqliteCliDriver implements DatabaseDriver {
 
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
-    const total = (await this.queryScalar<number>(
+    const total = (await this.readConn.queryScalar<number>(
       `SELECT COUNT(*) as count FROM request_logs ${whereClause}`,
       params
     )) ?? 0;
@@ -1010,8 +1231,11 @@ export class SqliteCliDriver implements DatabaseDriver {
     const limit = filter.limit || 100;
     const offset = filter.offset || 0;
 
-    const rows = await this.query(
-      `SELECT * FROM request_logs ${whereClause} ORDER BY timestamp DESC LIMIT ? OFFSET ?`,
+    const rows = await this.readConn.query(
+      `SELECT id, timestamp, provider_id, provider_name, method, path,
+              status_code, duration, success, error_message, client_id,
+              status, route_type, SUBSTR(request_body, 1, 500) as request_body
+       FROM request_logs ${whereClause} ORDER BY timestamp DESC LIMIT ? OFFSET ?`,
       [...params, limit, offset]
     );
 
@@ -1020,71 +1244,18 @@ export class SqliteCliDriver implements DatabaseDriver {
     return { logs, total };
   }
 
-  /**
-   * Get a single log by ID
-   */
   async getLogById(id: number): Promise<RequestLog | null> {
-    if (!this.isStarted) { return null; }
+    if (!this.readConn?.started) { return null; }
 
-    const rows = await this.query("SELECT * FROM request_logs WHERE id = ?", [id]);
+    const rows = await this.readConn.query("SELECT * FROM request_logs WHERE id = ?", [id]);
 
     if (rows.length === 0) { return null; }
 
     return dbRowToLog(rows[0]);
   }
 
-  /**
-   * Delete logs by IDs
-   */
-  async deleteLogs(ids: number[]): Promise<void> {
-    if (!this.isStarted || ids.length === 0) { return; }
-
-    const placeholders = ids.map(() => "?").join(",");
-    await this.exec(`DELETE FROM request_logs WHERE id IN (${placeholders})`, ids);
-  }
-
-  /**
-   * Clear all logs
-   */
-  async clearAllLogs(): Promise<void> {
-    if (!this.isStarted) { return; }
-    await this.exec("DELETE FROM request_logs");
-  }
-
-  /**
-   * Clean old logs
-   */
-  async cleanOldLogs(): Promise<void> {
-    if (!this.isStarted) { return; }
-
-    const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
-    await this.exec("DELETE FROM request_logs WHERE timestamp < ?", [thirtyDaysAgo]);
-
-    // Size-based cleanup
-    try {
-      if (fsSync.existsSync(this.config.path)) {
-        const stats = fsSync.statSync(this.config.path);
-        if (stats.size > MAX_DB_FILE_SIZE) {
-          this.log.warn(`[SqliteCli] Database size exceeds limit, trimming...`);
-          await this.exec(`
-            DELETE FROM request_logs
-            WHERE id NOT IN (
-              SELECT id FROM request_logs ORDER BY timestamp DESC LIMIT 1000
-            )
-          `);
-          await this.exec("VACUUM");
-        }
-      }
-    } catch (err) {
-      this.log.error("[SqliteCli] Size-based cleanup failed:", err);
-    }
-  }
-
-  /**
-   * Get database statistics
-   */
   async getStats(): Promise<DatabaseStats> {
-    if (!this.isStarted) {
+    if (!this.readConn?.started) {
       return {
         totalLogs: 0,
         successCount: 0,
@@ -1094,41 +1265,39 @@ export class SqliteCliDriver implements DatabaseDriver {
       };
     }
 
-    const total = (await this.queryScalar<number>("SELECT COUNT(*) as count FROM request_logs")) ?? 0;
-    const success = (await this.queryScalar<number>("SELECT COUNT(*) as count FROM request_logs WHERE success = 1")) ?? 0;
-    const error = (await this.queryScalar<number>("SELECT COUNT(*) as count FROM request_logs WHERE success = 0")) ?? 0;
-    const avgDuration = (await this.queryScalar<number>("SELECT AVG(duration) as avg FROM request_logs")) ?? 0;
+    const rows = await this.readConn.query(
+      `SELECT COUNT(*) as totalLogs,
+              SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END) as successCount,
+              SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) as errorCount,
+              AVG(duration) as avgDuration
+       FROM request_logs`
+    );
 
-
-    const byProviderRows = await this.query(
+    const row = rows[0] ?? {};
+    const byProviderRows = await this.readConn.query(
       "SELECT provider_id, COUNT(*) as count FROM request_logs GROUP BY provider_id"
     );
 
-
     const byProvider: Record<string, number> = {};
-    for (const row of byProviderRows) {
-      byProvider[row.provider_id as string] = row.count as number;
+    for (const r of byProviderRows) {
+      byProvider[r.provider_id as string] = r.count as number;
     }
 
     return {
-      totalLogs: total,
-      successCount: success,
-      errorCount: error,
-      avgDuration: Math.round(avgDuration),
+      totalLogs: (row.totalLogs as number) ?? 0,
+      successCount: (row.successCount as number) ?? 0,
+      errorCount: (row.errorCount as number) ?? 0,
+      avgDuration: Math.round((row.avgDuration as number) ?? 0),
       byProvider,
     };
   }
 
-  /**
-   * Check if driver is enabled
-   */
+  // ---- Properties ---------------------------------------------------------
+
   get enabled(): boolean {
-    return this.isEnabled && this.isStarted;
+    return this.isEnabled && this.writeConn?.started === true;
   }
 
-  /**
-   * Force flush pending writes
-   */
   forceFlush(): void {
     this.writeQueue.forceFlush();
   }

--- a/src/database/drivers/sqlite-cli.ts
+++ b/src/database/drivers/sqlite-cli.ts
@@ -73,7 +73,10 @@ function escapeValue(value: string | number | boolean | null | undefined): strin
 /**
  * Interpolate parameters into a SQL template.
  */
-function interpolateSql(sql: string, params?: (string | number | boolean | null | undefined)[]): string {
+function interpolateSql(
+  sql: string,
+  params?: (string | number | boolean | null | undefined)[]
+): string {
   if (!params || params.length === 0) {
     return sql;
   }
@@ -274,12 +277,7 @@ class CliConnection {
   private healthCheckInterval: NodeJS.Timeout | null = null;
   private static readonly healthCheckIntervalMs = 30_000;
 
-  constructor(
-    config: SqliteDriverConfig,
-    sqlite3Path: string,
-    log: Logger,
-    label: string
-  ) {
+  constructor(config: SqliteDriverConfig, sqlite3Path: string, log: Logger, label: string) {
     this.config = config;
     this.sqlite3Path = sqlite3Path;
     this.log = log;
@@ -301,13 +299,23 @@ class CliConnection {
     this.isClosing = true;
     this.isStarted = false;
 
-    if (!this.process) { return; }
+    if (!this.process) {
+      this.log.info(`[SqliteCli:${this.label}] IPC channel close requested (no subprocess)`);
+      return;
+    }
 
+    this.log.info(
+      `[SqliteCli:${this.label}] Closing sqlite3 IPC channel (pid=${this.process.pid ?? "?"})`
+    );
     const proc = this.process;
     return new Promise<void>(resolve => {
       const timeout = setTimeout(() => {
         if (this.process === proc) {
-          try { proc.kill("SIGKILL"); } catch { /* ignore */ }
+          try {
+            proc.kill("SIGKILL");
+          } catch {
+            /* ignore */
+          }
           this.process = null;
         }
         resolve();
@@ -337,11 +345,15 @@ class CliConnection {
   // ---- Health check -------------------------------------------------------
 
   startHealthCheck(): void {
-    if (this.healthCheckInterval) { return; }
+    if (this.healthCheckInterval) {
+      return;
+    }
     this.healthCheckInterval = setInterval(() => {
-      if (!this.isStarted || this.isClosing) { return; }
+      if (!this.isStarted || this.isClosing) {
+        return;
+      }
       this.queryScalar<number>("SELECT 1").catch(() => {
-        this.log.warn(`[SqliteCli:${this.label}] Health check failed, triggering restart`);
+        this.log.warn(`[SqliteCli:${this.label}] Health check failed — rebuilding IPC channel`);
         this.needsRestart = true;
         void this.processNextCommand();
       });
@@ -357,22 +369,35 @@ class CliConnection {
 
   // ---- SQL helpers --------------------------------------------------------
 
-  async exec(sql: string, params?: (string | number | boolean | null | undefined)[]): Promise<void> {
+  async exec(
+    sql: string,
+    params?: (string | number | boolean | null | undefined)[]
+  ): Promise<void> {
     const interpolated = interpolateSql(sql, params);
     await this.sendCommand(interpolated, true);
   }
 
-  async query(sql: string, params?: (string | number | boolean | null | undefined)[]): Promise<Record<string, unknown>[]> {
+  async query(
+    sql: string,
+    params?: (string | number | boolean | null | undefined)[]
+  ): Promise<Record<string, unknown>[]> {
     const interpolated = interpolateSql(sql, params);
     return this.sendCommand(interpolated, false);
   }
 
-  async queryScalar<T = number>(sql: string, params?: (string | number | boolean | null | undefined)[]): Promise<T | null> {
+  async queryScalar<T = number>(
+    sql: string,
+    params?: (string | number | boolean | null | undefined)[]
+  ): Promise<T | null> {
     const rows = await this.query(sql, params);
-    if (rows.length === 0) { return null; }
+    if (rows.length === 0) {
+      return null;
+    }
     const firstRow = rows[0];
     const keys = Object.keys(firstRow);
-    if (keys.length === 0) { return null; }
+    if (keys.length === 0) {
+      return null;
+    }
     return firstRow[keys[0]] as T;
   }
 
@@ -395,24 +420,34 @@ class CliConnection {
       });
       this.process = proc;
 
+      this.log.info(
+        `[SqliteCli:${this.label}] Spawning sqlite3 IPC channel (generation=${generation}, pid=${proc.pid ?? "pending"}, db=${this.config.path})`
+      );
+
       this.stdoutBuffer = "";
       this.stderrBuffer = "";
 
       proc.stdout.on("data", (data: Buffer) => {
-        if (generation !== this.processGeneration) { return; }
+        if (generation !== this.processGeneration) {
+          return;
+        }
         this.stdoutBuffer += data.toString();
         this.checkForSentinel();
       });
 
       proc.stderr.on("data", (data: Buffer) => {
-        if (generation !== this.processGeneration) { return; }
+        if (generation !== this.processGeneration) {
+          return;
+        }
         this.stderrBuffer += data.toString();
         this.checkForSentinel();
       });
 
       proc.on("exit", (code: number | null, signal: NodeJS.Signals | null) => {
         // Ignore stale exit events from a previous generation
-        if (generation !== this.processGeneration) { return; }
+        if (generation !== this.processGeneration) {
+          return;
+        }
 
         this.process = null;
 
@@ -429,11 +464,15 @@ class CliConnection {
         }
 
         // If restart() is driving the respawn, let it handle everything
-        if (this.isRestarting || this.isClosing) { return; }
+        if (this.isRestarting || this.isClosing) {
+          return;
+        }
 
         if (this.restartCount < this.maxRestarts) {
           this.restartCount++;
-          this.log.warn(`[SqliteCli:${this.label}] Process exited unexpectedly (code=${code}, signal=${signal}), restarting (${this.restartCount}/${this.maxRestarts})`);
+          this.log.warn(
+            `[SqliteCli:${this.label}] sqlite3 subprocess exited (code=${code}, signal=${signal}) — rebuilding IPC channel (attempt ${this.restartCount}/${this.maxRestarts})`
+          );
           this.spawnProcess()
             .then(() => void this.processNextCommand())
             .catch((err: unknown) => {
@@ -447,7 +486,13 @@ class CliConnection {
       });
 
       proc.on("error", (err: Error) => {
-        if (generation !== this.processGeneration) { return; }
+        if (generation !== this.processGeneration) {
+          return;
+        }
+        this.log.error(
+          `[SqliteCli:${this.label}] sqlite3 spawn/process error (generation=${generation})`,
+          err
+        );
         reject(err);
       });
 
@@ -476,6 +521,9 @@ class CliConnection {
             this.commandTimer = null;
           }
           this.isStarted = true;
+          this.log.info(
+            `[SqliteCli:${this.label}] IPC channel established — sentinel handshake OK (generation=${generation}, pid=${proc.pid ?? "?"})`
+          );
           resolve();
         },
         reject: err => {
@@ -503,20 +551,28 @@ class CliConnection {
   }
 
   private checkForSentinel(): void {
-    if (!this.currentQuery) { return; }
+    if (!this.currentQuery) {
+      return;
+    }
 
     const sentinel = this.currentQuery.sentinelId;
     const sentinelIdIndex = this.stdoutBuffer.indexOf(sentinel);
-    if (sentinelIdIndex === -1) { return; }
+    if (sentinelIdIndex === -1) {
+      return;
+    }
 
     const sentinelPrefix = `[{"_s":"`;
     const sentinelSuffix = `"}]`;
 
     const prefixIndex = this.stdoutBuffer.lastIndexOf(sentinelPrefix, sentinelIdIndex);
-    if (prefixIndex === -1) { return; }
+    if (prefixIndex === -1) {
+      return;
+    }
 
     const suffixIndex = this.stdoutBuffer.indexOf(sentinelSuffix, sentinelIdIndex);
-    if (suffixIndex === -1) { return; }
+    if (suffixIndex === -1) {
+      return;
+    }
 
     const sentinelEndIndex = suffixIndex + sentinelSuffix.length;
     const resultText = this.stdoutBuffer.substring(0, prefixIndex).trim();
@@ -561,6 +617,15 @@ class CliConnection {
   }
 
   private async handleError(error: Error): Promise<void> {
+    const stderrPreview = this.stderrBuffer.trim();
+    const stderrSuffix =
+      stderrPreview.length > 0
+        ? ` | stderr: ${stderrPreview.slice(0, 400)}${stderrPreview.length > 400 ? "…" : ""}`
+        : "";
+    this.log.warn(
+      `[SqliteCli:${this.label}] IPC channel fault — ${error.message}${stderrSuffix}; scheduling subprocess rebuild`
+    );
+
     this.needsRestart = true;
     this.stderrBuffer = "";
     this.stdoutBuffer = "";
@@ -580,7 +645,9 @@ class CliConnection {
 
   private parseJsonOutput(text: string): Record<string, unknown>[] {
     const trimmed = text.trim();
-    if (!trimmed) { return []; }
+    if (!trimmed) {
+      return [];
+    }
 
     const results: Record<string, unknown>[] = [];
     let currentArray = "";
@@ -609,7 +676,9 @@ class CliConnection {
             );
             results.push(...objects);
           } catch {
-            this.log.warn(`[SqliteCli:${this.label}] Skipped malformed JSON array chunk: ${currentArray.trim()}`);
+            this.log.warn(
+              `[SqliteCli:${this.label}] Skipped malformed JSON array chunk: ${currentArray.trim()}`
+            );
           }
           inArray = false;
           currentArray = "";
@@ -692,7 +761,9 @@ class CliConnection {
     this.commandTimer = setTimeout(() => {
       const stderrInfo = this.stderrBuffer.trim();
       void this.handleError(
-        new Error(`Command timed out after ${this.commandTimeoutMs}ms${stderrInfo ? `: ${stderrInfo}` : ""}`)
+        new Error(
+          `Command timed out after ${this.commandTimeoutMs}ms${stderrInfo ? `: ${stderrInfo}` : ""}`
+        )
       );
     }, this.commandTimeoutMs);
 
@@ -725,9 +796,15 @@ class CliConnection {
    * exit handler from spawning a duplicate process.
    */
   private async restart(): Promise<void> {
-    if (!this.needsRestart) { return; }
+    if (!this.needsRestart) {
+      return;
+    }
     this.needsRestart = false;
     this.isRestarting = true;
+
+    this.log.warn(
+      `[SqliteCli:${this.label}] Rebuilding IPC channel (replacing subprocess, generation=${this.processGeneration})`
+    );
 
     if (this.process) {
       const oldProc = this.process;
@@ -740,7 +817,11 @@ class CliConnection {
       oldProc.stdout?.removeAllListeners("data");
       oldProc.stderr?.removeAllListeners("data");
 
-      try { oldProc.kill("SIGKILL"); } catch { /* ignore */ }
+      try {
+        oldProc.kill("SIGKILL");
+      } catch {
+        /* ignore */
+      }
     }
 
     this.stdoutBuffer = "";
@@ -749,7 +830,6 @@ class CliConnection {
 
     try {
       await this.spawnProcess();
-      this.log.info(`[SqliteCli:${this.label}] Restarted successfully`);
     } catch (err) {
       this.log.error(`[SqliteCli:${this.label}] Restart failed:`, err);
       this.isStarted = false;
@@ -819,13 +899,12 @@ class WriteQueue {
     this.isProcessing = true;
     const itemsToWrite = this.queue.splice(0);
 
-    void this.flushWithRetry(itemsToWrite)
-      .finally(() => {
-        this.isProcessing = false;
-        if (this.queue.length > 0) {
-          this.flush();
-        }
-      });
+    void this.flushWithRetry(itemsToWrite).finally(() => {
+      this.isProcessing = false;
+      if (this.queue.length > 0) {
+        this.flush();
+      }
+    });
   }
 
   private async flushWithRetry(items: RequestLog[]): Promise<void> {
@@ -848,7 +927,9 @@ class WriteQueue {
   }
 
   private async writeBatch(logs: RequestLog[]): Promise<void> {
-    if (!this.conn) { return; }
+    if (!this.conn) {
+      return;
+    }
     const stmts = logs.map(log => {
       const { sql, params } = buildInsertSql(log);
       return interpolateSql(sql, params);
@@ -857,7 +938,9 @@ class WriteQueue {
   }
 
   private persistFailedWrites(items: RequestLog[]): void {
-    if (!this.failedWritesPath) { return; }
+    if (!this.failedWritesPath) {
+      return;
+    }
     try {
       const lines = items.map(log => JSON.stringify(log)).join("\n") + "\n";
       fsSync.appendFileSync(this.failedWritesPath, lines);
@@ -867,12 +950,18 @@ class WriteQueue {
   }
 
   async replayFailedWrites(): Promise<void> {
-    if (!this.failedWritesPath || !this.conn) { return; }
-    if (!fsSync.existsSync(this.failedWritesPath)) { return; }
+    if (!this.failedWritesPath || !this.conn) {
+      return;
+    }
+    if (!fsSync.existsSync(this.failedWritesPath)) {
+      return;
+    }
 
     const content = fsSync.readFileSync(this.failedWritesPath, "utf-8");
     const lines = content.trim().split("\n").filter(Boolean);
-    if (lines.length === 0) { return; }
+    if (lines.length === 0) {
+      return;
+    }
 
     const logs: RequestLog[] = lines.map(line => JSON.parse(line) as RequestLog);
     try {
@@ -946,7 +1035,9 @@ export class SqliteCliDriver implements DatabaseDriver {
       await this.readConn.start();
       this.readConn.startHealthCheck();
     } catch (err) {
-      this.log.warn(`[SqliteCli] Read connection failed to start, operating in write-only mode: ${err instanceof Error ? err.message : String(err)}`);
+      this.log.warn(
+        `[SqliteCli] Read connection failed to start, operating in write-only mode: ${err instanceof Error ? err.message : String(err)}`
+      );
     }
 
     const failedWritesPath = path.join(path.dirname(dbPath), "failed-writes.jsonl");
@@ -990,7 +1081,9 @@ export class SqliteCliDriver implements DatabaseDriver {
   }
 
   private async createSchema(): Promise<void> {
-    if (!this.writeConn) { return; }
+    if (!this.writeConn) {
+      return;
+    }
 
     await this.writeConn.exec(`
       CREATE TABLE IF NOT EXISTS request_logs (
@@ -1034,10 +1127,19 @@ export class SqliteCliDriver implements DatabaseDriver {
 
       const migrations: Array<{ column: string; sql: string }> = [
         { column: "target_url", sql: "ALTER TABLE request_logs ADD COLUMN target_url TEXT" },
-        { column: "original_request_body", sql: "ALTER TABLE request_logs ADD COLUMN original_request_body TEXT" },
-        { column: "original_response_body", sql: "ALTER TABLE request_logs ADD COLUMN original_response_body TEXT" },
+        {
+          column: "original_request_body",
+          sql: "ALTER TABLE request_logs ADD COLUMN original_request_body TEXT",
+        },
+        {
+          column: "original_response_body",
+          sql: "ALTER TABLE request_logs ADD COLUMN original_response_body TEXT",
+        },
         { column: "client_id", sql: "ALTER TABLE request_logs ADD COLUMN client_id TEXT" },
-        { column: "status", sql: "ALTER TABLE request_logs ADD COLUMN status TEXT DEFAULT 'completed'" },
+        {
+          column: "status",
+          sql: "ALTER TABLE request_logs ADD COLUMN status TEXT DEFAULT 'completed'",
+        },
         { column: "route_type", sql: "ALTER TABLE request_logs ADD COLUMN route_type TEXT" },
       ];
 
@@ -1054,12 +1156,16 @@ export class SqliteCliDriver implements DatabaseDriver {
   // ---- Write operations (writeConn) --------------------------------------
 
   insertLog(log: RequestLog): void {
-    if (!this.isEnabled) { return; }
+    if (!this.isEnabled) {
+      return;
+    }
     this.writeQueue.add(log);
   }
 
   insertLogPending(log: RequestLog): void {
-    if (!this.isEnabled || !this.writeConn?.started) { return; }
+    if (!this.isEnabled || !this.writeConn?.started) {
+      return;
+    }
 
     const { sql, params } = buildInsertSql(log, "pending");
     this.writeConn.exec(sql, params).catch(err => {
@@ -1076,10 +1182,13 @@ export class SqliteCliDriver implements DatabaseDriver {
     errorMessage: string | undefined,
     originalResponseBody?: string
   ): void {
-    if (!this.isEnabled || !this.writeConn?.started) { return; }
+    if (!this.isEnabled || !this.writeConn?.started) {
+      return;
+    }
 
-    this.writeConn.exec(
-      `UPDATE request_logs
+    this.writeConn
+      .exec(
+        `UPDATE request_logs
        SET status_code = ?,
            response_body = ?,
            original_response_body = ?,
@@ -1088,18 +1197,19 @@ export class SqliteCliDriver implements DatabaseDriver {
            error_message = ?,
            status = 'completed'
        WHERE client_id = ?`,
-      [
-        statusCode,
-        encodeForStorage(responseBody),
-        encodeForStorage(originalResponseBody),
-        duration,
-        success ? 1 : 0,
-        encodeForStorage(errorMessage),
-        clientId,
-      ]
-    ).catch(err => {
-      this.log.error("[SqliteCli] Failed to update log:", err);
-    });
+        [
+          statusCode,
+          encodeForStorage(responseBody),
+          encodeForStorage(originalResponseBody),
+          duration,
+          success ? 1 : 0,
+          encodeForStorage(errorMessage),
+          clientId,
+        ]
+      )
+      .catch(err => {
+        this.log.error("[SqliteCli] Failed to update log:", err);
+      });
   }
 
   updateLogStatus(
@@ -1109,31 +1219,30 @@ export class SqliteCliDriver implements DatabaseDriver {
     duration: number,
     errorMessage: string | undefined
   ): void {
-    if (!this.isEnabled || !this.writeConn?.started) { return; }
+    if (!this.isEnabled || !this.writeConn?.started) {
+      return;
+    }
 
-    this.writeConn.exec(
-      `UPDATE request_logs
+    this.writeConn
+      .exec(
+        `UPDATE request_logs
        SET status_code = ?,
            duration = ?,
            success = ?,
            error_message = ?,
            status = ?
        WHERE client_id = ?`,
-      [
-        statusCode,
-        duration,
-        0,
-        encodeForStorage(errorMessage),
-        status,
-        clientId,
-      ]
-    ).catch(err => {
-      this.log.error("[SqliteCli] Failed to update log status:", err);
-    });
+        [statusCode, duration, 0, encodeForStorage(errorMessage), status, clientId]
+      )
+      .catch(err => {
+        this.log.error("[SqliteCli] Failed to update log status:", err);
+      });
   }
 
   async writeBatch(logs: RequestLog[]): Promise<void> {
-    if (!this.writeConn?.started || logs.length === 0) { return; }
+    if (!this.writeConn?.started || logs.length === 0) {
+      return;
+    }
 
     const stmts: string[] = [];
     for (const log of logs) {
@@ -1145,20 +1254,26 @@ export class SqliteCliDriver implements DatabaseDriver {
   }
 
   async deleteLogs(ids: number[]): Promise<void> {
-    if (!this.writeConn?.started || ids.length === 0) { return; }
+    if (!this.writeConn?.started || ids.length === 0) {
+      return;
+    }
 
     const placeholders = ids.map(() => "?").join(",");
     await this.writeConn.exec(`DELETE FROM request_logs WHERE id IN (${placeholders})`, ids);
   }
 
   async clearAllLogs(): Promise<void> {
-    if (!this.writeConn?.started) { return; }
+    if (!this.writeConn?.started) {
+      return;
+    }
     await this.writeConn.exec("DELETE FROM request_logs");
     await this.writeConn.exec("VACUUM");
   }
 
   async cleanOldLogs(): Promise<void> {
-    if (!this.isEnabled || !this.writeConn?.started) { return; }
+    if (!this.isEnabled || !this.writeConn?.started) {
+      return;
+    }
 
     const cutoff = Date.now() - MAX_LOG_AGE_DAYS * 24 * 60 * 60 * 1000;
     await this.writeConn.exec("DELETE FROM request_logs WHERE timestamp < ?", [cutoff]);
@@ -1223,10 +1338,11 @@ export class SqliteCliDriver implements DatabaseDriver {
 
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
-    const total = (await this.readConn.queryScalar<number>(
-      `SELECT COUNT(*) as count FROM request_logs ${whereClause}`,
-      params
-    )) ?? 0;
+    const total =
+      (await this.readConn.queryScalar<number>(
+        `SELECT COUNT(*) as count FROM request_logs ${whereClause}`,
+        params
+      )) ?? 0;
 
     const limit = filter.limit || 100;
     const offset = filter.offset || 0;
@@ -1245,11 +1361,15 @@ export class SqliteCliDriver implements DatabaseDriver {
   }
 
   async getLogById(id: number): Promise<RequestLog | null> {
-    if (!this.readConn?.started) { return null; }
+    if (!this.readConn?.started) {
+      return null;
+    }
 
     const rows = await this.readConn.query("SELECT * FROM request_logs WHERE id = ?", [id]);
 
-    if (rows.length === 0) { return null; }
+    if (rows.length === 0) {
+      return null;
+    }
 
     return dbRowToLog(rows[0]);
   }


### PR DESCRIPTION
## Summary

This PR merges `feat/dev` into `main` with SQLite CLI IPC stabilization and related packaging changes, plus log level adjustments for IPC lifecycle events.

## Commits

- **fix(db, packaging): stabilize SQLite CLI IPC and whitelist VSIX** — Improves SQLite CLI IPC reliability and packaging allowlist for VSIX.
- **chore(sqlite-cli): IPC lifecycle logs use INFO/WARN/ERROR** — Aligns IPC lifecycle logging with standard severity levels.

## Checklist

- [ ] `npm run format` / `npm run lint` pass on this branch (per project guidelines).


Made with [Cursor](https://cursor.com)