### PR TITLE
macOS Tahoe proxy reliability, desktop networking, and persistent runtime logs

### DIFF
--- a/.github/workflows/build-dev-manual.yml
+++ b/.github/workflows/build-dev-manual.yml
@@ -64,4 +64,3 @@ jobs:
       suffix: ${{ needs.prepare.outputs.suffix }}
       skip_tests: ${{ inputs.skip_tests }}
     secrets: inherit
-    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+**Diagnostics**
+
+- Runtime messages (startup, configuration, proxy lifecycle, errors) are appended to dated log files under `~/.ccrelay/logs/`; files rotate daily and older ones are removed after about a week. This is separate from dashboard **request** history stored in the logging database.
+
+**Desktop**
+
+- Tray: **Open Logs Folder** (Electron and Tauri) opens `~/.ccrelay/logs/` in the system file manager.
+
+**VS Code**
+
+- **CCRelay: Open Logs Folder** command opens the same runtime log folder.
+
 ### Fixed
 
 **Desktop**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+**Desktop**
+
+- macOS Tahoe (26): Electron and Tauri signed builds include local-network usage text and networking entitlements so the app can bind the relay and reach upstreams without spurious permission or connectivity failures.
+
+**Proxy**
+
+- macOS Tahoe (26): long proxy waits and streaming responses no longer drop after a few seconds when using the desktop apps or the VS Code extension.
+
 ## [0.2.4] - 2026-05-13 (pre-release)
 
 Pre-release line for 0.2.4.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,7 +17,7 @@ export { setWebDistPath } from "./server/static";
 export { getUiAccessToken } from "./server/httpAccessGate";
 export { CCRELAY_UI_HEADER_NAME, CCRELAY_UI_HEADER_VALUE } from "./server/internalUiHeaders";
 
-export { Logger, ScopedLogger, LogLevel } from "./utils/logger";
+export { Logger, ScopedLogger, LogLevel, getLogDir } from "./utils/logger";
 
 export * as Api from "./api/index";
 

--- a/packages/core/src/server/handler.ts
+++ b/packages/core/src/server/handler.ts
@@ -509,6 +509,11 @@ export class ProxyServer {
         this.handleRequest(req, res);
       });
 
+      // Node defaults include keepAliveTimeout=5000ms, which can drop SSE / slow-upstream
+      // client connections while waiting for the first upstream byte (notably on macOS 26).
+      this.server.timeout = 0;
+      this.server.keepAliveTimeout = 0;
+
       const host = this.config.host;
       const port = this.config.port;
 

--- a/packages/core/src/server/proxy/executor.ts
+++ b/packages/core/src/server/proxy/executor.ts
@@ -93,6 +93,22 @@ const EXCLUDED_HEADERS = new Set([
 const RETRYABLE_CODES = ["ECONNREFUSED", "ECONNRESET", "ENOTFOUND", "ETIMEDOUT"];
 
 /**
+ * Dedicated upstream agents avoid Node/Electron globalAgent defaults (notably short idle
+ * timeouts on some macOS 26 + Electron combinations) and keep long-lived LLM streams stable.
+ */
+const upstreamHttpProxyAgent = new http.Agent({
+  keepAlive: true,
+  keepAliveMsecs: 30_000,
+  timeout: 0,
+});
+
+const upstreamHttpsProxyAgent = new https.Agent({
+  keepAlive: true,
+  keepAliveMsecs: 30_000,
+  timeout: 0,
+});
+
+/**
  * Context for tracking request execution state
  */
 interface ExecutionContext {
@@ -292,6 +308,7 @@ export class ProxyExecutor {
       method,
       headers: requestHeaders,
       signal: abortSignal,
+      agent: isHttps ? upstreamHttpsProxyAgent : upstreamHttpProxyAgent,
     };
 
     const ctx: ExecutionContext = {

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -3,6 +3,10 @@
  * Supports both VSCode environment and Worker threads
  */
 
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
 // Check if vscode is available (not available in worker threads)
 let vscode: typeof import("vscode") | null = null;
 try {
@@ -41,6 +45,114 @@ const LOG_LEVEL_MAP: Record<string, LogLevel> = {
   ERROR: LogLevel.ERROR,
 };
 
+/** Retention for daily runtime log files under {@link getLogDir} (UTC calendar days). */
+const RUNTIME_LOG_RETENTION_DAYS = 7;
+
+function utcDateString(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Directory for CCRelay **runtime** text logs (`ccrelay-YYYY-MM-DD.log`).
+ * This is separate from `~/.ccrelay/logs.db`, which stores proxied **request/response** rows for the dashboard.
+ */
+export function getLogDir(): string {
+  return path.join(os.homedir(), ".ccrelay", "logs");
+}
+
+function isNodeMainThread(): boolean {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const wt = require("worker_threads") as typeof import("worker_threads");
+    return wt.isMainThread;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Append-only daily log files with rotation (UTC) and old-file cleanup.
+ * Disabled in Node worker threads to avoid concurrent writers on the same files.
+ */
+class FileTransport {
+  private stream: fs.WriteStream | null = null;
+  private currentDate = "";
+  private readonly logDir = getLogDir();
+  private writeFailedLogged = false;
+
+  write(line: string): void {
+    try {
+      this.ensureStream();
+      if (this.stream && !this.stream.destroyed) {
+        this.stream.write(`${line}\n`, err => {
+          if (err && !this.writeFailedLogged) {
+            this.writeFailedLogged = true;
+            console.error("[CCRelay] File log write failed:", err.message);
+          }
+        });
+      }
+    } catch (e) {
+      if (!this.writeFailedLogged) {
+        this.writeFailedLogged = true;
+        console.error("[CCRelay] File log transport error:", e);
+      }
+    }
+  }
+
+  private ensureStream(): void {
+    const today = utcDateString(new Date());
+    if (this.stream && !this.stream.destroyed && today === this.currentDate) {
+      return;
+    }
+
+    fs.mkdirSync(this.logDir, { recursive: true });
+    this.cleanupOldLogs();
+
+    if (this.stream && !this.stream.destroyed) {
+      this.stream.end();
+    }
+
+    this.currentDate = today;
+    const filePath = path.join(this.logDir, `ccrelay-${today}.log`);
+    this.stream = fs.createWriteStream(filePath, { flags: "a" });
+  }
+
+  private cleanupOldLogs(): void {
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(this.logDir);
+    } catch {
+      return;
+    }
+
+    const cutoff = new Date();
+    cutoff.setUTCDate(cutoff.getUTCDate() - RUNTIME_LOG_RETENTION_DAYS);
+    const cutoffStr = utcDateString(cutoff);
+
+    for (const name of entries) {
+      const m = /^ccrelay-(\d{4}-\d{2}-\d{2})\.log$/.exec(name);
+      if (!m) {
+        continue;
+      }
+      const fileDay = m[1];
+      if (fileDay < cutoffStr) {
+        try {
+          fs.unlinkSync(path.join(this.logDir, name));
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  }
+
+  dispose(): void {
+    if (this.stream && !this.stream.destroyed) {
+      this.stream.end();
+    }
+    this.stream = null;
+  }
+}
+
 // Type definition for build config
 interface BuildConfig {
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -76,8 +188,11 @@ export class Logger {
   private minLevel: LogLevel = getDefaultLogLevel();
 
   private isDisposed: boolean = false;
+  private readonly fileTransport: FileTransport | null;
 
   private constructor() {
+    this.fileTransport = isNodeMainThread() ? new FileTransport() : null;
+
     if (vscode) {
       try {
         this.outputChannel = vscode.window.createOutputChannel("CCRelay");
@@ -117,6 +232,8 @@ export class Logger {
     if (this.logBuffer.length > this.maxBufferSize) {
       this.logBuffer.shift();
     }
+
+    this.fileTransport?.write(formatted);
 
     // Output to VSCode channel or console (for worker threads)
     if (this.outputChannel && !this.isDisposed) {
@@ -212,6 +329,7 @@ export class Logger {
 
   dispose(): void {
     this.isDisposed = true;
+    this.fileTransport?.dispose();
     if (this.outputChannel) {
       try {
         this.outputChannel.dispose();

--- a/packages/desktop-tauri/src-tauri/Cargo.lock
+++ b/packages/desktop-tauri/src-tauri/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "ccrelay"
-version = "0.2.1"
+version = "0.2.4"
 dependencies = [
  "serde",
  "serde_json",

--- a/packages/desktop-tauri/src-tauri/Info.plist
+++ b/packages/desktop-tauri/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>CCRelay needs local network access to proxy API requests between your IDE and AI services.</string>
+</dict>
+</plist>

--- a/packages/desktop-tauri/src-tauri/entitlements.plist
+++ b/packages/desktop-tauri/src-tauri/entitlements.plist
@@ -8,5 +8,9 @@
   <true/>
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+  <key>com.apple.security.network.server</key>
+  <true/>
 </dict>
 </plist>

--- a/packages/desktop-tauri/src-tauri/src/tray.rs
+++ b/packages/desktop-tauri/src-tauri/src/tray.rs
@@ -1,8 +1,9 @@
+use std::path::PathBuf;
 use std::sync::Mutex;
 use tauri::{
     menu::{MenuBuilder, MenuItem, PredefinedMenuItem},
     tray::{TrayIcon, TrayIconBuilder},
-    AppHandle, Manager,
+    AppHandle,
 };
 
 use crate::sidecar;
@@ -10,7 +11,33 @@ use crate::sidecar;
 const MENU_SHOW: &str = "show";
 const MENU_START: &str = "start";
 const MENU_STOP: &str = "stop";
+const MENU_LOGS: &str = "logs";
 const MENU_QUIT: &str = "quit";
+
+fn runtime_logs_dir() -> PathBuf {
+    let home = if cfg!(windows) {
+        std::env::var("USERPROFILE").unwrap_or_default()
+    } else {
+        std::env::var("HOME").unwrap_or_default()
+    };
+    PathBuf::from(home).join(".ccrelay").join("logs")
+}
+
+fn open_runtime_logs_folder() {
+    let dir = runtime_logs_dir();
+    #[cfg(target_os = "macos")]
+    {
+        let _ = std::process::Command::new("open").arg(&dir).status();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let _ = std::process::Command::new("explorer").arg(&dir).status();
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        let _ = std::process::Command::new("xdg-open").arg(&dir).status();
+    }
+}
 
 /// Stored menu items for runtime state updates
 pub struct TrayMenuState {
@@ -22,11 +49,12 @@ pub fn create_tray(app: &tauri::App) -> Result<TrayIcon, Box<dyn std::error::Err
     let show = MenuItem::with_id(app, MENU_SHOW, "Open Dashboard", true, None::<&str>)?;
     let start = MenuItem::with_id(app, MENU_START, "Start Server", true, None::<&str>)?;
     let stop = MenuItem::with_id(app, MENU_STOP, "Stop Server", false, None::<&str>)?;
+    let logs = MenuItem::with_id(app, MENU_LOGS, "Open Logs Folder", true, None::<&str>)?;
     let sep = PredefinedMenuItem::separator(app)?;
     let quit = MenuItem::with_id(app, MENU_QUIT, "Quit CCRelay", true, None::<&str>)?;
 
     let menu = MenuBuilder::new(app)
-        .items(&[&show, &start, &stop, &sep, &quit])
+        .items(&[&show, &start, &stop, &logs, &sep, &quit])
         .build()?;
 
     app.manage(Mutex::new(TrayMenuState {
@@ -55,6 +83,9 @@ pub fn create_tray(app: &tauri::App) -> Result<TrayIcon, Box<dyn std::error::Err
                 if let Err(e) = sidecar::stop_server(app) {
                     eprintln!("Failed to stop server: {e}");
                 }
+            }
+            MENU_LOGS => {
+                open_runtime_logs_folder();
             }
             MENU_QUIT => {
                 let _ = sidecar::stop_server(app);

--- a/packages/desktop-tauri/src-tauri/tauri.conf.json
+++ b/packages/desktop-tauri/src-tauri/tauri.conf.json
@@ -38,6 +38,7 @@
     },
     "macOS": {
       "entitlements": "entitlements.plist",
+      "infoPlist": "Info.plist",
       "signingIdentity": null,
       "minimumSystemVersion": "10.13"
     }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -59,6 +59,9 @@
       "out/database-worker.cjs"
     ],
     "mac": {
+      "extendInfo": {
+        "NSLocalNetworkUsageDescription": "CCRelay needs local network access to proxy API requests between your IDE and AI services."
+      },
       "category": "public.app-category.developer-tools",
       "target": [
         "dmg"

--- a/packages/desktop/packaging/entitlements.mac.inherit.plist
+++ b/packages/desktop/packaging/entitlements.mac.inherit.plist
@@ -8,5 +8,9 @@
   <true/>
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+  <key>com.apple.security.network.server</key>
+  <true/>
 </dict>
 </plist>

--- a/packages/desktop/packaging/entitlements.mac.plist
+++ b/packages/desktop/packaging/entitlements.mac.plist
@@ -8,5 +8,9 @@
   <true/>
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+  <key>com.apple.security.network.server</key>
+  <true/>
 </dict>
 </plist>

--- a/packages/desktop/src/tray.ts
+++ b/packages/desktop/src/tray.ts
@@ -4,7 +4,7 @@
 
 import { Tray, Menu, shell, nativeImage, app } from "electron";
 import * as path from "path";
-import type { ProxyServer, ConfigManager } from "@ccrelay/core";
+import { getLogDir, type ConfigManager, type ProxyServer } from "@ccrelay/core";
 import { setOpenAtLogin, getOpenAtLogin } from "./autoLaunch";
 import { dashboardWebUrl, showDashboardWindow } from "./window";
 
@@ -101,6 +101,12 @@ export function createTray(server: ProxyServer, config: ConfigManager): Tray {
         label: "Open Config File",
         click: (): void => {
           void shell.openPath(config.getConfigPath());
+        },
+      },
+      {
+        label: "Open Logs Folder",
+        click: (): void => {
+          void shell.openPath(getLogDir());
         },
       },
       { type: "separator" },

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -47,6 +47,10 @@
         "title": "CCRelay: Open Config File"
       },
       {
+        "command": "ccrelay.exportLogs",
+        "title": "CCRelay: Open Logs Folder"
+      },
+      {
         "command": "ccrelay.showLogs",
         "title": "CCRelay: Show Logs",
         "icon": "$(output)"

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -5,6 +5,7 @@ import {
   BUILD_HASH,
   BUILD_VERSION,
   ConfigManager,
+  getLogDir,
   GIT_HASH,
   LeaderElection,
   Logger,
@@ -124,6 +125,15 @@ export function activate(context: vscode.ExtensionContext) {
     }
   });
 
+  const exportLogsCommand = vscode.commands.registerCommand("ccrelay.exportLogs", async () => {
+    const logDir = getLogDir();
+    const uri = vscode.Uri.file(logDir);
+    const ok = await vscode.env.openExternal(uri);
+    if (!ok) {
+      vscode.window.showErrorMessage(`Could not open logs folder: ${logDir}`);
+    }
+  });
+
   const showLogsCommand = vscode.commands.registerCommand("ccrelay.showLogs", () => {
     logger?.show();
   });
@@ -160,6 +170,7 @@ export function activate(context: vscode.ExtensionContext) {
     startServerCommand,
     stopServerCommand,
     openSettingsCommand,
+    exportLogsCommand,
     showLogsCommand,
     clearLogsCommand,
     openWebUICommand,


### PR DESCRIPTION
## Summary

- **macOS Tahoe (26):** Harden the proxy and desktop shells so long waits and streaming responses stay connected; add local-network usage text and client/server networking entitlements where signing requires them.
- **Diagnostics:** Persist runtime log lines to dated files under `~/.ccrelay/logs/` with automatic rotation and retention; tray (Electron and Tauri) and VS Code expose **Open Logs Folder** for quick access.
- **CI:** Remove a duplicate `secrets: inherit` entry from the manual dev build workflow so the file stays valid YAML.

## Test plan

- [ ] `npm run test:all` on CI (or locally before merge)
- [ ] macOS Tahoe: run a long SSE or slow-first-byte proxy request from VS Code or desktop; confirm the stream is not cut off after a few seconds
- [ ] macOS: signed Electron/Tauri build can bind the relay and reach upstreams without spurious local-network prompts or failures
- [ ] After some activity, confirm `~/.ccrelay/logs/ccrelay-*.log` exists and tray / **CCRelay: Open Logs Folder** opens the folder in the file manager


Made with [Cursor](https://cursor.com)