### PR TITLE
fix(web,vscode): favicon, dashboard default tab, VS Code static path

### DIFF
--- a/packages/core/src/server/static.ts
+++ b/packages/core/src/server/static.ts
@@ -63,7 +63,8 @@ export function isStaticRequest(reqPath: string): boolean {
     reqPath === "/ccrelay" ||
     reqPath === "/ccrelay/" ||
     reqPath.startsWith("/ccrelay/assets") ||
-    reqPath.startsWith("/ccrelay/index.html")
+    reqPath.startsWith("/ccrelay/index.html") ||
+    reqPath === "/ccrelay/favicon.svg"
   );
 }
 

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import * as path from "path";
 import {
   Api,
   BUILD_HASH,
@@ -8,6 +9,7 @@ import {
   LeaderElection,
   Logger,
   ProxyServer,
+  setWebDistPath,
 } from "@ccrelay/core";
 import { StatusBarManager } from "./vscode/statusBar";
 import { LogViewerPanel } from "./vscode/logViewer";
@@ -33,6 +35,11 @@ export function activate(context: vscode.ExtensionContext) {
   logger.info(
     `[Extension:${instanceId}] Build version=${BUILD_VERSION} buildHash=${BUILD_HASH} gitHash=${GIT_HASH}`
   );
+
+  // Serve /ccrelay/* SPA from packaged web assets (matches webview Dashboard / LogViewer roots)
+  const webDistDir = path.join(context.extensionUri.fsPath, "out", "web");
+  setWebDistPath(webDistDir);
+  logger.info(`[Extension:${instanceId}] Web UI HTTP static root: ${webDistDir}`);
 
   // Initialize configuration manager (auto-creates config file if not exists)
   const configStart = Date.now();

--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CCRelay Management</title>
   </head>

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="purpleGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9B59B6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#8E44AD;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="grayGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#95A5A6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#7F8C8D;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+
+  <!-- Background circle -->
+  <circle cx="64" cy="64" r="56" fill="#2C3E50" opacity="0.1"/>
+
+  <!-- Main relay symbol - two arrows forming a cycle -->
+  <!-- Left arrow (curved upward) -->
+  <path d="M 32 75 Q 32 45 50 45 L 64 45"
+        stroke="url(#purpleGradient)"
+        stroke-width="10"
+        stroke-linecap="round"
+        fill="none"/>
+
+  <!-- Arrow head left -->
+  <path d="M 52 35 L 66 45 L 52 55"
+        fill="url(#purpleGradient)"
+        stroke="url(#purpleGradient)"
+        stroke-width="3"
+        stroke-linejoin="round"/>
+
+  <!-- Right arrow (curved downward) -->
+  <path d="M 96 53 Q 96 83 78 83 L 64 83"
+        stroke="url(#grayGradient)"
+        stroke-width="10"
+        stroke-linecap="round"
+        fill="none"/>
+
+  <!-- Arrow head right -->
+  <path d="M 76 93 L 62 83 L 76 73"
+        fill="url(#grayGradient)"
+        stroke="url(#grayGradient)"
+        stroke-width="3"
+        stroke-linejoin="round"/>
+
+  <!-- Center dot representing the relay/switch point -->
+  <circle cx="64" cy="64" r="8" fill="url(#purpleGradient)"/>
+  <circle cx="64" cy="64" r="4" fill="#FFFFFF"/>
+
+  <!-- Small connection lines to endpoints -->
+  <line x1="22" y1="64" x2="32" y2="64" stroke="#7F8C8D" stroke-width="4" stroke-linecap="round"/>
+  <line x1="96" y1="64" x2="106" y2="64" stroke="#7F8C8D" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- Small endpoint dots -->
+  <circle cx="18" cy="64" r="4" fill="#95A5A6"/>
+  <circle cx="110" cy="64" r="4" fill="#95A5A6"/>
+</svg>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,7 +43,7 @@ function useHashTab(defaultTab: Tab): [Tab, (tab: Tab) => void] {
 }
 
 function App() {
-  const [activeTab, setActiveTab] = useHashTab("providers");
+  const [activeTab, setActiveTab] = useHashTab("dashboard");
   const [version, setVersion] = useState<string | null>(null);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- **Web:** Add `favicon.svg`, serve under `/ccrelay/`; default to Dashboard on first load.
- **VS Code extension:** Configure web dist path so static dashboard assets resolve correctly.

## Commits
- `07bdf45` fix(web): add favicon.svg and serve it under `/ccrelay/` path
- `fe618ae` feat(vscode): set web dist path for static file serving in extension
- `d6cafd4` fix(web): default to dashboard tab on initial load


Made with [Cursor](https://cursor.com)