### PR TITLE
fix(desktop): align electron-builder arch with CI and cache Electron

### DIFF
--- a/.github/workflows/build-dev-auto.yml
+++ b/.github/workflows/build-dev-auto.yml
@@ -206,9 +206,17 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.configure.outputs.desktop_matrix) }}
     runs-on: ${{ matrix.os }}
+    env:
+      ELECTRON_CACHE: ${{ github.workspace }}/.electron-cache
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Cache Electron downloads
+        uses: actions/cache@v4
+        with:
+          path: .electron-cache
+          key: electron-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('package-lock.json', 'packages/desktop/package.json') }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/build-dev-manual.yml
+++ b/.github/workflows/build-dev-manual.yml
@@ -206,9 +206,17 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.configure.outputs.desktop_matrix) }}
     runs-on: ${{ matrix.os }}
+    env:
+      ELECTRON_CACHE: ${{ github.workspace }}/.electron-cache
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Cache Electron downloads
+        uses: actions/cache@v4
+        with:
+          path: .electron-cache
+          key: electron-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('package-lock.json', 'packages/desktop/package.json') }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -189,9 +189,17 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.configure.outputs.desktop_matrix) }}
     runs-on: ${{ matrix.os }}
+    env:
+      ELECTRON_CACHE: ${{ github.workspace }}/.electron-cache
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Cache Electron downloads
+        uses: actions/cache@v4
+        with:
+          path: .electron-cache
+          key: electron-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('package-lock.json', 'packages/desktop/package.json') }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ packages/vscode/out
 packages/vscode/node_modules
 packages/desktop/out
 packages/desktop/dist
+.electron-cache
 packages/desktop/web
 .vscode-test
 *.vsix

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -11,7 +11,9 @@
     "start": "electron .",
     "pack": "electron-builder",
     "pack:mac": "electron-builder --mac",
-    "pack:win": "electron-builder --win"
+    "pack:mac:all": "electron-builder --mac --x64 --arm64",
+    "pack:win": "electron-builder --win",
+    "pack:win:all": "electron-builder --win --x64 --arm64"
   },
   "dependencies": {
     "@ccrelay/core": "*"
@@ -58,24 +60,12 @@
       "category": "public.app-category.developer-tools",
       "identity": null,
       "target": [
-        {
-          "target": "zip",
-          "arch": [
-            "x64",
-            "arm64"
-          ]
-        }
+        "zip"
       ]
     },
     "win": {
       "target": [
-        {
-          "target": "nsis",
-          "arch": [
-            "x64",
-            "arm64"
-          ]
-        }
+        "nsis"
       ]
     },
     "nsis": {


### PR DESCRIPTION
## Summary

- Remove hardcoded `x64`/`arm64` from `mac` and `win` targets in `packages/desktop/package.json` so CI matrix flags (`--x64` / `--arm64`) control each job and avoid building both architectures in a single step.
- Add `pack:mac:all` and `pack:win:all` scripts for local builds that still need both architectures.
- Set `ELECTRON_CACHE` to the workspace and add `actions/cache` in desktop workflow jobs to reuse Electron downloads across runs.
- Ignore `.electron-cache` in git.

Made with [Cursor](https://cursor.com)