### PR TITLE
ci: reusable workflows, Tauri release builds, streamlined PR checks

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -1,0 +1,387 @@
+name: Build (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      build_targets:
+        type: string
+        default: 'all'
+      suffix:
+        type: string
+        default: ''
+      is_prod:
+        type: boolean
+        default: false
+      skip_tests:
+        type: boolean
+        default: false
+      create_release:
+        type: boolean
+        default: false
+      prerelease:
+        type: boolean
+        default: true
+      tag_name:
+        type: string
+        default: ''
+      release_name:
+        type: string
+        default: ''
+      retention_days:
+        type: number
+        default: 30
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: ${{ !inputs.skip_tests }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            web/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run tests (unit + integration)
+        run: npm run test:all
+
+  configure:
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ always() && (needs.test.result == 'success' || needs.test.result == 'skipped') }}
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      want_build_vscode: ${{ steps.targets.outputs.want_build_vscode }}
+      want_build_desktop: ${{ steps.targets.outputs.want_build_desktop }}
+      want_build_tauri: ${{ steps.targets.outputs.want_build_tauri }}
+      desktop_matrix: ${{ steps.targets.outputs.desktop_matrix }}
+      tauri_matrix: ${{ steps.targets.outputs.tauri_matrix }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: meta
+        run: |
+          VERSION=$(node -p "require('./packages/vscode/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve build targets & desktop matrix JSON
+        id: targets
+        env:
+          TARGET: ${{ inputs.build_targets || 'all' }}
+        run: |
+          MATRIX='[{"os":"macos-latest","platform":"mac","arch":"x64"},{"os":"macos-latest","platform":"mac","arch":"arm64"},{"os":"windows-latest","platform":"win","arch":"x64"},{"os":"windows-latest","platform":"win","arch":"arm64"}]'
+          MATRIX_MAC='[{"os":"macos-latest","platform":"mac","arch":"x64"},{"os":"macos-latest","platform":"mac","arch":"arm64"}]'
+          MATRIX_WIN='[{"os":"windows-latest","platform":"win","arch":"x64"},{"os":"windows-latest","platform":"win","arch":"arm64"}]'
+          MATRIX_MAC_X64='[{"os":"macos-latest","platform":"mac","arch":"x64"}]'
+          MATRIX_MAC_ARM64='[{"os":"macos-latest","platform":"mac","arch":"arm64"}]'
+          MATRIX_WIN_X64='[{"os":"windows-latest","platform":"win","arch":"x64"}]'
+          MATRIX_WIN_ARM64='[{"os":"windows-latest","platform":"win","arch":"arm64"}]'
+
+          TAURI_MATRIX='[{"os":"macos-latest","platform":"mac","arch":"arm64","rust_target":"aarch64-apple-darwin"},{"os":"macos-13","platform":"mac","arch":"x64","rust_target":"x86_64-apple-darwin"},{"os":"windows-latest","platform":"win","arch":"x64","rust_target":"x86_64-pc-windows-msvc"}]'
+          TAURI_MAC='[{"os":"macos-latest","platform":"mac","arch":"arm64","rust_target":"aarch64-apple-darwin"},{"os":"macos-13","platform":"mac","arch":"x64","rust_target":"x86_64-apple-darwin"}]'
+          TAURI_WIN='[{"os":"windows-latest","platform":"win","arch":"x64","rust_target":"x86_64-pc-windows-msvc"}]'
+          TAURI_MAC_X64='[{"os":"macos-13","platform":"mac","arch":"x64","rust_target":"x86_64-apple-darwin"}]'
+          TAURI_MAC_ARM64='[{"os":"macos-latest","platform":"mac","arch":"arm64","rust_target":"aarch64-apple-darwin"}]'
+          TAURI_WIN_X64='[{"os":"windows-latest","platform":"win","arch":"x64","rust_target":"x86_64-pc-windows-msvc"}]'
+
+          WANT_V=false
+          WANT_D=false
+          WANT_T=false
+          TAURI_TARGETS='[]'
+
+          case "$TARGET" in
+            all)
+              WANT_V=true
+              WANT_D=true
+              WANT_T=true
+              DESKTOP_MATRIX="$MATRIX"
+              TAURI_TARGETS="$TAURI_MATRIX"
+              ;;
+            vscode)
+              WANT_V=true
+              DESKTOP_MATRIX='[]'
+              ;;
+            desktop)
+              WANT_D=true
+              DESKTOP_MATRIX="$MATRIX"
+              ;;
+            desktop-mac)
+              WANT_D=true
+              DESKTOP_MATRIX="$MATRIX_MAC"
+              ;;
+            desktop-win)
+              WANT_D=true
+              DESKTOP_MATRIX="$MATRIX_WIN"
+              ;;
+            desktop-mac-x64)
+              WANT_D=true
+              DESKTOP_MATRIX="$MATRIX_MAC_X64"
+              ;;
+            desktop-mac-arm64)
+              WANT_D=true
+              DESKTOP_MATRIX="$MATRIX_MAC_ARM64"
+              ;;
+            desktop-win-x64)
+              WANT_D=true
+              DESKTOP_MATRIX="$MATRIX_WIN_X64"
+              ;;
+            desktop-win-arm64)
+              WANT_D=true
+              DESKTOP_MATRIX="$MATRIX_WIN_ARM64"
+              ;;
+            tauri)
+              WANT_T=true
+              DESKTOP_MATRIX='[]'
+              TAURI_TARGETS="$TAURI_MATRIX"
+              ;;
+            tauri-mac)
+              WANT_T=true
+              DESKTOP_MATRIX='[]'
+              TAURI_TARGETS="$TAURI_MAC"
+              ;;
+            tauri-win)
+              WANT_T=true
+              DESKTOP_MATRIX='[]'
+              TAURI_TARGETS="$TAURI_WIN"
+              ;;
+            tauri-mac-x64)
+              WANT_T=true
+              DESKTOP_MATRIX='[]'
+              TAURI_TARGETS="$TAURI_MAC_X64"
+              ;;
+            tauri-mac-arm64)
+              WANT_T=true
+              DESKTOP_MATRIX='[]'
+              TAURI_TARGETS="$TAURI_MAC_ARM64"
+              ;;
+            tauri-win-x64)
+              WANT_T=true
+              DESKTOP_MATRIX='[]'
+              TAURI_TARGETS="$TAURI_WIN_X64"
+              ;;
+            *)
+              echo "Unknown build_targets=$TARGET" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "want_build_vscode=$WANT_V" >> "$GITHUB_OUTPUT"
+          echo "want_build_desktop=$WANT_D" >> "$GITHUB_OUTPUT"
+          echo "want_build_tauri=$WANT_T" >> "$GITHUB_OUTPUT"
+          {
+            echo "desktop_matrix<<__MATRIX_EOF__"
+            echo "$DESKTOP_MATRIX"
+            echo "__MATRIX_EOF__"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "tauri_matrix<<__TAURI_MATRIX_EOF__"
+            echo "$TAURI_TARGETS"
+            echo "__TAURI_MATRIX_EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+  build-vscode:
+    runs-on: ubuntu-latest
+    needs: configure
+    if: ${{ needs.configure.outputs.want_build_vscode == 'true' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            web/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build package
+        run: npm run ${{ inputs.is_prod && 'package:prod' || 'package:dev' }}
+
+      - name: Rename vsix file
+        if: ${{ inputs.suffix != '' }}
+        run: |
+          SUFFIX="${{ inputs.suffix }}"
+          cd dists
+          for file in *.vsix; do
+            BASENAME="${file%.vsix}"
+            mv "$file" "${BASENAME}${SUFFIX}.vsix"
+          done
+          ls -la
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ccrelay-vscode-${{ inputs.is_prod && 'prod' || 'dev' }}-${{ needs.configure.outputs.version }}${{ inputs.suffix }}
+          path: dists/*.vsix
+          retention-days: ${{ inputs.retention_days }}
+
+  build-desktop:
+    needs: configure
+    if: ${{ needs.configure.outputs.want_build_desktop == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.configure.outputs.desktop_matrix) }}
+    runs-on: ${{ matrix.os }}
+    env:
+      ELECTRON_CACHE: ${{ github.workspace }}/.electron-cache
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache Electron downloads
+        uses: actions/cache@v4
+        with:
+          path: .electron-cache
+          key: electron-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('package-lock.json', 'packages/desktop/package.json') }}
+          restore-keys: |
+            electron-${{ runner.os }}-${{ matrix.arch }}-
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            web/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build desktop
+        run: npm run desktop:build
+
+      - name: Pack desktop (${{ matrix.platform }} ${{ matrix.arch }})
+        run: npx electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish never
+        working-directory: packages/desktop
+
+      - name: Upload desktop artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ccrelay-desktop-${{ matrix.platform }}-${{ matrix.arch }}-${{ needs.configure.outputs.version }}${{ inputs.suffix }}
+          path: |
+            packages/desktop/dist/*.zip
+            packages/desktop/dist/*.exe
+          retention-days: ${{ inputs.retention_days }}
+
+  build-tauri:
+    needs: configure
+    if: ${{ needs.configure.outputs.want_build_tauri == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.configure.outputs.tauri_matrix) }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            packages/desktop-tauri/src-tauri/target
+          key: cargo-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('packages/desktop-tauri/src-tauri/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ matrix.arch }}-
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            web/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Tauri (frontend, SEA sidecar, Rust host prep)
+        run: npm run tauri:build
+        env:
+          CCRELAY_SEA: '1'
+
+      - name: Pack Tauri (${{ matrix.platform }} ${{ matrix.arch }})
+        run: npx tauri build --target ${{ matrix.rust_target }}
+        working-directory: packages/desktop-tauri
+
+      - name: Stage Tauri bundle files
+        shell: bash
+        run: |
+          mkdir -p tauri-dist
+          BUNDLE="packages/desktop-tauri/src-tauri/target/${{ matrix.rust_target }}/release/bundle"
+          if [ -d "$BUNDLE" ]; then
+            find "$BUNDLE" -type f \( -name '*.dmg' -o -name '*.app.tar.gz' -o -name '*.msi' -o -name '*.exe' \) -exec cp {} tauri-dist/ \;
+          fi
+          ls -la tauri-dist/
+
+      - name: Upload Tauri artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ccrelay-tauri-${{ matrix.platform }}-${{ matrix.arch }}-${{ needs.configure.outputs.version }}${{ inputs.suffix }}
+          path: tauri-dist/*
+          if-no-files-found: error
+          retention-days: ${{ inputs.retention_days }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [configure, build-vscode, build-desktop, build-tauri]
+    if: >-
+      ${{ always()
+        && inputs.create_release
+        && needs.configure.result == 'success'
+        && (needs.configure.outputs.want_build_vscode != 'true' || needs.build-vscode.result == 'success')
+        && (needs.configure.outputs.want_build_desktop != 'true' || needs.build-desktop.result == 'success')
+        && (needs.configure.outputs.want_build_tauri != 'true' || needs.build-tauri.result == 'success')
+      }}
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: List release assets
+        run: find release-assets -type f | head -50
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag_name }}
+          name: ${{ inputs.release_name }}
+          prerelease: ${{ inputs.prerelease }}
+          files: release-assets/*
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-dev-auto.yml
+++ b/.github/workflows/build-dev-auto.yml
@@ -24,253 +24,50 @@ on:
           - desktop-mac-arm64
           - desktop-win-x64
           - desktop-win-arm64
+          - tauri
+          - tauri-mac
+          - tauri-win
+          - tauri-mac-x64
+          - tauri-mac-arm64
+          - tauri-win-x64
         default: all
 
 permissions:
   contents: write
 
+concurrency:
+  group: build-dev-auto-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
+  prepare:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Run lint
-        run: npm run lint
-
-      - name: Run tests (unit + integration)
-        run: npm run test:all
-
-  configure:
-    runs-on: ubuntu-latest
-    needs: test
     outputs:
-      version: ${{ steps.meta.outputs.version }}
       suffix: ${{ steps.meta.outputs.suffix }}
-      want_build_vscode: ${{ steps.targets.outputs.want_build_vscode }}
-      want_build_desktop: ${{ steps.targets.outputs.want_build_desktop }}
-      desktop_matrix: ${{ steps.targets.outputs.desktop_matrix }}
+      tag_name: ${{ steps.meta.outputs.tag_name }}
+      release_name: ${{ steps.meta.outputs.release_name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Resolve version & suffix
+      - name: Resolve version, suffix & release metadata
         id: meta
         run: |
           VERSION=$(node -p "require('./packages/vscode/package.json').version")
           DATE=$(date +%Y%m%d)
           SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
-          SUFFIX="-auto-${DATE}-${SHORT_SHA}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
+          echo "suffix=-auto-${DATE}-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "tag_name=dev-${VERSION}-${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "release_name=Dev Build ${VERSION} (#${{ github.run_number }})" >> "$GITHUB_OUTPUT"
 
-      - name: Resolve build targets & desktop matrix JSON
-        id: targets
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          INPUT_TARGETS: ${{ github.event.inputs.build_targets }}
-        run: |
-          MATRIX='[{"os":"macos-latest","platform":"mac","arch":"x64"},{"os":"macos-latest","platform":"mac","arch":"arm64"},{"os":"windows-latest","platform":"win","arch":"x64"},{"os":"windows-latest","platform":"win","arch":"arm64"}]'
-          MATRIX_MAC='[{"os":"macos-latest","platform":"mac","arch":"x64"},{"os":"macos-latest","platform":"mac","arch":"arm64"}]'
-          MATRIX_WIN='[{"os":"windows-latest","platform":"win","arch":"x64"},{"os":"windows-latest","platform":"win","arch":"arm64"}]'
-          MATRIX_MAC_X64='[{"os":"macos-latest","platform":"mac","arch":"x64"}]'
-          MATRIX_MAC_ARM64='[{"os":"macos-latest","platform":"mac","arch":"arm64"}]'
-          MATRIX_WIN_X64='[{"os":"windows-latest","platform":"win","arch":"x64"}]'
-          MATRIX_WIN_ARM64='[{"os":"windows-latest","platform":"win","arch":"arm64"}]'
-
-          WANT_V=false
-          WANT_D=false
-
-          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_TARGETS" ]; then
-            TARGET="$INPUT_TARGETS"
-          else
-            TARGET=all
-          fi
-
-          case "$TARGET" in
-            all)
-              WANT_V=true
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX"
-              ;;
-            vscode)
-              WANT_V=true
-              DESKTOP_MATRIX='[]'
-              ;;
-            desktop)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX"
-              ;;
-            desktop-mac)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_MAC"
-              ;;
-            desktop-win)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_WIN"
-              ;;
-            desktop-mac-x64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_MAC_X64"
-              ;;
-            desktop-mac-arm64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_MAC_ARM64"
-              ;;
-            desktop-win-x64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_WIN_X64"
-              ;;
-            desktop-win-arm64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_WIN_ARM64"
-              ;;
-            *)
-              echo "Unknown build_targets=$TARGET" >&2
-              exit 1
-              ;;
-          esac
-
-          if [ "$WANT_V" = true ]; then
-            echo "want_build_vscode=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "want_build_vscode=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          if [ "$WANT_D" = true ]; then
-            echo "want_build_desktop=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "want_build_desktop=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          {
-            echo "desktop_matrix<<__MATRIX_EOF__"
-            echo "$DESKTOP_MATRIX"
-            echo "__MATRIX_EOF__"
-          } >> "$GITHUB_OUTPUT"
-
-  build-vscode:
-    runs-on: ubuntu-latest
-    needs: configure
-    if: ${{ needs.configure.outputs.want_build_vscode == 'true' }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: |
-          npm install
-          cd web && npm install
-
-      - name: Build dev package
-        run: npm run package:dev
-
-      - name: Rename vsix file
-        run: |
-          SUFFIX="${{ needs.configure.outputs.suffix }}"
-          cd dists
-          for file in *.vsix; do
-            BASENAME="${file%.vsix}"
-            mv "$file" "${BASENAME}${SUFFIX}.vsix"
-          done
-          ls -la
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ccrelay-vscode-dev-${{ needs.configure.outputs.version }}${{ needs.configure.outputs.suffix }}
-          path: dists/*.vsix
-          retention-days: 30
-
-  build-desktop:
-    needs: configure
-    if: ${{ needs.configure.outputs.want_build_desktop == 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.configure.outputs.desktop_matrix) }}
-    runs-on: ${{ matrix.os }}
-    env:
-      ELECTRON_CACHE: ${{ github.workspace }}/.electron-cache
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Cache Electron downloads
-        uses: actions/cache@v4
-        with:
-          path: .electron-cache
-          key: electron-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('package-lock.json', 'packages/desktop/package.json') }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: |
-          npm install
-          cd web && npm install
-
-      - name: Build desktop
-        run: npm run desktop:build
-
-      - name: Pack desktop (${{ matrix.platform }} ${{ matrix.arch }})
-        run: npx electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish never
-        working-directory: packages/desktop
-
-      - name: Upload desktop artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ccrelay-desktop-${{ matrix.platform }}-${{ matrix.arch }}-${{ needs.configure.outputs.version }}${{ needs.configure.outputs.suffix }}
-          path: |
-            packages/desktop/dist/*.zip
-            packages/desktop/dist/*.exe
-          retention-days: 30
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [configure, build-vscode, build-desktop]
-    if: >-
-      ${{
-        needs.configure.result == 'success'
-        && (needs.configure.outputs.want_build_vscode != 'true' || needs.build-vscode.result == 'success')
-        && (needs.configure.outputs.want_build_desktop != 'true' || needs.build-desktop.result == 'success')
-      }}
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: release-assets
-          merge-multiple: true
-
-      - name: List release assets
-        run: find release-assets -type f | head -50
-
-      - name: Create dev release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: dev-${{ needs.configure.outputs.version }}-${{ github.run_number }}
-          name: Dev Build ${{ needs.configure.outputs.version }} (#${{ github.run_number }})
-          prerelease: true
-          files: release-assets/*
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build:
+    needs: prepare
+    uses: ./.github/workflows/_build.yml
+    with:
+      build_targets: ${{ inputs.build_targets || 'all' }}
+      suffix: ${{ needs.prepare.outputs.suffix }}
+      create_release: true
+      prerelease: true
+      tag_name: ${{ needs.prepare.outputs.tag_name }}
+      release_name: ${{ needs.prepare.outputs.release_name }}
+    secrets: inherit

--- a/.github/workflows/build-dev-manual.yml
+++ b/.github/workflows/build-dev-manual.yml
@@ -17,6 +17,12 @@ on:
           - desktop-mac-arm64
           - desktop-win-x64
           - desktop-win-arm64
+          - tauri
+          - tauri-mac
+          - tauri-win
+          - tauri-mac-x64
+          - tauri-mac-arm64
+          - tauri-win-x64
         default: all
       suffix:
         description: 'Optional suffix for artifact name (e.g., test, debug)'
@@ -29,218 +35,33 @@ on:
         default: false
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: build-dev-manual-${{ github.event.inputs.build_targets }}
+  cancel-in-progress: true
 
 jobs:
-  test:
+  prepare:
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.skip_tests != 'true' }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Run lint
-        run: npm run lint
-
-      - name: Run tests (unit + integration)
-        run: npm run test:all
-
-  configure:
-    runs-on: ubuntu-latest
-    needs: test
-    if: ${{ always() && (needs.test.result == 'success' || needs.test.result == 'skipped') }}
     outputs:
-      version: ${{ steps.meta.outputs.version }}
       suffix: ${{ steps.meta.outputs.suffix }}
-      want_build_vscode: ${{ steps.targets.outputs.want_build_vscode }}
-      want_build_desktop: ${{ steps.targets.outputs.want_build_desktop }}
-      desktop_matrix: ${{ steps.targets.outputs.desktop_matrix }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Resolve version & suffix
+      - name: Resolve suffix
         id: meta
         run: |
-          VERSION=$(node -p "require('./packages/vscode/package.json').version")
-          INPUT_SUFFIX="${{ github.event.inputs.suffix }}"
+          INPUT_SUFFIX="${{ inputs.suffix }}"
           if [ -n "$INPUT_SUFFIX" ]; then
-            SUFFIX="-manual-${INPUT_SUFFIX}"
+            echo "suffix=-manual-${INPUT_SUFFIX}" >> "$GITHUB_OUTPUT"
           else
-            SUFFIX="-manual-${{ github.run_number }}"
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
-
-      - name: Resolve build targets & desktop matrix JSON
-        id: targets
-        env:
-          TARGET: ${{ github.event.inputs.build_targets || 'all' }}
-        run: |
-          MATRIX='[{"os":"macos-latest","platform":"mac","arch":"x64"},{"os":"macos-latest","platform":"mac","arch":"arm64"},{"os":"windows-latest","platform":"win","arch":"x64"},{"os":"windows-latest","platform":"win","arch":"arm64"}]'
-          MATRIX_MAC='[{"os":"macos-latest","platform":"mac","arch":"x64"},{"os":"macos-latest","platform":"mac","arch":"arm64"}]'
-          MATRIX_WIN='[{"os":"windows-latest","platform":"win","arch":"x64"},{"os":"windows-latest","platform":"win","arch":"arm64"}]'
-          MATRIX_MAC_X64='[{"os":"macos-latest","platform":"mac","arch":"x64"}]'
-          MATRIX_MAC_ARM64='[{"os":"macos-latest","platform":"mac","arch":"arm64"}]'
-          MATRIX_WIN_X64='[{"os":"windows-latest","platform":"win","arch":"x64"}]'
-          MATRIX_WIN_ARM64='[{"os":"windows-latest","platform":"win","arch":"arm64"}]'
-
-          WANT_V=false
-          WANT_D=false
-
-          case "$TARGET" in
-            all)
-              WANT_V=true
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX"
-              ;;
-            vscode)
-              WANT_V=true
-              DESKTOP_MATRIX='[]'
-              ;;
-            desktop)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX"
-              ;;
-            desktop-mac)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_MAC"
-              ;;
-            desktop-win)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_WIN"
-              ;;
-            desktop-mac-x64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_MAC_X64"
-              ;;
-            desktop-mac-arm64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_MAC_ARM64"
-              ;;
-            desktop-win-x64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_WIN_X64"
-              ;;
-            desktop-win-arm64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_WIN_ARM64"
-              ;;
-            *)
-              echo "Unknown build_targets=$TARGET" >&2
-              exit 1
-              ;;
-          esac
-
-          if [ "$WANT_V" = true ]; then
-            echo "want_build_vscode=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "want_build_vscode=false" >> "$GITHUB_OUTPUT"
+            echo "suffix=-manual-${{ github.run_number }}" >> "$GITHUB_OUTPUT"
           fi
 
-          if [ "$WANT_D" = true ]; then
-            echo "want_build_desktop=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "want_build_desktop=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          {
-            echo "desktop_matrix<<__MATRIX_EOF__"
-            echo "$DESKTOP_MATRIX"
-            echo "__MATRIX_EOF__"
-          } >> "$GITHUB_OUTPUT"
-
-  build-vscode:
-    runs-on: ubuntu-latest
-    needs: configure
-    if: ${{ needs.configure.outputs.want_build_vscode == 'true' }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: |
-          npm install
-          cd web && npm install
-
-      - name: Build dev package
-        run: npm run package:dev
-
-      - name: Rename vsix file
-        run: |
-          SUFFIX="${{ needs.configure.outputs.suffix }}"
-          cd dists
-          for file in *.vsix; do
-            BASENAME="${file%.vsix}"
-            mv "$file" "${BASENAME}${SUFFIX}.vsix"
-          done
-          ls -la
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ccrelay-vscode-dev-${{ needs.configure.outputs.version }}${{ needs.configure.outputs.suffix }}
-          path: dists/*.vsix
-          retention-days: 30
-
-  build-desktop:
-    needs: configure
-    if: ${{ needs.configure.outputs.want_build_desktop == 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.configure.outputs.desktop_matrix) }}
-    runs-on: ${{ matrix.os }}
-    env:
-      ELECTRON_CACHE: ${{ github.workspace }}/.electron-cache
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Cache Electron downloads
-        uses: actions/cache@v4
-        with:
-          path: .electron-cache
-          key: electron-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('package-lock.json', 'packages/desktop/package.json') }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: |
-          npm install
-          cd web && npm install
-
-      - name: Build desktop
-        run: npm run desktop:build
-
-      - name: Pack desktop (${{ matrix.platform }} ${{ matrix.arch }})
-        run: npx electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish never
-        working-directory: packages/desktop
-
-      - name: Upload desktop artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ccrelay-desktop-${{ matrix.platform }}-${{ matrix.arch }}-${{ needs.configure.outputs.version }}${{ needs.configure.outputs.suffix }}
-          path: |
-            packages/desktop/dist/*.zip
-            packages/desktop/dist/*.exe
-          retention-days: 30
+  build:
+    needs: prepare
+    uses: ./.github/workflows/_build.yml
+    with:
+      build_targets: ${{ inputs.build_targets || 'all' }}
+      suffix: ${{ needs.prepare.outputs.suffix }}
+      skip_tests: ${{ inputs.skip_tests }}
+    secrets: inherit

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -17,6 +17,12 @@ on:
           - desktop-mac-arm64
           - desktop-win-x64
           - desktop-win-arm64
+          - tauri
+          - tauri-mac
+          - tauri-win
+          - tauri-mac-x64
+          - tauri-mac-arm64
+          - tauri-win-x64
         default: all
       tag_name:
         description: 'Tag name to release (e.g., v1.0.0), will use package.json version if empty'
@@ -26,37 +32,16 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: build-prod
+  cancel-in-progress: false
+
 jobs:
-  test:
+  prepare:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Run lint
-        run: npm run lint
-
-      - name: Run tests (unit + integration)
-        run: npm run test:all
-
-  configure:
-    runs-on: ubuntu-latest
-    needs: test
     outputs:
-      version: ${{ steps.meta.outputs.version }}
       tag_name: ${{ steps.meta.outputs.tag_name }}
-      want_build_vscode: ${{ steps.targets.outputs.want_build_vscode }}
-      want_build_desktop: ${{ steps.targets.outputs.want_build_desktop }}
-      desktop_matrix: ${{ steps.targets.outputs.desktop_matrix }}
+      release_name: ${{ steps.meta.outputs.release_name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -65,195 +50,24 @@ jobs:
         id: meta
         run: |
           VERSION=$(node -p "require('./packages/vscode/package.json').version")
-          INPUT_TAG="${{ github.event.inputs.tag_name }}"
+          INPUT_TAG="${{ inputs.tag_name }}"
           if [ -n "$INPUT_TAG" ]; then
             TAG_NAME="$INPUT_TAG"
           else
             TAG_NAME="v${VERSION}"
           fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "release_name=Release $TAG_NAME" >> "$GITHUB_OUTPUT"
 
-      - name: Resolve build targets & desktop matrix JSON
-        id: targets
-        env:
-          TARGET: ${{ github.event.inputs.build_targets || 'all' }}
-        run: |
-          MATRIX='[{"os":"macos-latest","platform":"mac","arch":"x64"},{"os":"macos-latest","platform":"mac","arch":"arm64"},{"os":"windows-latest","platform":"win","arch":"x64"},{"os":"windows-latest","platform":"win","arch":"arm64"}]'
-          MATRIX_MAC='[{"os":"macos-latest","platform":"mac","arch":"x64"},{"os":"macos-latest","platform":"mac","arch":"arm64"}]'
-          MATRIX_WIN='[{"os":"windows-latest","platform":"win","arch":"x64"},{"os":"windows-latest","platform":"win","arch":"arm64"}]'
-          MATRIX_MAC_X64='[{"os":"macos-latest","platform":"mac","arch":"x64"}]'
-          MATRIX_MAC_ARM64='[{"os":"macos-latest","platform":"mac","arch":"arm64"}]'
-          MATRIX_WIN_X64='[{"os":"windows-latest","platform":"win","arch":"x64"}]'
-          MATRIX_WIN_ARM64='[{"os":"windows-latest","platform":"win","arch":"arm64"}]'
-
-          WANT_V=false
-          WANT_D=false
-
-          case "$TARGET" in
-            all)
-              WANT_V=true
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX"
-              ;;
-            vscode)
-              WANT_V=true
-              DESKTOP_MATRIX='[]'
-              ;;
-            desktop)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX"
-              ;;
-            desktop-mac)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_MAC"
-              ;;
-            desktop-win)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_WIN"
-              ;;
-            desktop-mac-x64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_MAC_X64"
-              ;;
-            desktop-mac-arm64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_MAC_ARM64"
-              ;;
-            desktop-win-x64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_WIN_X64"
-              ;;
-            desktop-win-arm64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_WIN_ARM64"
-              ;;
-            *)
-              echo "Unknown build_targets=$TARGET" >&2
-              exit 1
-              ;;
-          esac
-
-          if [ "$WANT_V" = true ]; then
-            echo "want_build_vscode=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "want_build_vscode=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          if [ "$WANT_D" = true ]; then
-            echo "want_build_desktop=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "want_build_desktop=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          {
-            echo "desktop_matrix<<__MATRIX_EOF__"
-            echo "$DESKTOP_MATRIX"
-            echo "__MATRIX_EOF__"
-          } >> "$GITHUB_OUTPUT"
-
-  build-vscode:
-    runs-on: ubuntu-latest
-    needs: configure
-    if: ${{ needs.configure.outputs.want_build_vscode == 'true' }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: |
-          npm install
-          cd web && npm install
-
-      - name: Build prod package
-        run: npm run package:prod
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ccrelay-vscode-prod-${{ needs.configure.outputs.version }}
-          path: dists/*.vsix
-          retention-days: 90
-
-  build-desktop:
-    needs: configure
-    if: ${{ needs.configure.outputs.want_build_desktop == 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.configure.outputs.desktop_matrix) }}
-    runs-on: ${{ matrix.os }}
-    env:
-      ELECTRON_CACHE: ${{ github.workspace }}/.electron-cache
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Cache Electron downloads
-        uses: actions/cache@v4
-        with:
-          path: .electron-cache
-          key: electron-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('package-lock.json', 'packages/desktop/package.json') }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: |
-          npm install
-          cd web && npm install
-
-      - name: Build desktop
-        run: npm run desktop:build
-
-      - name: Pack desktop (${{ matrix.platform }} ${{ matrix.arch }})
-        run: npx electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish never
-        working-directory: packages/desktop
-
-      - name: Upload desktop artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ccrelay-desktop-${{ matrix.platform }}-${{ matrix.arch }}-${{ needs.configure.outputs.version }}
-          path: |
-            packages/desktop/dist/*.zip
-            packages/desktop/dist/*.exe
-          retention-days: 90
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [configure, build-vscode, build-desktop]
-    if: >-
-      ${{
-        needs.configure.result == 'success'
-        && (needs.configure.outputs.want_build_vscode != 'true' || needs.build-vscode.result == 'success')
-        && (needs.configure.outputs.want_build_desktop != 'true' || needs.build-desktop.result == 'success')
-      }}
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: release-assets
-          merge-multiple: true
-
-      - name: List release assets
-        run: find release-assets -type f | head -50
-
-      - name: Create release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ needs.configure.outputs.tag_name }}
-          name: Release ${{ needs.configure.outputs.tag_name }}
-          prerelease: false
-          files: release-assets/*
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build:
+    needs: prepare
+    uses: ./.github/workflows/_build.yml
+    with:
+      build_targets: ${{ inputs.build_targets || 'all' }}
+      is_prod: true
+      create_release: true
+      prerelease: false
+      tag_name: ${{ needs.prepare.outputs.tag_name }}
+      release_name: ${{ needs.prepare.outputs.release_name }}
+      retention_days: 90
+    secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,13 @@
 name: Lint
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
+
+concurrency:
+  group: lint-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -18,13 +19,7 @@ jobs:
       - name: Check if docs-only changes
         id: check
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            files=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files --jq '.[].filename')
-          else
-            # For push events, compare with the previous state using github's before/after SHA
-            git fetch origin ${{ github.event.before }} --depth=1 2>/dev/null || true
-            files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} 2>/dev/null || git diff --name-only HEAD^ HEAD)
-          fi
+          files=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files --jq '.[].filename')
           if echo "$files" | grep -qvE '(\.md$|^docs/)'; then
             echo "has_code_changes=true" >> $GITHUB_OUTPUT
           else
@@ -39,12 +34,13 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            web/package-lock.json
 
       - name: Install dependencies
         if: steps.check.outputs.has_code_changes == 'true'
-        run: |
-          npm install
-          cd web && npm install
+        run: npm install
 
       - name: Lint root
         if: steps.check.outputs.has_code_changes == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,13 @@
 name: Test
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
+
+concurrency:
+  group: test-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -18,13 +19,7 @@ jobs:
       - name: Check if docs-only changes
         id: check
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            files=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files --jq '.[].filename')
-          else
-            # For push events, compare with the previous state using github's before/after SHA
-            git fetch origin ${{ github.event.before }} --depth=1 2>/dev/null || true
-            files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} 2>/dev/null || git diff --name-only HEAD^ HEAD)
-          fi
+          files=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files --jq '.[].filename')
           if echo "$files" | grep -qvE '(\.md$|^docs/)'; then
             echo "has_code_changes=true" >> $GITHUB_OUTPUT
           else
@@ -39,6 +34,9 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            web/package-lock.json
 
       - name: Install dependencies
         if: steps.check.outputs.has_code_changes == 'true'


### PR DESCRIPTION
## Summary

This change refactors GitHub Actions so build logic lives in one reusable workflow, adds Tauri desktop artifacts to the same dev/prod release pipeline as Electron (with `ccrelay-tauri-*` artifact names to avoid collisions), and reduces duplicate work on `main` by running lint and test only on pull requests.

## What changed

- **`_build.yml`**: Shared jobs for test gate, configure matrices, VSIX, Electron, Tauri (mac arm64 + mac x64 on `macos-13` + Windows x64), and GitHub Release upload. Tauri builds use `CCRELAY_SEA=1` for the sidecar.
- **Callers**: `build-dev-auto`, `build-dev-manual`, and `build-prod` delegate to the reusable workflow and expose `tauri` / `tauri-mac` / `tauri-win` / per-arch variants as `build_targets` options. `all` includes VSIX, Electron (four combos), and Tauri (three combos).
- **Lint / Test**: Trigger on PRs to `main` only, with concurrency groups and `web/package-lock.json` in npm cache paths.

## Notes

- Tauri Windows ARM64 is not built (no hosted runner); Electron Win ARM64 is unchanged.
- Dev auto builds on push to `main` still run the full test gate plus releases.

Made with [Cursor](https://cursor.com)