### PR TITLE
fix(tauri): SEA sidecar bundling and CI matrix without macOS x64 Tauri

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -94,10 +94,9 @@ jobs:
           MATRIX_WIN_X64='[{"os":"windows-latest","platform":"win","arch":"x64"}]'
           MATRIX_WIN_ARM64='[{"os":"windows-latest","platform":"win","arch":"arm64"}]'
 
-          TAURI_MATRIX='[{"os":"macos-latest","platform":"mac","arch":"arm64","rust_target":"aarch64-apple-darwin"},{"os":"macos-13","platform":"mac","arch":"x64","rust_target":"x86_64-apple-darwin"},{"os":"windows-latest","platform":"win","arch":"x64","rust_target":"x86_64-pc-windows-msvc"}]'
-          TAURI_MAC='[{"os":"macos-latest","platform":"mac","arch":"arm64","rust_target":"aarch64-apple-darwin"},{"os":"macos-13","platform":"mac","arch":"x64","rust_target":"x86_64-apple-darwin"}]'
+          TAURI_MATRIX='[{"os":"macos-latest","platform":"mac","arch":"arm64","rust_target":"aarch64-apple-darwin"},{"os":"windows-latest","platform":"win","arch":"x64","rust_target":"x86_64-pc-windows-msvc"}]'
+          TAURI_MAC='[{"os":"macos-latest","platform":"mac","arch":"arm64","rust_target":"aarch64-apple-darwin"}]'
           TAURI_WIN='[{"os":"windows-latest","platform":"win","arch":"x64","rust_target":"x86_64-pc-windows-msvc"}]'
-          TAURI_MAC_X64='[{"os":"macos-13","platform":"mac","arch":"x64","rust_target":"x86_64-apple-darwin"}]'
           TAURI_MAC_ARM64='[{"os":"macos-latest","platform":"mac","arch":"arm64","rust_target":"aarch64-apple-darwin"}]'
           TAURI_WIN_X64='[{"os":"windows-latest","platform":"win","arch":"x64","rust_target":"x86_64-pc-windows-msvc"}]'
 
@@ -160,11 +159,6 @@ jobs:
               WANT_T=true
               DESKTOP_MATRIX='[]'
               TAURI_TARGETS="$TAURI_WIN"
-              ;;
-            tauri-mac-x64)
-              WANT_T=true
-              DESKTOP_MATRIX='[]'
-              TAURI_TARGETS="$TAURI_MAC_X64"
               ;;
             tauri-mac-arm64)
               WANT_T=true

--- a/.github/workflows/build-dev-auto.yml
+++ b/.github/workflows/build-dev-auto.yml
@@ -27,7 +27,6 @@ on:
           - tauri
           - tauri-mac
           - tauri-win
-          - tauri-mac-x64
           - tauri-mac-arm64
           - tauri-win-x64
         default: all

--- a/.github/workflows/build-dev-manual.yml
+++ b/.github/workflows/build-dev-manual.yml
@@ -20,7 +20,6 @@ on:
           - tauri
           - tauri-mac
           - tauri-win
-          - tauri-mac-x64
           - tauri-mac-arm64
           - tauri-win-x64
         default: all

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -20,7 +20,6 @@ on:
           - tauri
           - tauri-mac
           - tauri-win
-          - tauri-mac-x64
           - tauri-mac-arm64
           - tauri-win-x64
         default: all

--- a/scripts/esbuild.tauri.mjs
+++ b/scripts/esbuild.tauri.mjs
@@ -23,15 +23,6 @@ const commonOptions = {
   platform: "node",
   target: "node20",
   format: "cjs",
-  external: [
-    "pg",
-    "pg-*",
-    "pgpass",
-    "postgres-array",
-    "postgres-bytea",
-    "postgres-date",
-    "postgres-interval",
-  ],
   sourcemap: false,
   minify: false,
 };
@@ -82,8 +73,8 @@ if (isSea) {
     stdio: "inherit",
   });
 
-  // Copy node binary and inject SEA blob
-  const nodePath = execSync("which node").toString().trim();
+  // Copy node binary and inject SEA blob (use execPath: Windows is node.exe, not `node`)
+  const nodePath = process.execPath;
   fs.copyFileSync(nodePath, sidecarBinaryPath);
   fs.chmodSync(sidecarBinaryPath, 0o755);
 
@@ -93,8 +84,9 @@ if (isSea) {
     });
   }
 
+  const machoFlag = process.platform === "darwin" ? " --macho-segment-name NODE_SEA" : "";
   execSync(
-    `npx postject "${sidecarBinaryPath}" NODE_SEA_BLOB "${seaBlobPath}" --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2`,
+    `npx postject "${sidecarBinaryPath}" NODE_SEA_BLOB "${seaBlobPath}" --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2${machoFlag}`,
     { stdio: "inherit" }
   );
 
@@ -107,7 +99,7 @@ if (isSea) {
   console.log(`SEA binary created: ${sidecarBinaryPath}`);
 } else {
   // Development: create a wrapper script that runs node with the bundle
-  const nodePath = execSync("which node").toString().trim();
+  const nodePath = process.execPath;
   const wrapperScript = `#!/bin/sh
 exec "${nodePath}" "${outDir}/ccrelay-server.js" "$@"
 `;


### PR DESCRIPTION
## Summary

Fixes Tauri desktop builds where the Node.js SEA sidecar failed in production (CI and packaged apps) while local dev still worked. Also removes the Tauri macOS Intel job from CI because `macos-13` runners queue indefinitely.

## Changes

### `scripts/esbuild.tauri.mjs`

- **Bundle `pg` and related deps** into the sidecar (no `external` list). SEA has no `node_modules`; VS Code/Electron keep their existing externalized builds elsewhere.
- **`process.execPath`** instead of `which node` when copying the Node binary for SEA (Windows uses `node.exe`).
- **`--macho-segment-name NODE_SEA`** for postject on macOS so Node can find the embedded blob.

### CI (`.github/workflows`)

- Tauri matrix is **mac arm64 + Windows x64** only; drop `macos-13` / Intel Tauri and the `tauri-mac-x64` dispatch option. Electron `desktop-mac-x64` is unchanged.

## Verify locally

```bash
CCRELAY_SEA=1 npm run tauri:build
cd packages/desktop-tauri && npx tauri build
```

Made with [Cursor](https://cursor.com)