### PR TITLE
docs: Web Search Server Tools naming; Tauri release artifacts; README acknowledgements

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -332,11 +332,46 @@ jobs:
 
       - name: Stage Tauri bundle files
         shell: bash
+        env:
+          VERSION: ${{ needs.configure.outputs.version }}
+          MATRIX_PLATFORM: ${{ matrix.platform }}
+          MATRIX_ARCH: ${{ matrix.arch }}
         run: |
+          set -euo pipefail
           mkdir -p tauri-dist
           BUNDLE="packages/desktop-tauri/src-tauri/target/${{ matrix.rust_target }}/release/bundle"
-          if [ -d "$BUNDLE" ]; then
-            find "$BUNDLE" -type f \( -name '*.dmg' -o -name '*.app.tar.gz' -o -name '*.msi' -o -name '*.exe' \) -exec cp {} tauri-dist/ \;
+          if [[ "$MATRIX_PLATFORM" == "mac" ]]; then
+            EB_PLATFORM=darwin
+          else
+            EB_PLATFORM=win32
+          fi
+          # Mirror Electron artifactName: ${productName}-${version}-${platform}-${arch}.${ext}, plus "-tauri-"
+          BASE="CCRelay-${VERSION}-tauri-${EB_PLATFORM}-${MATRIX_ARCH}"
+          if [[ ! -d "$BUNDLE" ]]; then
+            echo "Missing bundle dir: $BUNDLE" >&2
+            exit 1
+          fi
+          copied=0
+          while IFS= read -r -d '' f; do
+            case "$f" in
+              *.dmg)
+                cp "$f" "tauri-dist/${BASE}.dmg"
+                copied=$((copied + 1))
+                ;;
+              *.exe)
+                cp "$f" "tauri-dist/${BASE}.exe"
+                copied=$((copied + 1))
+                ;;
+              *.app.tar.gz)
+                cp "$f" "tauri-dist/${BASE}.app.tar.gz"
+                copied=$((copied + 1))
+                ;;
+              *) ;;
+            esac
+          done < <(find "$BUNDLE" -type f \( -name '*.dmg' -o -name '*.exe' -o -name '*.app.tar.gz' \) -print0)
+          if [[ "$copied" -eq 0 ]]; then
+            echo "No installable .dmg/.exe/.app.tar.gz under $BUNDLE" >&2
+            exit 1
           fi
           ls -la tauri-dist/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This release expands the web dashboard (logs, stats, provider wizard) and tighte
 
 **Protocol/Conversion**
 
-- **Azure OpenAI**: Anthropic inbound requests using hosted web search are sent to the **Responses** API when Chat Completions would reject those tools.
+- **Azure OpenAI**: Anthropic inbound requests using Web Search Server Tools are sent to the **Responses** API when Chat Completions would reject those tools.
 - Hosted Chat **hosted-tool** shaping for outbound requests is inferred from the provider URL (no separate UI toggle).
 
 **Desktop**
@@ -60,8 +60,8 @@ This release expands the web dashboard (logs, stats, provider wizard) and tighte
 **Protocol/Conversion**
 
 - **Gemini** (OpenAI-compatible): strip unsupported URL query flags; outbound Chat bodies omit Responses-only fields and unsupported tool types.
-- **Z.ai GLM** (including `open.bigmodel.cn`): preserve web search across OpenAI Chat ↔ Anthropic; normalize streaming SSE (`web_search_prime` → standard `web_search` / `web_search_tool_result`) for **`/v1/messages`** and **`/anthropic/v1/messages`**; align assistant text that still references `web_search_prime`.
-- **Xiaomi MiMo**: carry hosted web search in Anthropic ↔ OpenAI conversions; map **`url_citation`** to **`web_search` / `web_search_tool_result`** instead of a trailing JSON-only blob.
+- **Z.ai GLM** (including `open.bigmodel.cn`): preserve Web Search Server Tools across OpenAI Chat ↔ Anthropic; normalize streaming SSE (`web_search_prime` → standard `web_search` / `web_search_tool_result`) for **`/v1/messages`** and **`/anthropic/v1/messages`**; align assistant text that still references `web_search_prime`.
+- **Xiaomi MiMo**: carry Web Search Server Tools in Anthropic ↔ OpenAI conversions; map **`url_citation`** to **`web_search` / `web_search_tool_result`** instead of a trailing JSON-only blob.
 
 ## [0.2.0] - 2026-05-04
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,7 @@ A lightweight Tauri desktop app (`packages/desktop-tauri`) runs the same core as
 - Uses a sidecar architecture: Rust shell manages a Node.js server process
 - Tray menu with Start/Stop Server and Open Dashboard
 - Download from [GitHub Releases](https://github.com/inflaborg/ccrelay/releases):
-  - **macOS**: `CCRelay.app` (Apple Silicon and Intel)
-  - **Windows**: `CCRelay.exe` (x64 and arm64)
+  - Installer names follow the Electron desktop pattern (`CCRelay-<version>-<platform>-<arch>.<ext>`) with **`tauri`** added after the version (for example `CCRelay-0.2.1-tauri-darwin-arm64.dmg`, `CCRelay-0.2.1-tauri-win32-x64.exe`). Windows ships **NSIS `.exe`** only (no MSI).
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -663,8 +663,8 @@ Issues and Pull Requests are welcome!
 
 This project is **100% AI-generated code**. Special thanks to:
 
-- **[Claude Code](https://claude.ai/code)** — AI coding assistant
-- **[GLM](https://z.ai/model-api)** — GLM models as the backend provider
+- **[Cursor](https://cursor.com)** and **[Claude Code](https://claude.ai/code)** — AI coding assistants
+- **[GLM](https://z.ai/model-api)** and **[Xiaomi MiMo](https://platform.xiaomimimo.com/token-plan)** — model APIs used as development backends
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@
 
 ### Verified upstreams (by host)
 
-Relaying uses the **provider `baseUrl` hostname**. The rows below are **upstream endpoints we have validated** when you add them as a provider. Vendors may offer Anthropic APIs, OpenAI-compatible APIs, or both — but your **client protocol** and the **upstream protocol** are often not the same. When they differ, CCRelay applies **generic protocol conversion** first, then **hostname-specific alignment** where we maintain it. When the wire looks the same on both sides, **tooling still differs** by vendor (for example hosted web search, strict Chat schemas, or Responses-only tools).
+Relaying uses the **provider `baseUrl` hostname**. The rows below are **upstream endpoints we have validated** when you add them as a provider. Vendors may offer Anthropic APIs, OpenAI-compatible APIs, or both — but your **client protocol** and the **upstream protocol** are often not the same. When they differ, CCRelay applies **generic protocol conversion** first, then **hostname-specific alignment** where we maintain it. When the wire looks the same on both sides, **tooling still differs** by vendor (for example Web Search Server Tools, strict Chat schemas, or Responses-only tools).
 
-**Hosts not listed** get **generic conversion only** (no extra platform layer). **Listed hosts** get **generic conversion plus** platform rules for tools, messages, responses, and request URL/body quirks. The last column is where **hosted web search** is supported for that vendor; it does not depend on how you reach the relay.
+**Hosts not listed** get **generic conversion only** (no extra platform layer). **Listed hosts** get **generic conversion plus** platform rules for tools, messages, responses, and request URL/body quirks. The last column is where **Web Search Server Tools** are supported for that vendor; it does not depend on how you reach the relay.
 
-**Example — Azure OpenAI:** Upstream **hosted web search** exists **only** on the **Responses API** (hence “Responses API only” in the Web search column). You can still point clients at CCRelay using the **OpenAI Chat Completions** surface. After you set **Azure OpenAI** as the provider `baseUrl`, Chat-shaped calls that include hosted web search are **rewritten in the conversion layer** into upstream **Responses** requests so search keeps working—you do not need the client to call `/v1/responses` itself.
+**Example — Azure OpenAI:** Upstream **Web Search Server Tools** exist **only** on the **Responses API** (hence “Responses API only” in the Web Search Server Tools column). You can still point clients at CCRelay using the **OpenAI Chat Completions** surface. After you set **Azure OpenAI** as the provider `baseUrl`, Chat-shaped calls that include Web Search Server Tools are **rewritten in the conversion layer** into upstream **Responses** requests so search keeps working—you do not need the client to call `/v1/responses` itself.
 
-| Provider (target host) | Anthropic `/v1/messages` | OpenAI `/chat/completions` | OpenAI `/v1/responses` | Web search |
+| Provider (target host) | Anthropic `/v1/messages` | OpenAI `/chat/completions` | OpenAI `/v1/responses` | Web Search Server Tools |
 | --- | --- | --- | --- | --- |
 | **Z.ai GLM** (`api.z.ai`, `open.bigmodel.cn`) | Supported | Supported | Not supported | Supported |
 | **Xiaomi MiMo** (`api.xiaomimimo.com`) | Supported | Supported | Not supported | Chat only |
@@ -82,9 +82,9 @@ Relaying uses the **provider `baseUrl` hostname**. The rows below are **upstream
 
 **Screenshots (Claude Code through CCRelay)**
 
-![Claude Code — GLM hosted web search](https://raw.githubusercontent.com/inflaborg/ccrelay/main/docs/screenshot-claude-glm-web-search.png)
+![Claude Code — GLM Web Search Server Tools](https://raw.githubusercontent.com/inflaborg/ccrelay/main/docs/screenshot-claude-glm-web-search.png)
 
-![Claude Code — Xiaomi MiMo hosted web search](https://raw.githubusercontent.com/inflaborg/ccrelay/main/docs/screenshot-claude-xiaomi-mimo-web-search.png)
+![Claude Code — Xiaomi MiMo Web Search Server Tools](https://raw.githubusercontent.com/inflaborg/ccrelay/main/docs/screenshot-claude-xiaomi-mimo-web-search.png)
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -66,13 +66,13 @@
 
 ### 已验证上游（按主机）
 
-中继按 **provider 的 `baseUrl` 主机名** 选规则。下表中的行是我们在配置为 provider 时**已验证过**的上游端点。各厂商可能同时提供 Anthropic 协议、OpenAI 兼容接口等，但**客户端协议**与**上游协议**常常不一致；不一致时需要**协议转换**，一致时也可能在**工具能力**上不同（例如托管网页搜索、仅 Chat 接受的字段、或仅 Responses 支持的托管工具）。
+中继按 **provider 的 `baseUrl` 主机名** 选规则。下表中的行是我们在配置为 provider 时**已验证过**的上游端点。各厂商可能同时提供 Anthropic 协议、OpenAI 兼容接口等，但**客户端协议**与**上游协议**常常不一致；不一致时需要**协议转换**，一致时也可能在**工具能力**上不同（例如服务端联网搜索工具、仅 Chat 接受的字段、或仅 Responses 支持的托管工具）。
 
-**未出现在表中的主机**只走**通用协议转换**（无额外平台层）。**表中列出的主机**在通用转换之上，还会按主机名叠加**平台对齐**（工具、消息、响应形态及 URL/请求体等）。最后一列表示该厂商**托管网页搜索**在上游侧的接入位置；与如何访问本地中继无关。
+**未出现在表中的主机**只走**通用协议转换**（无额外平台层）。**表中列出的主机**在通用转换之上，还会按主机名叠加**平台对齐**（工具、消息、响应形态及 URL/请求体等）。最后一列表示该厂商**服务端联网搜索工具**在上游侧的接入位置；与如何访问本地中继无关。
 
-**示例——Azure OpenAI：** 上游侧 **托管网页搜索** 仅存在于 **Responses API**（因此表的 Web search 列为「仅 Responses API」）。你仍可以让客户端用 **OpenAI Chat Completions** 对接 CCRelay。将 **Azure OpenAI** 配成 provider 的 `baseUrl` 后，含托管 web search 的 **Chat 形态**请求会在**转换层**被改写为对上游的 **Responses** 调用，从而继续支持搜索——不必要求客户端直接调用 `/v1/responses`。
+**示例——Azure OpenAI：** 上游侧 **服务端联网搜索工具** 仅存在于 **Responses API**（因此表中「服务端联网搜索工具」列为「仅 Responses API」）。你仍可以让客户端用 **OpenAI Chat Completions** 对接 CCRelay。将 **Azure OpenAI** 配成 provider 的 `baseUrl` 后，含服务端联网搜索工具的 **Chat 形态**请求会在**转换层**被改写为对上游的 **Responses** 调用，从而继续支持搜索——不必要求客户端直接调用 `/v1/responses`。
 
-| 提供商（目标主机） | Anthropic `/v1/messages` | OpenAI `/chat/completions` | OpenAI `/v1/responses` | Web search |
+| 提供商（目标主机） | Anthropic `/v1/messages` | OpenAI `/chat/completions` | OpenAI `/v1/responses` | 服务端联网搜索工具 |
 | --- | --- | --- | --- | --- |
 | **Z.ai GLM**（`api.z.ai`、`open.bigmodel.cn`） | 支持 | 支持 | 不支持 | 支持 |
 | **小米 MiMo**（`api.xiaomimimo.com`） | 支持 | 支持 | 不支持 | 仅 Chat |
@@ -82,9 +82,9 @@
 
 **截图示例（Claude Code 经 CCRelay）**
 
-![Claude Code — 使用 GLM 托管网页搜索](https://raw.githubusercontent.com/inflaborg/ccrelay/main/docs/screenshot-claude-glm-web-search.png)
+![Claude Code — 使用 GLM 服务端联网搜索工具](https://raw.githubusercontent.com/inflaborg/ccrelay/main/docs/screenshot-claude-glm-web-search.png)
 
-![Claude Code — 使用小米 MiMo 托管网页搜索](https://raw.githubusercontent.com/inflaborg/ccrelay/main/docs/screenshot-claude-xiaomi-mimo-web-search.png)
+![Claude Code — 使用小米 MiMo 服务端联网搜索工具](https://raw.githubusercontent.com/inflaborg/ccrelay/main/docs/screenshot-claude-xiaomi-mimo-web-search.png)
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -664,8 +664,8 @@ ccrelay/
 
 本项目代码 **100% 由 AI 生成**。特别感谢：
 
-- **[Claude Code](https://claude.ai/code)** — AI 编程助手
-- **[GLM](https://z.ai/model-api)** — GLM 模型作为后端提供商
+- **[Cursor](https://cursor.com)** 与 **[Claude Code](https://claude.ai/code)** — AI 编程助手
+- **[GLM](https://z.ai/model-api)** 与 **[小米 MiMo](https://platform.xiaomimimo.com/token-plan)** — 开发阶段使用的模型后端
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -154,8 +154,7 @@ xattr -cr /path/to/CCRelay.app
 - 使用 Sidecar 架构：Rust 壳层管理 Node.js 服务进程
 - 托盘菜单支持启动/停止服务器和打开控制台
 - 从 [GitHub Releases](https://github.com/inflaborg/ccrelay/releases) 下载：
-  - **macOS**: `CCRelay.app`（Apple Silicon 和 Intel）
-  - **Windows**: `CCRelay.exe`（x64 和 arm64）
+  - 安装包命名与 Electron 桌面版一致（`CCRelay-<版本>-<platform>-<arch>.<扩展名>`），在版本号后增加 **`tauri`**（例如 `CCRelay-0.2.1-tauri-darwin-arm64.dmg`、`CCRelay-0.2.1-tauri-win32-x64.exe`）。Windows 仅提供 **NSIS 安装包（`.exe`）**，不提供 MSI。
 
 ### 开发
 

--- a/packages/desktop-tauri/src-tauri/tauri.conf.json
+++ b/packages/desktop-tauri/src-tauri/tauri.conf.json
@@ -17,7 +17,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["dmg", "nsis"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary

- **Tauri packaging**: bundle only `dmg` + `nsis` (no MSI); CI stages installers as `CCRelay-<version>-tauri-<platform>-<arch>.<ext>`, aligned with Electron `artifactName` plus `tauri`.
- **README** / **README_CN**: terminology **Web Search Server Tools** / **服务端联网搜索工具**; Tauri download bullets updated.
- **Acknowledgments**: Cursor + Claude Code; GLM + Xiaomi MiMo.

## Commits

- Stage Tauri bundles and update docs
- Rename hosted web search wording
- Add Cursor and Xiaomi MiMo to acknowledgements


Made with [Cursor](https://cursor.com)