### PR TITLE
fix(core): disable upstream socket idle timeout in proxy executor

### DIFF
--- a/packages/core/src/server/proxy/executor.ts
+++ b/packages/core/src/server/proxy/executor.ts
@@ -216,8 +216,9 @@ export class ProxyExecutor {
         reject
       );
 
-      // No request timeout - rely on client disconnect detection
-      // Long-running LLM requests can take arbitrary time
+      // Explicitly disable upstream socket idle-timeout. Some runtimes (e.g. Electron)
+      // inherit a ~5s default; LLM upstream TTFB can exceed that. Rely on client disconnect + abortSignal.
+      proxyReq.setTimeout(0);
 
       if (body) {
         proxyReq.write(body);


### PR DESCRIPTION
## Summary

Desktop (Electron) builds were returning **503** from CCRelay while the VS Code extension behaved normally, with logs showing `Proxy timeout` after roughly five seconds despite the same provider and config.

## Cause

Some runtimes attach a short **socket idle timeout** to outbound `https.request` sockets. Electron is one case: upstream time-to-first-byte for large or slow LLM calls can exceed that window, which fires `proxyReq`'\''s `timeout` listener and surfaces as `Proxy timeout` → **503**.

## Change

Call `proxyReq.setTimeout(0)` after wiring error handlers so upstream requests do not use an implicit idle timeout; cancellation still follows client disconnect and `AbortSignal` as documented in the executor.

## Verification

- `npm run lint` / unit tests (pre-commit hook)
- Manual: long TTFB scenarios on desktop should no longer hit spurious 503s.

Made with [Cursor](https://cursor.com)