### PR TITLE
feat: add Astraflow (UCloud) provider preset

### DIFF
--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -24,6 +24,16 @@ providers:
     providerType: "anthropic"   # anthropic | openai | openai_chat
     enabled: true
 
+  # Example: Astraflow (UCloud) — OpenAI-compatible, 200+ models
+  # astraflow:
+  #   name: "Astraflow Global"
+  #   baseUrl: "https://api-us-ca.umodelverse.ai/v1"   # China: https://api.modelverse.cn/v1
+  #   mode: "inject"
+  #   providerType: "openai_chat"
+  #   apiKey: "\${ASTRAFLOW_API_KEY}"                  # China: \${ASTRAFLOW_CN_API_KEY}
+  #   authHeader: "authorization"
+  #   enabled: true
+
   # Example: Custom provider
   # custom:
   #   name: "Custom Provider"

--- a/web/src/features/providers/wizard/presets.ts
+++ b/web/src/features/providers/wizard/presets.ts
@@ -353,6 +353,54 @@ export const PARTNER_PRESETS: readonly PartnerPreset[] = [
     ],
   },
   {
+    id: "astraflow",
+    nameKey: "wizard.brand.astraflow",
+    mode: "inject",
+    idPrefix: "astraflow",
+    namePrefix: "Astraflow",
+    defaultModelIds: [],
+    defaultCustomModels: true,
+    authHeader: "authorization",
+    options: [
+      {
+        key: "region",
+        label: "wizard.option.region",
+        type: "select",
+        options: [
+          { value: "intl", label: "wizard.region.international" },
+          { value: "cn", label: "wizard.region.china" },
+        ],
+        defaultValue: "intl",
+      },
+    ],
+    segmentRules: [
+      {
+        segmentKey: "regionHost",
+        fromOption: "region",
+        map: {
+          intl: "https://api-us-ca.umodelverse.ai",
+          cn: "https://api.modelverse.cn",
+        },
+      },
+      {
+        segmentKey: "regionTag",
+        fromOption: "region",
+        map: {
+          intl: "intl",
+          cn: "cn",
+        },
+      },
+    ],
+    variants: [
+      {
+        providerType: "openai_chat",
+        urlTemplate: "{regionHost}/v1",
+        idSuffix: "{regionTag}-openai",
+        nameSuffix: "{regionTag}-OpenAI",
+      },
+    ],
+  },
+  {
     id: "deepseek",
     nameKey: "wizard.brand.deepseek",
     mode: "inject",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -259,7 +259,8 @@
       "azure": "Azure OpenAI",
       "minimax": "MiniMax",
       "geminiOpenai": "Gemini (OpenAI-compatible)",
-      "deepseek": "DeepSeek"
+      "deepseek": "DeepSeek",
+      "astraflow": "Astraflow (UCloud)"
     },
     "toggle": {
       "off": "No",

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -259,7 +259,8 @@
       "azure": "Azure OpenAI",
       "minimax": "MiniMax",
       "geminiOpenai": "Gemini（OpenAI 兼容）",
-      "deepseek": "DeepSeek（深度求索）"
+      "deepseek": "DeepSeek（深度求索）",
+      "astraflow": "Astraflow（优刻得）"
     },
     "toggle": {
       "off": "否",


### PR DESCRIPTION
## Summary

Adds **Astraflow by UCloud** as a partner preset in the provider wizard, alongside an example entry in the default config YAML.

### What is Astraflow?
Astraflow (优刻得) is an OpenAI-compatible AI model aggregation platform supporting 200+ models. It has two regional endpoints:
- **Global**: `https://api-us-ca.umodelverse.ai/v1` — API key env: `ASTRAFLOW_API_KEY`
- **China**: `https://api.modelverse.cn/v1` — API key env: `ASTRAFLOW_CN_API_KEY`

Because Astraflow is fully OpenAI Chat–compatible, the integration only needs a `baseUrl` + `apiKey`; no new SDK or sub-package is required.

### Changes
| File | What changed |
|---|---|
| `web/src/features/providers/wizard/presets.ts` | New `astraflow` entry in `PARTNER_PRESETS` with global/China region selector |
| `web/src/i18n/en.json` | English brand label `"astraflow"` |
| `web/src/i18n/zh.json` | Chinese brand label `"astraflow"` |
| `packages/core/src/config/defaults.ts` | Commented example Astraflow provider block in `DEFAULT_CONFIG_YAML` |
