### PR TITLE
fix(tauri): restore Manager import and rustfmt sidecar

### DIFF
--- a/packages/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/packages/desktop-tauri/src-tauri/src/sidecar.rs
@@ -62,11 +62,9 @@ pub async fn start_server(app: &AppHandle) -> Result<(), String> {
                     }
                 }
                 // Once we have port, host, and token — server is fully ready
-                if let (Some(port), Some(host), Some(token)) = (
-                    port_found,
-                    host_found.clone(),
-                    token_found.clone(),
-                ) {
+                if let (Some(port), Some(host), Some(token)) =
+                    (port_found, host_found.clone(), token_found.clone())
+                {
                     let state = app.state::<Mutex<SidecarState>>();
                     if let Ok(mut s) = state.lock() {
                         s.port = Some(port);
@@ -120,7 +118,9 @@ pub fn stop_server(app: &AppHandle) -> Result<(), String> {
     let mut s = state.lock().map_err(|e| e.to_string())?;
     let was_leader = s.is_leader;
     if let Some(child) = s.child.take() {
-        child.kill().map_err(|e| format!("Failed to kill sidecar: {e}"))?;
+        child
+            .kill()
+            .map_err(|e| format!("Failed to kill sidecar: {e}"))?;
     }
     s.port = None;
     s.host = None;

--- a/packages/desktop-tauri/src-tauri/src/tray.rs
+++ b/packages/desktop-tauri/src-tauri/src/tray.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 use tauri::{
     menu::{MenuBuilder, MenuItem, PredefinedMenuItem},
     tray::{TrayIcon, TrayIconBuilder},
-    AppHandle,
+    AppHandle, Manager,
 };
 
 use crate::sidecar;


### PR DESCRIPTION
## Summary

- Restore the `Manager` trait import in the Tauri tray module so `app.manage()` / `app.state()` compile in CI (`npx tauri build`).
- Apply `rustfmt` to `sidecar.rs` so formatting matches the rest of the crate.

## Test plan

- [ ] CI Tauri matrix builds succeed for macOS targets
- [ ] Optional: local `cargo fmt --check` in `packages/desktop-tauri/src-tauri`


Made with [Cursor](https://cursor.com)