### PR TITLE
fix(desktop): mac CI zip-only; Gatekeeper docs and notarization TODO

### DIFF
--- a/.github/workflows/build-dev-auto.yml
+++ b/.github/workflows/build-dev-auto.yml
@@ -140,7 +140,6 @@ jobs:
         with:
           name: ccrelay-desktop-${{ matrix.platform }}-${{ matrix.arch }}-${{ needs.build-vscode.outputs.version }}${{ needs.build-vscode.outputs.suffix }}
           path: |
-            packages/desktop/dist/*.dmg
             packages/desktop/dist/*.zip
             packages/desktop/dist/*.exe
           retention-days: 30

--- a/.github/workflows/build-dev-manual.yml
+++ b/.github/workflows/build-dev-manual.yml
@@ -149,7 +149,6 @@ jobs:
         with:
           name: ccrelay-desktop-${{ matrix.platform }}-${{ matrix.arch }}-${{ needs.build-vscode.outputs.version }}${{ needs.build-vscode.outputs.suffix }}
           path: |
-            packages/desktop/dist/*.dmg
             packages/desktop/dist/*.zip
             packages/desktop/dist/*.exe
           retention-days: 30

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -123,7 +123,6 @@ jobs:
         with:
           name: ccrelay-desktop-${{ matrix.platform }}-${{ matrix.arch }}-${{ needs.build-vscode.outputs.version }}
           path: |
-            packages/desktop/dist/*.dmg
             packages/desktop/dist/*.zip
             packages/desktop/dist/*.exe
           retention-days: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Desktop tray app (Electron)**: packaged `CCRelay` app with system tray, shared `~/.ccrelay` config and leader election with the VS Code extension. **Open Dashboard** loads the `/ccrelay/` web UI inside an Electron `BrowserWindow` over HTTP; duplicate launches focus that window.
-- **CI desktop installers**: GitHub Actions `build-dev-auto`, `build-dev-manual`, and `build-prod` workflows build desktop artifacts after the VSIX — matrix **macOS** (`x64` + `arm64`, dmg + zip) and **Windows** (`x64` + `arm64`, NSIS `.exe`). `build-dev-auto` and `build-prod` aggregate assets into a prerelease/release; `build-dev-manual` uploads workflow artifacts only.
+- **CI desktop installers**: GitHub Actions `build-dev-auto`, `build-dev-manual`, and `build-prod` workflows build desktop artifacts after the VSIX — matrix **macOS** (`x64` + `arm64`, **zip only**; DMG removed because unsigned electron-builder DMGs on CI produced invalid zlib blobs, not openable UDIF disks) and **Windows** (`x64` + `arm64`, NSIS `.exe`). `build-dev-auto` and `build-prod` aggregate assets into a prerelease/release; `build-dev-manual` uploads workflow artifacts only.
 - **`providerType` split**: `providerType` now has three values — `"anthropic"` (unchanged), `"openai"` (full passthrough — both Chat Completions and Responses API are forwarded without conversion), `"openai_chat"` (Chat Completions only — Responses API requests are converted to Chat Completions before forwarding). Existing `"openai"` configs are treated as full passthrough; update to `"openai_chat"` to preserve the previous Responses→Chat conversion behavior.
 - **Synthetic SSE for `POST /v1/chat/completions` with `stream: true` (cross-protocol)**: when upstream returns non-streaming but the client requested streaming, ccrelay emits `text/event-stream` with `chat.completion.chunk` deltas (text, thinking, tool calls) and `[DONE]`. Previously this path only existed for `POST /v1/responses`.
 - **Cross-protocol `GET /v1/models` conversion**: when the client's API surface (OpenAI vs Anthropic) differs from the upstream provider type, the response is automatically converted to the client's expected format.
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Desktop packaging**: Electron `build.mac` / `build.win` targets declare **`x64` and `arm64`** explicitly for dmg/zip (macOS) and NSIS (Windows). Packaged desktop **app icons** are generated from `packages/vscode/assets/icon.svg`.
+- **Desktop packaging**: Electron `build.mac` (`identity: null`, **zip** targets only) / `build.win` declare **`x64` and `arm64`** explicitly. Packaged desktop **app icons** are generated from `packages/vscode/assets/icon.svg`.
 - **Windows / Linux Electron window**: removes the default in-window menu bar (**File / Edit / View / Window**) via `Menu.setApplicationMenu(null)`; macOS continues to use the system menu bar only.
 - **Converter simplification**: `convertRequestToOpenAI`, `convertOpenAIRequestToAnthropic`, and `convertResponsesRequestToChatCompletions` no longer accept a `provider` parameter for custom path resolution — paths are now deterministic (`/chat/completions` for OpenAI, `/v1/messages` for Anthropic).
 - **Cross-protocol conversion guard**: `needsConversion` and upstream wire detection now correctly distinguish all three provider types (`"anthropic"`, `"openai"`, `"openai_chat"`) instead of treating anything non-Anthropic as full OpenAI passthrough.
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Desktop macOS packaging (unsigned CI)**: `electron-builder` DMG output on GitHub Actions produced **invalid disk images** (`hdiutil`: "image not recognized"; `file` reported raw zlib). macOS artifacts are now **ZIP only** with `mac.identity: null` so releases ship openable `CCRelay.app` archives.
 - **SQLite log storage without `sqlite3` CLI**: when `logging.enabled` uses SQLite but the **`sqlite3` executable is not installed or not on `PATH`**, the proxy starts **without** persisted request logs (warning logged); config is unchanged until you install SQLite or switch the logging driver.
 - **Desktop packaged builds**: trays ship platform-appropriate PNGs via `extraResources`; **`database-worker.cjs`** is listed in **`asarUnpack`** so Worker threads load correctly; **`sqlite3` discovery** tries common paths (e.g. `/usr/bin/sqlite3`, Homebrew on macOS, `PATH`/`where` on Windows) when the environment trims `PATH`.
 - **SQLite log database (CLI driver)**: eliminated the race between manual `restart()` and the subprocess `exit` handler spawning overlapping sqlite3 processes (which broke sentinel framing on the stdin/stdout pipe); stale I/O is ignored via a process generation counter and listeners are stripped before kill. Stdin writes respect pipe backpressure; list queries use explicit columns plus a short `request_body` preview to shrink IPC traffic; pragma cache/mmap limits tightened for extension RAM.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 - [Commands](#commands)
 - [Development](#development)
 - [File Locations](#file-locations)
+- [TODO](#todo)
 - [License](#license)
 
 ---
@@ -112,8 +113,24 @@ The monorepo includes **`packages/desktop`**, an optional Electron **tray** app 
 - **`~/.ccrelay/config.yaml`**, **`~/.ccrelay/state.json`**, Leader/Follower election, WebSocket sync, provider switching, HTTP API, and **`/ccrelay/`** web UI behave the same across extension and desktop.
 - **Tray** → **Open Dashboard** loads the dashboard inside an Electron **`BrowserWindow`** via **HTTP** to the proxy (not `file:`). Duplicate app launches bring the existing dashboard window forward.
 - **Windows / Linux**: the default Electron **File / Edit / View / Window** menu bar inside the dashboard window is **hidden** (`Menu.setApplicationMenu(null)`). **macOS** uses the usual **system** menu bar.
-- Packaged installers are produced under **`packages/desktop/dist/`** (dmg + zip on macOS, NSIS `.exe` on Windows). Locally: `npm run desktop:pack:mac` or `desktop:pack:win` **on the host OS**.
+- Packaged installers are produced under **`packages/desktop/dist/`** (**macOS:** zip archives containing `CCRelay.app` — no DMG by default because unsigned CI DMGs from electron-builder were not valid UDIF images; **Windows:** NSIS `.exe`). Locally: `npm run desktop:pack:mac` or `desktop:pack:win` **on the host OS**.
 - **`electron-builder` targets** declare both **`x64`** and **`arm64`** (Intel vs Apple‑silicon Mac; x64 vs ARM64 Windows). **GitHub Actions** (**Build Dev** auto & manual, **Build Prod**) run **VSIX packaging first**, then a **four‑job matrix** (mac/win × two arches) uploads desktop binaries alongside the VSIX release assets (`Build Dev (Manual)` attaches artifacts only; Dev auto & Prod also publish a unified release).
+
+### macOS: first launch from a GitHub release (zip)
+
+Release builds are **not** Apple-notarized. After you unzip, the browser may mark the download with **quarantine**; Gatekeeper can show *“Apple could not verify … is free of malware”*.
+
+1. Remove quarantine from the app bundle (adjust the path if you moved or renamed it):
+
+   ```bash
+   xattr -cr ~/Downloads/CCRelay.app
+   ```
+
+   If the `.app` is inside a folder (e.g. after unzipping), point at that path instead, e.g. `xattr -cr ~/Downloads/CCRelay-darwin-arm64/CCRelay.app`.
+
+2. Alternatively, **Control‑click (right‑click)** `CCRelay.app` → **Open** the first time, or approve the app under **System Settings → Privacy & Security**.
+
+Apps you build locally under `packages/desktop/dist/` usually have no quarantine, so they may open without these steps—see [TODO](#todo) for the long-term fix (signing + notarization).
 
 SQLite-backed **logging** still requires the **`sqlite3`** command-line binary on **`PATH`** (plus known fallbacks) when persistence is desired; otherwise the server runs with logging storage effectively off for that process—see core features above.
 
@@ -697,6 +714,12 @@ ccrelay/
 | YAML Config | `~/.ccrelay/config.yaml` | Main configuration file (auto-created) |
 | Runtime state | `~/.ccrelay/state.json` | Persisted active provider id (shared by extension + desktop) |
 | Log database | `~/.ccrelay/logs.db` | Request/response logs (when enabled) |
+
+---
+
+## TODO
+
+- **Desktop (macOS) distribution**: Ship **Apple Developer ID** signing and **notarization** via `electron-builder` in CI (GitHub Secrets: certificate export as `CSC_LINK` / `CSC_KEY_PASSWORD`, and Apple notary API credentials — e.g. `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`). That removes Gatekeeper/quarantine prompts for downloaded builds. Optionally re-enable **DMG** once signing works (CI DMGs were invalid without a proper signing pipeline).
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -33,6 +33,7 @@
 - [命令](#命令)
 - [开发](#开发)
 - [文件位置](#文件位置)
+- [TODO](#todo)
 - [许可证](#许可证)
 
 ---
@@ -112,8 +113,25 @@ npm run compile
 - **`~/.ccrelay/config.yaml`**、**`~/.ccrelay/state.json`**、Leader/Follower 选举、WebSocket 同步、Provider 切换、HTTP API、`/ccrelay/` Web UI 等与扩展保持一致。
 - 托盘菜单 **打开控制台**：在 Electron **`BrowserWindow`** 内通过 **HTTP** 访问本地代理加载仪表盘（不用 `file://`）；再次启动应用会聚焦已有窗口。
 - **Windows / Linux**：隐藏 Electron 内置的窗口内菜单栏（**文件 / 编辑 / 视图 / 窗口**）；**macOS** 继续使用系统顶层菜单。
-- 安装包输出在 **`packages/desktop/dist/`**（macOS：dmg + zip；Windows：NSIS `.exe`）。本地需在目标系统上执行 `npm run desktop:pack:mac` 或 `desktop:pack:win`。
+- 安装包输出在 **`packages/desktop/dist/`**（**macOS：** 含 `CCRelay.app` 的 **zip**，默认不再打 DMG——无签名场景下 CI 产出的 DMG 不是合法 UDIF；**Windows：** NSIS `.exe`）。本地需在目标系统上执行 `npm run desktop:pack:mac` 或 `desktop:pack:win`。
 - **`electron-builder` 产物**面向 **`x64` 与 `arm64`**（Intel / Apple Silicon Mac；x64 / ARM64 Windows）。**GitHub Actions**（**Build Dev** 自动与 Manual、**Build Prod**）在打完 **VSIX** 之后，再通过 **四条并行任务矩阵**（mac/win × 两架构）上传桌面安装包；其中 **Build Dev (Manual)** 仅上传 artifact（不自动发 GitHub Release），**Build Dev (Auto)** 与 **Build Prod** 会发布包含 VSIX + 桌面包的 Release。
+
+### macOS：从 GitHub Release zip 首次打开
+
+正式发布包当前 **未经 Apple 公证**。浏览器下载_zip 解压后，`CCRelay.app` 可能带有 **隔离（quarantine）** 标记，Gatekeeper 会提示 *「Apple 无法验证 …」*。
+
+1. 去掉扩展属性后再双击（路径按实际解压位置修改）：
+
+   ```bash
+   xattr -cr ~/Downloads/CCRelay.app
+   ```
+
+   若 `.app` 在解压后的子目录内，改用该路径，例如：`xattr -cr ~/Downloads/CCRelay-darwin-arm64/CCRelay.app`。
+
+2. 或 **按住 Control 点击** → **打开** 并在弹窗中选择打开；或在 **系统设置 → 隐私与安全性** 中允许。
+
+本机 `packages/desktop/dist/` 下直接构建的产物通常没有隔离属性，故往往无需上述步骤。根本方案见 [TODO](#todo)（签名 + 公证）。
+
 - SQLite **日志持久化**仍需在 **`PATH`** 中能找到 **`sqlite3`**（并含常见路径回退）；无法满足时本轮进程不写库但仍可启动——见上文「请求日志」说明。
 
 ---
@@ -693,6 +711,12 @@ ccrelay/
 | YAML 配置 | `~/.ccrelay/config.yaml` | 主配置文件（自动创建） |
 | 运行时状态 | `~/.ccrelay/state.json` | 当前启用的提供商 id（扩展与桌面端共用） |
 | 日志数据库 | `~/.ccrelay/logs.db` | 请求/响应日志（启用后） |
+
+---
+
+## TODO
+
+- **桌面 macOS 分发**：在 CI 中通过 `electron-builder` 配置 **Apple Developer ID 签名 + 公证（notarization）**（GitHub Secrets：证书导出为 `CSC_LINK` / `CSC_KEY_PASSWORD`，以及 Apple 公证凭据，如 `APPLE_ID`、`APPLE_APP_SPECIFIC_PASSWORD`、`APPLE_TEAM_ID`），使从网页下载的版本不再被 Gatekeeper/quarantine 阻拦。签名流程稳定后可选 **恢复 DMG**（此前无签名时 CI 产物为非法 UDIF）。
 
 ---
 

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -55,11 +55,8 @@
     ],
     "mac": {
       "category": "public.app-category.developer-tools",
+      "identity": null,
       "target": [
-        {
-          "target": "dmg",
-          "arch": ["x64", "arm64"]
-        },
         {
           "target": "zip",
           "arch": ["x64", "arm64"]


### PR DESCRIPTION
## Summary

Follow-up after invalid unsigned DMGs from CI (`hdiutil` could not recognize the image).

## Changes

- **mac packaging**: electron-builder emits **ZIP only** for mac (`mac.identity: null`); drop DMG target so releases ship a valid `.app` archive.
- **CI**: workflow artifact uploads no longer glob `*.dmg`.
- **Docs**: CHANGELOG note; README / README_CN — **macOS first launch** from a downloaded zip (`xattr -cr …`, Control‑click Open), plus a **TODO** for Developer ID signing + notarization and optional DMG restore.

## Test plan

- [ ] CI desktop matrix still produces mac `*.zip` + win `*.exe`
- [ ] Local `xattr -lr` fresh download path documented accurately

Made with [Cursor](https://cursor.com)