### PR TITLE
feat(clientConfig): add Claude Desktop configuration support

### DIFF
--- a/packages/core/src/api/clientConfig.ts
+++ b/packages/core/src/api/clientConfig.ts
@@ -3,6 +3,7 @@
  * GET/POST /ccrelay/api/client-config
  */
 
+import * as crypto from "crypto";
 import * as fs from "fs";
 import * as http from "http";
 import * as os from "os";
@@ -41,6 +42,17 @@ export function setServer(server: ProxyServer | null): void {
 const CLAUDE_SETTINGS = () => path.join(os.homedir(), ".claude", "settings.json");
 const CODEX_CONFIG = () => path.join(os.homedir(), ".codex", "config.toml");
 
+function claudeDesktopDir(): string | null {
+  const p = os.platform();
+  if (p === "darwin") {
+    return path.join(os.homedir(), "Library", "Application Support", "Claude-3p");
+  }
+  if (p === "win32") {
+    return path.join(os.homedir(), "AppData", "Local", "Claude-3p");
+  }
+  return null;
+}
+
 export type ClientConfigItemStatus = "ok" | "missing" | "wrong_target" | "invalid";
 
 export interface ClientConfigItem {
@@ -68,6 +80,7 @@ export interface ClientConfigGetResponse {
   port: number;
   claudeCode: ClientConfigItem;
   codex: ClientConfigItem;
+  claudeDesktop: ClientConfigItem | null;
   /** Parsed from settings.json env when file is readable */
   claudeDefaultModels: ClaudeDefaultModels;
 }
@@ -274,6 +287,64 @@ function detectCodex(codexPath: string, port: number): ClientConfigItem {
   return { status: "wrong_target", filePath, currentValue: baseUrl, modelProvider, model };
 }
 
+interface ClaudeDesktopMeta {
+  appliedId: string;
+  entries: Array<{ id: string; name: string }>;
+}
+
+function readClaudeDesktopMeta(dir: string): ClaudeDesktopMeta | null {
+  const metaPath = path.join(dir, "configLibrary", "_meta.json");
+  if (!fs.existsSync(metaPath)) {
+    return null;
+  }
+  try {
+    const raw = fs.readFileSync(metaPath, "utf-8");
+    const parsed = JSON.parse(raw) as ClaudeDesktopMeta;
+    if (typeof parsed.appliedId === "string" && parsed.appliedId.trim()) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function detectClaudeDesktop(dir: string | null, port: number): ClientConfigItem | null {
+  if (!dir) {
+    return null;
+  }
+  const filePath = path.join(dir, "configLibrary");
+  if (!fs.existsSync(dir)) {
+    return { status: "missing", filePath };
+  }
+  const meta = readClaudeDesktopMeta(dir);
+  if (!meta) {
+    return { status: "missing", filePath: path.join(filePath, "_meta.json") };
+  }
+  const configPath = path.join(filePath, `${meta.appliedId}.json`);
+  if (!fs.existsSync(configPath)) {
+    return { status: "missing", filePath: configPath };
+  }
+  try {
+    const raw = fs.readFileSync(configPath, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const baseUrl = parsed.inferenceGatewayBaseUrl;
+    if (typeof baseUrl !== "string" || !baseUrl.trim()) {
+      return {
+        status: "missing",
+        filePath: configPath,
+        message: "inferenceGatewayBaseUrl not set",
+      };
+    }
+    if (isLocalProxyAnthropicBase(baseUrl.trim(), port)) {
+      return { status: "ok", filePath: configPath, currentValue: baseUrl.trim() };
+    }
+    return { status: "wrong_target", filePath: configPath, currentValue: baseUrl.trim() };
+  } catch {
+    return { status: "invalid", filePath: configPath, message: "Invalid JSON" };
+  }
+}
+
 /**
  * GET /ccrelay/api/client-config
  */
@@ -292,12 +363,13 @@ export function handleGetClientConfig(_req: http.IncomingMessage, res: http.Serv
     port,
     claudeCode: detectClaude(claudePath, port),
     codex: detectCodex(CODEX_CONFIG(), port),
+    claudeDesktop: detectClaudeDesktop(claudeDesktopDir(), port),
     claudeDefaultModels: readClaudeDefaultModelsFromFile(claudePath),
   };
   sendJson(res, 200, body);
 }
 
-type ApplyTarget = "claudeCode" | "codex";
+type ApplyTarget = "claudeCode" | "codex" | "claudeDesktop";
 
 /**
  * POST /ccrelay/api/client-config/apply
@@ -329,8 +401,11 @@ export async function handleApplyClientConfig(
     }>(req);
     const target = body.target;
     const overwrite = Boolean(body.overwrite);
-    if (target !== "claudeCode" && target !== "codex") {
-      sendJson(res, 400, { status: "error", message: "target must be claudeCode or codex" });
+    if (target !== "claudeCode" && target !== "codex" && target !== "claudeDesktop") {
+      sendJson(res, 400, {
+        status: "error",
+        message: "target must be claudeCode, codex, or claudeDesktop",
+      });
       return;
     }
 
@@ -411,6 +486,49 @@ export async function handleApplyClientConfig(
         sendJson(res, 200, {
           status: "ok",
           message: `Removed CCRelay provider from ${codexPath}`,
+        });
+        return;
+      }
+
+      if (target === "claudeDesktop") {
+        const dir = claudeDesktopDir();
+        if (!dir || !fs.existsSync(dir)) {
+          sendJson(res, 200, { status: "ok", message: "No Claude-3p directory to clean up" });
+          return;
+        }
+        const meta = readClaudeDesktopMeta(dir);
+        if (meta) {
+          const configPath = path.join(dir, "configLibrary", `${meta.appliedId}.json`);
+          if (fs.existsSync(configPath)) {
+            fs.unlinkSync(configPath);
+          }
+          const metaPath = path.join(dir, "configLibrary", "_meta.json");
+          if (fs.existsSync(metaPath)) {
+            fs.unlinkSync(metaPath);
+          }
+        }
+        // Change deploymentMode from "3p" back to "1p"
+        const desktopConfigPath = path.join(dir, "claude_desktop_config.json");
+        if (fs.existsSync(desktopConfigPath)) {
+          try {
+            const cfg = JSON.parse(fs.readFileSync(desktopConfigPath, "utf-8")) as Record<
+              string,
+              unknown
+            >;
+            cfg.deploymentMode = "1p";
+            fs.writeFileSync(desktopConfigPath, `${JSON.stringify(cfg, null, 2)}\n`, "utf-8");
+          } catch {
+            // ignore invalid JSON
+          }
+        }
+        // Remove developer_settings.json
+        const devSettingsPath = path.join(dir, "developer_settings.json");
+        if (fs.existsSync(devSettingsPath)) {
+          fs.unlinkSync(devSettingsPath);
+        }
+        sendJson(res, 200, {
+          status: "ok",
+          message: `Removed CCRelay config from ${dir}`,
         });
         return;
       }
@@ -539,6 +657,112 @@ export async function handleApplyClientConfig(
           : CODEX_DEFAULT_MODEL;
       fs.writeFileSync(codexPath, buildCodexTemplate(port, codexModel), "utf-8");
       sendJson(res, 200, { status: "ok", message: `Updated ${codexPath}` });
+      return;
+    }
+
+    if (target === "claudeDesktop") {
+      const dir = claudeDesktopDir();
+      if (!dir) {
+        sendJson(res, 400, {
+          status: "error",
+          message: "Claude Desktop configuration is not supported on this platform.",
+        });
+        return;
+      }
+      const existing = detectClaudeDesktop(dir, port);
+      if (
+        existing &&
+        (existing.status === "wrong_target" || existing.status === "invalid") &&
+        !overwrite
+      ) {
+        sendJson(res, 409, {
+          status: "error",
+          code: "NEEDS_OVERWRITE",
+          message:
+            existing.status === "invalid"
+              ? "Claude Desktop config file is not valid JSON. Confirm overwrite."
+              : "Claude Desktop config points to a different base URL. Confirm overwrite.",
+        });
+        return;
+      }
+
+      const configLibDir = path.join(dir, "configLibrary");
+      if (!fs.existsSync(configLibDir)) {
+        fs.mkdirSync(configLibDir, { recursive: true });
+      }
+
+      // 1. developer_settings.json — merge
+      /* eslint-disable @typescript-eslint/naming-convention -- Claude Desktop settings keys */
+      const devSettingsPath = path.join(dir, "developer_settings.json");
+      let devSettings: Record<string, unknown> = {};
+      if (fs.existsSync(devSettingsPath)) {
+        try {
+          devSettings = JSON.parse(fs.readFileSync(devSettingsPath, "utf-8")) as Record<
+            string,
+            unknown
+          >;
+        } catch {
+          devSettings = {};
+        }
+      }
+      devSettings.allowDevTools = true;
+      fs.writeFileSync(devSettingsPath, `${JSON.stringify(devSettings, null, 2)}\n`, "utf-8");
+
+      // 2. claude_desktop_config.json — merge
+      const desktopConfigPath = path.join(dir, "claude_desktop_config.json");
+      let desktopConfig: Record<string, unknown> = {};
+      if (fs.existsSync(desktopConfigPath)) {
+        try {
+          desktopConfig = JSON.parse(fs.readFileSync(desktopConfigPath, "utf-8")) as Record<
+            string,
+            unknown
+          >;
+        } catch {
+          desktopConfig = {};
+        }
+      }
+      desktopConfig.deploymentMode = "3p";
+      fs.writeFileSync(desktopConfigPath, `${JSON.stringify(desktopConfig, null, 2)}\n`, "utf-8");
+
+      // 3. configLibrary/_meta.json — reuse existing appliedId or generate new one
+      const metaPath = path.join(configLibDir, "_meta.json");
+      const existingMeta = readClaudeDesktopMeta(dir);
+      const appliedId = existingMeta?.appliedId ?? crypto.randomUUID();
+      const meta = {
+        appliedId,
+        entries: [
+          {
+            id: appliedId,
+            name: "CCRelay",
+          },
+        ],
+      };
+      fs.writeFileSync(metaPath, `${JSON.stringify(meta, null, 2)}\n`, "utf-8");
+
+      // 4. configLibrary/{appliedId}.json — merge
+      const configPath = path.join(configLibDir, `${appliedId}.json`);
+      let ccConfig: Record<string, unknown> = {};
+      if (fs.existsSync(configPath)) {
+        try {
+          ccConfig = JSON.parse(fs.readFileSync(configPath, "utf-8")) as Record<string, unknown>;
+        } catch {
+          ccConfig = {};
+        }
+      }
+      ccConfig.coworkEgressAllowedHosts = ["*"];
+      ccConfig.disableDeploymentModeChooser = true;
+      ccConfig.inferenceProvider = "gateway";
+      ccConfig.inferenceGatewayBaseUrl = `http://127.0.0.1:${port}/anthropic`;
+      ccConfig.inferenceGatewayApiKey = "1";
+      ccConfig.inferenceGatewayHeaders = {
+        "x-ccrelay-model-alias": "1",
+      };
+      ccConfig.disableEssentialTelemetry = true;
+      ccConfig.disableNonessentialTelemetry = true;
+      /* eslint-enable @typescript-eslint/naming-convention */
+      fs.writeFileSync(configPath, `${JSON.stringify(ccConfig, null, 2)}\n`, "utf-8");
+
+      sendJson(res, 200, { status: "ok", message: `Updated Claude Desktop config in ${dir}` });
     }
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -181,7 +181,7 @@ export const api = {
     fetchAPI<ClientConfigGetResponse>("/client-config"),
 
   applyClientConfig: async (body: {
-    target: "claudeCode" | "codex";
+    target: "claudeCode" | "codex" | "claudeDesktop";
     overwrite?: boolean;
     model?: string;
     restore?: boolean;

--- a/web/src/features/dashboard/ClientConfigStatus.tsx
+++ b/web/src/features/dashboard/ClientConfigStatus.tsx
@@ -1,7 +1,15 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { FileCode2, Loader2, RotateCcw, SlidersHorizontal, Terminal, X } from "lucide-react";
+import {
+  FileCode2,
+  Loader2,
+  Monitor,
+  RotateCcw,
+  SlidersHorizontal,
+  Terminal,
+  X,
+} from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -58,8 +66,12 @@ export default function ClientConfigStatus() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const [pendingTarget, setPendingTarget] = useState<"claudeCode" | "codex" | null>(null);
-  const [applyingTo, setApplyingTo] = useState<"claudeCode" | "codex" | null>(null);
+  const [pendingTarget, setPendingTarget] = useState<
+    "claudeCode" | "codex" | "claudeDesktop" | null
+  >(null);
+  const [applyingTo, setApplyingTo] = useState<"claudeCode" | "codex" | "claudeDesktop" | null>(
+    null
+  );
   const [modelModalOpen, setModelModalOpen] = useState(false);
   const [opus, setOpus] = useState("");
   const [sonnet, setSonnet] = useState("");
@@ -68,7 +80,9 @@ export default function ClientConfigStatus() {
   const [codexModalMode, setCodexModalMode] = useState<"apply" | "configure">("apply");
   const [codexModel, setCodexModel] = useState("");
   const [pendingCodexModel, setPendingCodexModel] = useState<string | undefined>(undefined);
-  const [restoreTarget, setRestoreTarget] = useState<"claudeCode" | "codex" | null>(null);
+  const [restoreTarget, setRestoreTarget] = useState<
+    "claudeCode" | "codex" | "claudeDesktop" | null
+  >(null);
   const [restoreConfirmOpen, setRestoreConfirmOpen] = useState(false);
 
   const { data, isLoading } = useQuery({
@@ -78,7 +92,7 @@ export default function ClientConfigStatus() {
   });
 
   const applyMutation = useMutation({
-    mutationFn: (args: { target: "claudeCode" | "codex"; overwrite: boolean }) =>
+    mutationFn: (args: { target: "claudeCode" | "codex" | "claudeDesktop"; overwrite: boolean }) =>
       api.applyClientConfig(args),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["clientConfig"] });
@@ -117,7 +131,7 @@ export default function ClientConfigStatus() {
   });
 
   const restoreMutation = useMutation({
-    mutationFn: (target: "claudeCode" | "codex") =>
+    mutationFn: (target: "claudeCode" | "codex" | "claudeDesktop") =>
       api.applyClientConfig({ target, restore: true }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["clientConfig"] });
@@ -129,13 +143,22 @@ export default function ClientConfigStatus() {
     },
   });
 
-  const runApply = (target: "claudeCode" | "codex", overwrite: boolean, model?: string) => {
+  const runApply = (
+    target: "claudeCode" | "codex" | "claudeDesktop",
+    overwrite: boolean,
+    model?: string
+  ) => {
     setApplyingTo(target);
     applyMutation.mutate({ target, overwrite, ...(model ? { model } : {}) });
   };
 
-  const onConfigureClick = (target: "claudeCode" | "codex") => {
-    const item = target === "claudeCode" ? data?.claudeCode : data?.codex;
+  const onConfigureClick = (target: "claudeCode" | "codex" | "claudeDesktop") => {
+    const item =
+      target === "claudeCode"
+        ? data?.claudeCode
+        : target === "codex"
+          ? data?.codex
+          : data?.claudeDesktop;
     if (!item) {
       return;
     }
@@ -168,7 +191,9 @@ export default function ClientConfigStatus() {
       ? data?.claudeCode
       : pendingTarget === "codex"
         ? data?.codex
-        : null;
+        : pendingTarget === "claudeDesktop"
+          ? data?.claudeDesktop
+          : null;
 
   return (
     <>
@@ -191,6 +216,77 @@ export default function ClientConfigStatus() {
             <div className="h-16 animate-pulse bg-muted rounded" />
           ) : (
             <>
+              {data?.claudeDesktop && (
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 rounded-md border border-border/60 p-2.5">
+                  <div className="flex items-start gap-2 min-w-0">
+                    <Monitor className="h-3.5 w-3.5 text-muted-foreground shrink-0 mt-0.5" />
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-xs font-medium">
+                          {t("clientConfig.claudeDesktop.name")}
+                        </span>
+                        {statusBadge(data.claudeDesktop.status, t)}
+                      </div>
+                      <p className="text-[10px] text-muted-foreground font-mono truncate mt-0.5">
+                        {data.claudeDesktop.filePath}
+                      </p>
+                      {data.claudeDesktop.currentValue && (
+                        <p className="text-[10px] text-muted-foreground truncate">
+                          inferenceGatewayBaseUrl: {data.claudeDesktop.currentValue}
+                        </p>
+                      )}
+                      {data.claudeDesktop.message && data.claudeDesktop.status !== "ok" && (
+                        <p className="text-[10px] text-amber-600 dark:text-amber-500 mt-0.5">
+                          {data.claudeDesktop.message}
+                        </p>
+                      )}
+                      <p className="text-[10px] text-muted-foreground mt-0.5">
+                        {t("clientConfig.claudeDesktop.expected")}{" "}
+                        <span className="font-mono">{data?.expectedAnthropicBase ?? "—"}</span>
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 sm:pl-2 gap-1">
+                    {data.claudeDesktop.status === "ok" && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-7 text-xs gap-1 text-muted-foreground hover:text-destructive"
+                        disabled={restoreMutation.isPending}
+                        onClick={() => {
+                          setRestoreTarget("claudeDesktop");
+                          setRestoreConfirmOpen(true);
+                        }}
+                      >
+                        {restoreMutation.isPending && applyingTo === "claudeDesktop" ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : (
+                          <RotateCcw className="h-3 w-3" />
+                        )}
+                        <span className="hidden sm:inline">
+                          {t("clientConfig.claudeDesktop.restore")}
+                        </span>
+                      </Button>
+                    )}
+                    <Button
+                      size="sm"
+                      variant={data.claudeDesktop.status === "ok" ? "outline" : "default"}
+                      className="h-7 text-xs"
+                      disabled={data.claudeDesktop.status === "ok" || applyMutation.isPending}
+                      onClick={() => onConfigureClick("claudeDesktop")}
+                    >
+                      {applyMutation.isPending && applyingTo === "claudeDesktop" ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : data.claudeDesktop.status === "ok" ? (
+                        t("clientConfig.claudeDesktop.upToDate")
+                      ) : (
+                        t("clientConfig.claudeDesktop.apply")
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              )}
+
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 rounded-md border border-border/60 p-2.5">
                 <div className="flex items-start gap-2 min-w-0">
                   <FileCode2 className="h-3.5 w-3.5 text-muted-foreground shrink-0 mt-0.5" />
@@ -444,13 +540,17 @@ export default function ClientConfigStatus() {
                 name:
                   restoreTarget === "codex"
                     ? t("clientConfig.codex.name")
-                    : t("clientConfig.claudeCode.name"),
+                    : restoreTarget === "claudeDesktop"
+                      ? t("clientConfig.claudeDesktop.name")
+                      : t("clientConfig.claudeCode.name"),
               })}
             </AlertDialogTitle>
             <AlertDialogDescription>
               {restoreTarget === "codex"
                 ? t("clientConfig.dialog.restore.codexDescription")
-                : t("clientConfig.dialog.restore.claudeDescription")}
+                : restoreTarget === "claudeDesktop"
+                  ? t("clientConfig.dialog.restore.claudeDesktopDescription")
+                  : t("clientConfig.dialog.restore.claudeDescription")}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -489,7 +589,9 @@ export default function ClientConfigStatus() {
             <AlertDialogTitle>
               {pendingTarget === "codex"
                 ? t("clientConfig.dialog.replaceCodex.title")
-                : t("clientConfig.dialog.overwrite.title")}
+                : pendingTarget === "claudeDesktop"
+                  ? t("clientConfig.dialog.replaceClaudeDesktop.title")
+                  : t("clientConfig.dialog.overwrite.title")}
             </AlertDialogTitle>
             <AlertDialogDescription>
               {pendingTarget === "codex" ? (
@@ -499,6 +601,15 @@ export default function ClientConfigStatus() {
                   <strong>replace the file</strong> with the CCRelay template (model{" "}
                   <span className="font-mono">{pendingCodexModel || CODEX_DEFAULT_MODEL}</span>,
                   provider <span className="font-mono">ccrelay</span>).
+                </>
+              ) : pendingTarget === "claudeDesktop" ? (
+                <>
+                  Your Claude Desktop config points to{" "}
+                  <span className="font-mono">{pendingItem?.currentValue ?? "another URL"}</span>.
+                  Applying will merge CCRelay settings into the Claude-3p config directory.
+                  {pendingItem?.status === "invalid" && (
+                    <> {t("clientConfig.dialog.overwrite.invalidJson")}</>
+                  )}
                 </>
               ) : (
                 <>

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -76,7 +76,7 @@
   },
   "clientConfig": {
     "title": "Client configuration",
-    "description": "Check Claude Code ({{claudePath}}) and Codex ({{codexPath}}) configs point to this CCRelay instance (port {{port}}).",
+    "description": "Check Claude Desktop, Claude Code ({{claudePath}}), and Codex ({{codexPath}}) configs point to this CCRelay instance (port {{port}}).",
     "status": {
       "ok": "OK",
       "notSet": "Not set",
@@ -94,6 +94,13 @@
         "suggested": "Suggested:"
       },
       "configureModels": "Configure default models",
+      "restore": "Restore",
+      "upToDate": "Up to date",
+      "apply": "Apply CCRelay settings"
+    },
+    "claudeDesktop": {
+      "name": "Claude Desktop",
+      "expected": "Expected:",
       "restore": "Restore",
       "upToDate": "Up to date",
       "apply": "Apply CCRelay settings"
@@ -121,10 +128,14 @@
       "replaceCodex": {
         "title": "Replace Codex config?"
       },
+      "replaceClaudeDesktop": {
+        "title": "Overwrite Claude Desktop config?"
+      },
       "restore": {
         "title": "Restore {{name}} config?",
         "claudeDescription": "This will remove CCRelay-injected keys (ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN, etc.) from settings.json. Other settings are preserved.",
         "codexDescription": "This will remove the CCRelay model provider section from config.toml and reset the model to the default.",
+        "claudeDesktopDescription": "This will remove CCRelay config files from the Claude-3p directory, revert deploymentMode to 1p, and delete developer_settings.json.",
         "action": "Restore"
       }
     },

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -76,7 +76,7 @@
   },
   "clientConfig": {
     "title": "客户端配置",
-    "description": "检查 Claude Code（{{claudePath}}）和 Codex（{{codexPath}}）配置是否指向此 CCRelay 实例（端口 {{port}}）。",
+    "description": "检查 Claude Desktop、Claude Code（{{claudePath}}）和 Codex（{{codexPath}}）配置是否指向此 CCRelay 实例（端口 {{port}}）。",
     "status": {
       "ok": "正常",
       "notSet": "未设置",
@@ -94,6 +94,13 @@
         "suggested": "建议："
       },
       "configureModels": "配置默认模型",
+      "restore": "还原",
+      "upToDate": "已是最新",
+      "apply": "应用 CCRelay 设置"
+    },
+    "claudeDesktop": {
+      "name": "Claude Desktop",
+      "expected": "期望值:",
       "restore": "还原",
       "upToDate": "已是最新",
       "apply": "应用 CCRelay 设置"
@@ -121,10 +128,14 @@
       "replaceCodex": {
         "title": "替换 Codex 配置？"
       },
+      "replaceClaudeDesktop": {
+        "title": "覆盖 Claude Desktop 配置？"
+      },
       "restore": {
         "title": "还原 {{name}} 配置？",
         "claudeDescription": "将从 settings.json 中移除 CCRelay 注入的键（ANTHROPIC_BASE_URL、ANTHROPIC_AUTH_TOKEN 等）。其他设置不受影响。",
         "codexDescription": "将从 config.toml 中移除 CCRelay 的 model_provider 配置段，并将 model 重置为默认值。",
+        "claudeDesktopDescription": "将从 Claude-3p 目录中移除 CCRelay 配置文件，将 deploymentMode 还原为 1p，并删除 developer_settings.json。",
         "action": "还原"
       }
     },

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -246,6 +246,7 @@ export interface ClientConfigGetResponse {
   expectedAnthropicBase: string;
   expectedCodexBaseUrl: string;
   port: number;
+  claudeDesktop: ClientConfigItem | null;
   claudeCode: ClientConfigItem;
   codex: ClientConfigItem;
   claudeDefaultModels: ClaudeDefaultModels;


### PR DESCRIPTION
## Summary

- Add Claude Desktop (macOS/Windows) as a third client config option in the dashboard, alongside Claude Code and Codex
- Backend manages 4 JSON files under the platform-specific `Claude-3p` directory (`~/Library/Application Support/Claude-3p` on macOS, `%LocalAppData%\Claude-3p` on Windows)
- Dynamic `appliedId` (UUID) — reuses existing ID from `_meta.json` on re-apply, generates new one on first apply
- Apply merges values into existing JSON files without overwriting other keys; Restore deletes CCRelay config and reverts `deploymentMode` to `"1p"`
- Claude Desktop section appears first in the dashboard (before Claude Code and Codex); hidden on unsupported platforms (Linux)

## Test plan

- [ ] Click Apply on Claude Desktop — verify 4 JSON files created under `Claude-3p` directory
- [ ] Click Restore — verify CCRelay config files deleted, `deploymentMode` reverted to `"1p"`, `developer_settings.json` removed
- [ ] Click Apply again after Restore — verify re-apply works correctly
- [ ] Verify Claude Desktop section hidden on Linux
- [ ] Verify Claude Code and Codex config still works as before