### PR TITLE
feat(desktop): macOS Developer ID signing and notarization for Electron and Tauri

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -30,6 +30,19 @@ on:
       retention_days:
         type: number
         default: 30
+    secrets:
+      APPLE_CSC_LINK:
+        required: false
+      APPLE_CSC_KEY_PASSWORD:
+        required: false
+      APPLE_ID:
+        required: false
+      APPLE_APP_SPECIFIC_PASSWORD:
+        required: false
+      APPLE_TEAM_ID:
+        required: false
+      APPLE_SIGNING_IDENTITY:
+        required: false
 
 permissions:
   contents: write
@@ -268,11 +281,42 @@ jobs:
       - name: Build desktop
         run: npm run desktop:build
 
+      - name: Import signing certificate
+        id: mac_signing
+        if: matrix.platform == 'mac'
+        env:
+          CSC_LINK: ${{ secrets.APPLE_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${CSC_LINK:-}" ]]; then
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            echo "No APPLE_CSC_LINK secret — skipping signing certificate import"
+            exit 0
+          fi
+          KEYCHAIN=build.keychain
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 16)"
+          P12_FILE="$RUNNER_TEMP/cert.p12"
+          echo "$CSC_LINK" | base64 --decode > "$P12_FILE"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security default-keychain -s "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$P12_FILE" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
+          rm -f "$P12_FILE"
+          echo "signed=true" >> "$GITHUB_OUTPUT"
+
       - name: Pack desktop (${{ matrix.platform }} ${{ matrix.arch }})
         run: npx electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish never
         working-directory: packages/desktop
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ matrix.platform == 'mac' }}
+          APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.platform == 'mac' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}
 
-      - name: Verify macOS dmg integrity
+      - name: Verify macOS DMG and code signature
         if: matrix.platform == 'mac'
         run: |
           set -euo pipefail
@@ -294,7 +338,18 @@ jobs:
               exit 1
             fi
             echo "OK: $dmg (${size} bytes) — $filetype"
+            hdiutil verify "$dmg"
           done
+          if [[ "${{ steps.mac_signing.outputs.signed }}" == "true" ]]; then
+            APP=$(find packages/desktop/dist -name '*.app' -maxdepth 3 | head -1)
+            if [[ -z "${APP}" ]]; then
+              echo "::error::No .app found under packages/desktop/dist"
+              exit 1
+            fi
+            echo "Verifying code signature: $APP"
+            codesign --verify --deep --strict "$APP"
+            echo "Code signature OK"
+          fi
 
       - name: Upload desktop artifact
         uses: actions/upload-artifact@v4
@@ -304,6 +359,10 @@ jobs:
             packages/desktop/dist/*.dmg
             packages/desktop/dist/*.exe
           retention-days: ${{ inputs.retention_days }}
+
+      - name: Cleanup signing keychain
+        if: matrix.platform == 'mac' && always()
+        run: security delete-keychain build.keychain || true
 
   build-tauri:
     needs: configure
@@ -350,9 +409,40 @@ jobs:
         env:
           CCRELAY_SEA: '1'
 
+      - name: Import signing certificate
+        id: tauri_mac_signing
+        if: matrix.platform == 'mac'
+        env:
+          CSC_LINK: ${{ secrets.APPLE_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${CSC_LINK:-}" ]]; then
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            echo "No APPLE_CSC_LINK secret — skipping signing certificate import"
+            exit 0
+          fi
+          KEYCHAIN=build.keychain
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 16)"
+          P12_FILE="$RUNNER_TEMP/cert.p12"
+          echo "$CSC_LINK" | base64 --decode > "$P12_FILE"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security default-keychain -s "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$P12_FILE" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
+          rm -f "$P12_FILE"
+          echo "signed=true" >> "$GITHUB_OUTPUT"
+
       - name: Pack Tauri (${{ matrix.platform }} ${{ matrix.arch }})
         run: npx tauri build --target ${{ matrix.rust_target }}
         working-directory: packages/desktop-tauri
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ matrix.platform == 'mac' && secrets.APPLE_SIGNING_IDENTITY || '' }}
+          APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}
+          APPLE_PASSWORD: ${{ matrix.platform == 'mac' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}
 
       - name: Stage Tauri bundle files
         shell: bash
@@ -406,6 +496,10 @@ jobs:
           path: tauri-dist/*
           if-no-files-found: error
           retention-days: ${{ inputs.retention_days }}
+
+      - name: Cleanup signing keychain
+        if: matrix.platform == 'mac' && always()
+        run: security delete-keychain build.keychain || true
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-dev-manual.yml
+++ b/.github/workflows/build-dev-manual.yml
@@ -64,3 +64,4 @@ jobs:
       suffix: ${{ needs.prepare.outputs.suffix }}
       skip_tests: ${{ inputs.skip_tests }}
     secrets: inherit
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ packages/core/src/api/version.generated.ts
 /dist
 /internal-docs
 /.claude/worktrees
+
+# Signing certificates (never commit)
+signing/
+*.p12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Pre-release line for 0.2.4.
 
+### Added
+
+**UI**
+
+- **Add provider** wizard: **DeepSeek** preset with OpenAI Chat and Anthropic endpoints and common v4 model IDs.
+
+**Protocol/Conversion**
+
+- **DeepSeek**: Chat Completions requests to the official API host receive a compatible thinking toggle and normalized reasoning effort for extended-thinking mode.
+
 ### Changed
 
 **Protocol/Conversion**

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@
 - [Commands](#commands)
 - [Development](#development)
 - [File Locations](#file-locations)
-- [TODO](#todo)
 - [License](#license)
 
 ---
@@ -139,16 +138,6 @@ An optional Electron desktop app (`packages/desktop`) runs the same core as the 
 - Download from [GitHub Releases](https://github.com/inflaborg/ccrelay/releases):
   - **macOS**: `CCRelay-<version>-darwin-arm64.dmg` or `-darwin-x64.dmg`
   - **Windows**: `CCRelay-<version>-win32-x64.exe` or `-win32-arm64.exe`
-
-### macOS: First Launch
-
-Release builds are not Apple-notarized. If Gatekeeper blocks the app:
-
-```bash
-xattr -cr /path/to/CCRelay.app
-```
-
-Or **Control-click** the app → **Open** the first time.
 
 ---
 
@@ -747,13 +736,6 @@ ccrelay/
 | State    | `~/.ccrelay/state.json`                                  | Active provider ID         |
 | IPC lock | `~/.ccrelay/ccrelay-lock.sock` (Unix) / named pipe (Win) | Leader election            |
 | Log DB   | `~/.ccrelay/logs.db`                                     | Request logs (Leader only) |
-
----
-
-## TODO
-
-- macOS: Apple Developer ID signing + notarization in CI to remove Gatekeeper prompts
-- Re-enable DMG packaging once signing works
 
 ---
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -34,7 +34,6 @@
 - [命令](#命令)
 - [开发](#开发)
 - [文件位置](#文件位置)
-- [TODO](#todo)
 - [许可证](#许可证)
 
 ---
@@ -140,16 +139,6 @@ npm run compile        # 或 npm run watch
 - 从 [GitHub Releases](https://github.com/inflaborg/ccrelay/releases) 下载：
   - **macOS**: `CCRelay-<版本>-darwin-arm64.dmg` 或 `-darwin-x64.dmg`
   - **Windows**: `CCRelay-<版本>-win32-x64.exe` 或 `-win32-arm64.exe`
-
-### macOS：首次打开
-
-发布版本未经 Apple 公证。如果 Gatekeeper 阻止打开：
-
-```bash
-xattr -cr /path/to/CCRelay.app
-```
-
-或 **按住 Control 点击** 应用 → **打开**。
 
 ---
 
@@ -748,13 +737,6 @@ ccrelay/
 | 状态       | `~/.ccrelay/state.json`                                 | 当前激活的提供商 ID        |
 | IPC 锁     | `~/.ccrelay/ccrelay-lock.sock`（Unix）/ 命名管道（Win） | Leader 选举                |
 | 日志数据库 | `~/.ccrelay/logs.db`                                    | 请求日志（仅 Leader 写入） |
-
----
-
-## TODO
-
-- macOS：在 CI 中配置 Apple Developer ID 签名 + 公证，移除 Gatekeeper 提示
-- 签名完成后恢复 DMG 打包
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "desktop:build": "node scripts/generate-version.mjs && node scripts/build-config.mjs && npm run build:web:desktop && npm run bundle:desktop",
     "desktop:start": "npm run desktop:build && npm run start -w ccrelay-desktop",
     "desktop:pack:mac": "npm run desktop:build && npm run pack:mac -w ccrelay-desktop",
+    "desktop:pack:mac:signed": "bash scripts/pack-mac-signed.sh",
     "desktop:pack:win": "npm run desktop:build && npm run pack:win -w ccrelay-desktop",
     "bundle:tauri": "node scripts/esbuild.tauri.mjs",
     "build:web:tauri": "npx shx rm -rf packages/desktop-tauri/web && cd web && npm run build && npx shx mkdir -p ../packages/desktop-tauri && npx shx cp -r dist ../packages/desktop-tauri/web",

--- a/packages/core/src/converter/platform-transforms/deepseek/request-sanitize.ts
+++ b/packages/core/src/converter/platform-transforms/deepseek/request-sanitize.ts
@@ -1,0 +1,41 @@
+/**
+ * DeepSeek OpenAI-compatible Chat Completions: emit native `thinking` toggle and normalize
+ * `reasoning_effort` to `high` | `max` per DeepSeek docs. In thinking mode, temperature / top_p /
+ * penalties are ignored upstream; strip them for a smaller payload.
+ */
+
+/** Injected on outbound `/v1/chat/completions` bodies when upstream host is `api.deepseek.com`. */
+export function deepseekChatSanitize(body: Record<string, unknown>): void {
+  const raw = body.reasoning_effort;
+  const effort =
+    typeof raw === "string" && raw.trim() !== "" ? raw.trim().toLowerCase() : undefined;
+
+  if (effort === undefined) {
+    return;
+  }
+
+  if (effort === "none") {
+    body.thinking = { type: "disabled" };
+    delete body.reasoning_effort;
+    return;
+  }
+
+  body.thinking = { type: "enabled" };
+  body.reasoning_effort = normalizeDeepseekEffort(effort);
+  delete body.temperature;
+  delete body.top_p;
+  delete body.presence_penalty;
+  delete body.frequency_penalty;
+}
+
+/** Map OpenAI-style effort to DeepSeek-accepted `high` | `max` (low/medium → high, xhigh → max). */
+export function normalizeDeepseekEffort(effort: string): string {
+  const e = effort.toLowerCase();
+  if (e === "low" || e === "medium" || e === "minimal") {
+    return "high";
+  }
+  if (e === "xhigh") {
+    return "max";
+  }
+  return e;
+}

--- a/packages/core/src/converter/platform-transforms/index.ts
+++ b/packages/core/src/converter/platform-transforms/index.ts
@@ -49,6 +49,8 @@ export {
   mimoWebSearchTransform,
   minimaxChatSanitize,
   minimaxReasoningDetailsResponseTransform,
+  deepseekChatSanitize,
+  normalizeDeepseekEffort,
   azureWebSearchRequestOverride,
   azureResponsesWebSearchResponseTransform,
   sanitizeAzureResponsesRequestTools,

--- a/packages/core/src/converter/platform-transforms/registries.ts
+++ b/packages/core/src/converter/platform-transforms/registries.ts
@@ -20,6 +20,7 @@ import { azureChatSanitize } from "./azure-openai/chat-sanitize";
 import { glmChatSanitize } from "./glm/request-sanitize";
 import { geminiChatSanitize } from "./gemini/request-sanitize";
 import { geminiThoughtTagsResponseTransform } from "./gemini/response-thoughts";
+import { deepseekChatSanitize } from "./deepseek/request-sanitize";
 import { minimaxChatSanitize } from "./minimax/request-sanitize";
 import { minimaxReasoningDetailsResponseTransform } from "./minimax/response-reasoning";
 import { passthroughTransform } from "./passthrough";
@@ -78,6 +79,7 @@ export const ANTHROPIC_SSE_TRANSFORM_REGISTRY: Readonly<
 export const REQUEST_SANITIZE_REGISTRY: Readonly<Record<string, PlatformRequestSanitizeTransform>> =
   {
     "azure-chat-sanitize": azureChatSanitize,
+    "deepseek-chat-sanitize": deepseekChatSanitize,
     "gemini-chat-sanitize": geminiChatSanitize,
     "glm-chat-sanitize": glmChatSanitize,
     "minimax-chat-sanitize": minimaxChatSanitize,
@@ -96,6 +98,7 @@ export {
   sanitizeAzureResponsesRequestTools,
 } from "./azure-openai/responses-request-tools";
 export { azureChatSanitize } from "./azure-openai/chat-sanitize";
+export { deepseekChatSanitize, normalizeDeepseekEffort } from "./deepseek/request-sanitize";
 export { glmChatSanitize } from "./glm/request-sanitize";
 export {
   canGeminiDisableThinking,

--- a/packages/core/src/converter/platform-transforms/rules.ts
+++ b/packages/core/src/converter/platform-transforms/rules.ts
@@ -1,6 +1,6 @@
 /**
  * Layer 1: declarative hostname → platform transforms (tools, messages, responses).
- * Provider implementations live under `glm/`, `xiaomimimo/`, `minimax/`, `azure-openai/`, `gemini/`.
+ * Provider implementations live under `glm/`, `xiaomimimo/`, `minimax/`, `azure-openai/`, `gemini/`, `deepseek/`.
  */
 
 /* eslint-disable @typescript-eslint/naming-convention -- wire tool.type literals */
@@ -87,5 +87,10 @@ export const PLATFORM_TRANSFORM_RULES: readonly PlatformTransformRule[] = [
     stripQuery: true,
     requestSanitize: "gemini-chat-sanitize",
     responses: "gemini-thought-tags",
+  },
+  {
+    provider: "deepseek",
+    domains: ["api.deepseek.com"],
+    requestSanitize: "deepseek-chat-sanitize",
   },
 ];

--- a/packages/desktop-tauri/src-tauri/entitlements.plist
+++ b/packages/desktop-tauri/src-tauri/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/packages/desktop-tauri/src-tauri/tauri.conf.json
+++ b/packages/desktop-tauri/src-tauri/tauri.conf.json
@@ -35,6 +35,11 @@
       "nsis": {
         "installMode": "currentUser"
       }
+    },
+    "macOS": {
+      "entitlements": "entitlements.plist",
+      "signingIdentity": null,
+      "minimumSystemVersion": "10.13"
     }
   }
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -60,10 +60,14 @@
     ],
     "mac": {
       "category": "public.app-category.developer-tools",
-      "identity": null,
       "target": [
         "dmg"
-      ]
+      ],
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "packaging/entitlements.mac.plist",
+      "entitlementsInherit": "packaging/entitlements.mac.inherit.plist",
+      "notarize": true
     },
     "win": {
       "target": [

--- a/packages/desktop/packaging/entitlements.mac.inherit.plist
+++ b/packages/desktop/packaging/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/packages/desktop/packaging/entitlements.mac.plist
+++ b/packages/desktop/packaging/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/scripts/pack-mac-signed.sh
+++ b/scripts/pack-mac-signed.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Local signed + notarized macOS build (Electron), matching CI inputs.
+# Prerequisites: Developer ID .p12 + Apple notarization credentials in the environment.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+missing=()
+[[ -z "${CSC_LINK:-}" ]] && missing+=(CSC_LINK)
+[[ -z "${CSC_KEY_PASSWORD:-}" ]] && missing+=(CSC_KEY_PASSWORD)
+[[ -z "${APPLE_ID:-}" ]] && missing+=(APPLE_ID)
+[[ -z "${APPLE_APP_SPECIFIC_PASSWORD:-}" ]] && missing+=(APPLE_APP_SPECIFIC_PASSWORD)
+[[ -z "${APPLE_TEAM_ID:-}" ]] && missing+=(APPLE_TEAM_ID)
+
+if ((${#missing[@]})); then
+  echo "pack-mac-signed: missing env: ${missing[*]}" >&2
+  echo "Export CSC_LINK (path to .p12 or base64), CSC_KEY_PASSWORD, APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID" >&2
+  exit 1
+fi
+
+echo "=== Building Electron desktop (signed + notarized) ==="
+npm run desktop:build
+(
+  cd packages/desktop
+  export CSC_IDENTITY_AUTO_DISCOVERY=true
+  npx electron-builder --mac --publish never
+)
+
+echo "Done. For Tauri signed builds, also set APPLE_SIGNING_IDENTITY and run:"
+echo "  npm run tauri:build && cd packages/desktop-tauri && npx tauri build"

--- a/tests/unit/converter/platform-transforms/deepseek/request-sanitize.test.ts
+++ b/tests/unit/converter/platform-transforms/deepseek/request-sanitize.test.ts
@@ -1,0 +1,151 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import {
+  applyPlatformRequestSanitize,
+  deepseekChatSanitize,
+  matchHostedToolRuleForBaseUrl,
+  normalizeDeepseekEffort,
+} from "@/converter/platform-transforms";
+import { describe, expect, it } from "vitest";
+
+const DEEPSEEK_BASE = "https://api.deepseek.com/v1";
+
+describe("DeepSeek platform rule", () => {
+  it("matches api.deepseek.com with requestSanitize", () => {
+    const r = matchHostedToolRuleForBaseUrl(`${DEEPSEEK_BASE}/chat/completions`);
+    expect(r?.provider).toBe("deepseek");
+    expect(r?.requestSanitize).toBe("deepseek-chat-sanitize");
+  });
+});
+
+describe("normalizeDeepseekEffort", () => {
+  it("maps low, medium, minimal to high", () => {
+    expect(normalizeDeepseekEffort("low")).toBe("high");
+    expect(normalizeDeepseekEffort("medium")).toBe("high");
+    expect(normalizeDeepseekEffort("minimal")).toBe("high");
+  });
+
+  it("maps xhigh to max", () => {
+    expect(normalizeDeepseekEffort("xhigh")).toBe("max");
+  });
+
+  it("passes through high and max", () => {
+    expect(normalizeDeepseekEffort("high")).toBe("high");
+    expect(normalizeDeepseekEffort("max")).toBe("max");
+  });
+});
+
+describe("deepseekChatSanitize", () => {
+  it("no-ops when reasoning_effort is absent", () => {
+    const body: Record<string, unknown> = {
+      model: "deepseek-v4-pro",
+      messages: [],
+      temperature: 0.7,
+    };
+    deepseekChatSanitize(body);
+    expect(body).toEqual({
+      model: "deepseek-v4-pro",
+      messages: [],
+      temperature: 0.7,
+    });
+  });
+
+  it("no-ops when reasoning_effort is blank", () => {
+    const body: Record<string, unknown> = {
+      model: "deepseek-v4-pro",
+      reasoning_effort: "   ",
+      messages: [],
+    };
+    deepseekChatSanitize(body);
+    expect(body.reasoning_effort).toBe("   ");
+    expect(body.thinking).toBeUndefined();
+  });
+
+  it("sets thinking disabled and removes effort for none", () => {
+    const body: Record<string, unknown> = {
+      model: "deepseek-v4-pro",
+      reasoning_effort: "none",
+      messages: [],
+    };
+    deepseekChatSanitize(body);
+    expect(body.thinking).toEqual({ type: "disabled" });
+    expect(body.reasoning_effort).toBeUndefined();
+    expect(body.messages).toEqual([]);
+  });
+
+  it("enables thinking, normalizes effort, strips sampling fields", () => {
+    const body: Record<string, unknown> = {
+      model: "deepseek-v4-pro",
+      reasoning_effort: "medium",
+      messages: [{ role: "user", content: "hi" }],
+      temperature: 0.5,
+      top_p: 0.9,
+      presence_penalty: 0.1,
+      frequency_penalty: 0.2,
+    };
+    deepseekChatSanitize(body);
+    expect(body.thinking).toEqual({ type: "enabled" });
+    expect(body.reasoning_effort).toBe("high");
+    expect(body.temperature).toBeUndefined();
+    expect(body.top_p).toBeUndefined();
+    expect(body.presence_penalty).toBeUndefined();
+    expect(body.frequency_penalty).toBeUndefined();
+    expect(body.messages).toEqual([{ role: "user", content: "hi" }]);
+  });
+
+  it("maps xhigh to max when enabled", () => {
+    const body: Record<string, unknown> = {
+      model: "deepseek-v4-pro",
+      reasoning_effort: "xhigh",
+      messages: [],
+    };
+    deepseekChatSanitize(body);
+    expect(body.thinking).toEqual({ type: "enabled" });
+    expect(body.reasoning_effort).toBe("max");
+  });
+
+  it("preserves high and max", () => {
+    const highBody: Record<string, unknown> = {
+      model: "deepseek-v4-flash",
+      reasoning_effort: "high",
+      messages: [],
+    };
+    deepseekChatSanitize(highBody);
+    expect(highBody.reasoning_effort).toBe("high");
+
+    const maxBody: Record<string, unknown> = {
+      model: "deepseek-v4-flash",
+      reasoning_effort: "max",
+      messages: [],
+    };
+    deepseekChatSanitize(maxBody);
+    expect(maxBody.reasoning_effort).toBe("max");
+  });
+});
+
+describe("applyPlatformRequestSanitize (DeepSeek)", () => {
+  it("runs deepseek sanitizer for DeepSeek baseUrl", () => {
+    const body: Record<string, unknown> = {
+      model: "deepseek-v4-pro",
+      reasoning_effort: "low",
+      messages: [],
+      temperature: 1,
+    };
+    applyPlatformRequestSanitize(body, `${DEEPSEEK_BASE}/`);
+    expect(body.thinking).toEqual({ type: "enabled" });
+    expect(body.reasoning_effort).toBe("high");
+    expect(body.temperature).toBeUndefined();
+  });
+
+  it("does not mutate body for unrelated upstream", () => {
+    const body: Record<string, unknown> = {
+      model: "gpt-4",
+      reasoning_effort: "low",
+      temperature: 0.5,
+    };
+    applyPlatformRequestSanitize(body, "https://api.openai.com/v1");
+    expect(body.reasoning_effort).toBe("low");
+    expect(body.temperature).toBe(0.5);
+    expect(body.thinking).toBeUndefined();
+  });
+});

--- a/tests/unit/converter/platform-transforms/index.test.ts
+++ b/tests/unit/converter/platform-transforms/index.test.ts
@@ -128,6 +128,12 @@ describe("matchHostedToolRuleForBaseUrl", () => {
   it("does not match MiMo for other xiaomimimo.com hosts", () => {
     expect(matchHostedToolRuleForBaseUrl("https://staging.xiaomimimo.com/v1")).toBeUndefined();
   });
+
+  it("hits DeepSeek rule for api.deepseek.com", () => {
+    const r = matchHostedToolRuleForBaseUrl("https://api.deepseek.com/v1/chat/completions");
+    expect(r?.provider).toBe("deepseek");
+    expect(r?.requestSanitize).toBe("deepseek-chat-sanitize");
+  });
 });
 
 describe("normalizeToolForProvider", () => {

--- a/tests/unit/web/presets-display.test.ts
+++ b/tests/unit/web/presets-display.test.ts
@@ -24,6 +24,11 @@ describe("upstreamModelIdToDisplayName", () => {
   it("formats Gemini preview ids", () => {
     expect(upstreamModelIdToDisplayName("gemini-3.1-pro-preview")).toBe("Gemini 3.1 Pro Preview");
   });
+
+  it("formats DeepSeek model ids", () => {
+    expect(upstreamModelIdToDisplayName("deepseek-v4-pro")).toBe("DeepSeek V4 Pro");
+    expect(upstreamModelIdToDisplayName("deepseek-v4-flash")).toBe("DeepSeek V4 Flash");
+  });
 });
 
 describe("defaultModelIdsAsText", () => {

--- a/web/src/features/providers/wizard/presets.ts
+++ b/web/src/features/providers/wizard/presets.ts
@@ -7,6 +7,7 @@ const VENDOR_DISPLAY: Record<string, string> = {
   mimo: "MiMo",
   minimax: "MiniMax",
   gemini: "Gemini",
+  deepseek: "DeepSeek",
   claude: "Claude",
 };
 
@@ -348,6 +349,32 @@ export const PARTNER_PRESETS: readonly PartnerPreset[] = [
         urlTemplate: "{fixedBaseUrl}",
         idSuffix: "openai",
         nameSuffix: "",
+      },
+    ],
+  },
+  {
+    id: "deepseek",
+    nameKey: "wizard.brand.deepseek",
+    mode: "inject",
+    idPrefix: "deepseek",
+    namePrefix: "DeepSeek",
+    defaultModelIds: ["deepseek-v4-pro", "deepseek-v4-flash"],
+    defaultCustomModels: true,
+    fixedBaseUrl: "https://api.deepseek.com/v1",
+    options: [],
+    segmentRules: [],
+    variants: [
+      {
+        providerType: "openai_chat",
+        urlTemplate: "{fixedBaseUrl}",
+        idSuffix: "openai",
+        nameSuffix: "-OpenAI",
+      },
+      {
+        providerType: "anthropic",
+        urlTemplate: "https://api.deepseek.com/anthropic",
+        idSuffix: "anthropic",
+        nameSuffix: "-Anthropic",
       },
     ],
   },

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -258,7 +258,8 @@
       "xiaomi": "Xiaomi MiMo",
       "azure": "Azure OpenAI",
       "minimax": "MiniMax",
-      "geminiOpenai": "Gemini (OpenAI-compatible)"
+      "geminiOpenai": "Gemini (OpenAI-compatible)",
+      "deepseek": "DeepSeek"
     },
     "toggle": {
       "off": "No",

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -258,7 +258,8 @@
       "xiaomi": "小米 MiMo",
       "azure": "Azure OpenAI",
       "minimax": "MiniMax",
-      "geminiOpenai": "Gemini（OpenAI 兼容）"
+      "geminiOpenai": "Gemini（OpenAI 兼容）",
+      "deepseek": "DeepSeek（深度求索）"
     },
     "toggle": {
       "off": "否",


### PR DESCRIPTION
## Summary

Adds macOS **Developer ID Application** code signing and **Apple notarization** for both the Electron () and Tauri () desktop builds, aligned with the artale-director pattern.

## Changes

- **Electron:** Hardened runtime, entitlements plists, `notarize: true` in electron-builder; CI imports base64 `.p12` into a temp keychain and sets `CSC_IDENTITY_AUTO_DISCOVERY` + Apple notarization env vars.
- **Tauri:** `bundle.macOS` entitlements; CI passes `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID` for sign + notarize.
- **CI:** Reusable workflow declares optional Apple secrets; `build-dev-manual` uses `secrets: inherit`; post-build DMG checks + `codesign --verify` when signing ran.
- **Local:** `scripts/pack-mac-signed.sh` and `npm run desktop:pack:mac:signed`; `.gitignore` for `signing/` and `*.p12`.
- **Docs:** README / README_CN trimmed (removed long macOS signing section per follow-up).

## Required repo secrets (for signed CI builds)

`APPLE_CSC_LINK`, `APPLE_CSC_KEY_PASSWORD`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`, `APPLE_SIGNING_IDENTITY` (Tauri).

## Testing

- [ ] CI mac desktop + tauri matrix with secrets configured
- [ ] Unsigned CI path (no secrets) still acceptable for fork/dev (Electron may fail if `notarize: true` without credentials — confirm org policy)


Made with [Cursor](https://cursor.com)