### PR TITLE
feat(desktop): native SQLite logging and Logs refresh fix

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -269,7 +269,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+**UI**
+
+- Dashboard **Client configuration** section now detects and manages **Claude Desktop** (macOS and Windows) alongside Claude Code and Codex. Apply writes CCRelay proxy settings to the platform-specific `Claude-3p` config directory; Restore removes them and reverts the deployment mode.
+
 **Diagnostics**
 
 - Runtime messages (startup, configuration, proxy lifecycle, errors) are appended to dated log files under `~/.ccrelay/logs/`; files rotate daily and older ones are removed after about a week. This is separate from dashboard **request** history stored in the logging database.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Desktop**
 
+- Request log storage uses an in-process SQLite driver on Electron for lower latency than the CLI subprocess backend. After upgrading, run `npm install` so the native module is rebuilt for your Electron version.
 - Tray: **Open Logs Folder** (Electron and Tauri) opens `~/.ccrelay/logs/` in the system file manager.
 
 **VS Code**
@@ -26,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CCRelay: Open Logs Folder** command opens the same runtime log folder.
 
 ### Fixed
+
+**UI**
+
+- Request logs: manual refresh on the Logs page now always fetches the latest entries from the server instead of reusing a short-lived cached list.
 
 **Desktop**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2319,6 +2319,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -3397,7 +3407,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3430,13 +3439,20 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -3467,9 +3483,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3496,7 +3512,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3512,7 +3527,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -3717,9 +3731,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/chromium-pickle-js": {
       "version": "0.2.0",
@@ -4063,7 +4075,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -4079,9 +4090,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -4198,7 +4207,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -4549,7 +4557,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -5059,9 +5066,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "dev": true,
       "license": "(MIT OR WTFPL)",
-      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -5201,9 +5206,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -5267,6 +5272,12 @@
       "engines": {
         "node": ">=16.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/filelist": {
       "version": "1.0.6",
@@ -5415,9 +5426,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "11.3.4",
@@ -5558,9 +5567,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "11.1.0",
@@ -5976,7 +5983,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5991,8 +5997,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "7.0.5",
@@ -6043,16 +6048,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/interpret": {
       "version": "1.4.0",
@@ -7160,7 +7162,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7189,7 +7190,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7209,9 +7209,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -7250,9 +7248,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -7287,9 +7283,7 @@
       "version": "3.89.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
       "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -7452,7 +7446,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -8036,9 +8029,7 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -8153,7 +8144,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -8234,9 +8224,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -8323,9 +8311,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -8566,7 +8552,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8636,7 +8621,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8843,7 +8827,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8858,14 +8841,12 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
       "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8881,7 +8862,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -9075,9 +9055,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -9170,9 +9148,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9364,9 +9340,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -9378,9 +9352,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -9700,9 +9672,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -9844,9 +9814,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "14.0.0",
@@ -10197,29 +10165,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",
@@ -10385,25 +10331,66 @@
       "dependencies": {
         "js-yaml": "^4.1.1",
         "pg": "^8.18.0",
-        "ws": "^8.18.0",
+        "ws": "^8.20.1",
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.19.11",
         "@types/pg": "^8.16.0",
         "@types/ws": "^8.5.13",
+        "better-sqlite3": "12.9.0",
         "typescript": "^5.0.4"
+      }
+    },
+    "packages/core/node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "packages/core/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "packages/desktop": {
       "name": "ccrelay-desktop",
       "version": "0.2.4",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@ccrelay/core": "*"
+        "@ccrelay/core": "*",
+        "better-sqlite3": "12.9.0"
       },
       "devDependencies": {
+        "@electron/rebuild": "^3.7.0",
         "@types/node": "^22.19.11",
         "electron": "^41.5.0",
         "electron-builder": "^26.8.1",
@@ -10696,6 +10683,20 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/desktop/node_modules/better-sqlite3": {
+      "version": "12.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.10.0.tgz",
+      "integrity": "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
     },
     "packages/desktop/node_modules/brace-expansion": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
   },
   "dependencies": {},
   "overrides": {
+    "fast-uri": "^3.1.2",
+    "ws": "^8.20.1",
     "uuid": "^14.0.0",
     "@typescript-eslint/typescript-estree": {
       "minimatch": "^10.2.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,10 +12,12 @@
   "dependencies": {
     "js-yaml": "^4.1.1",
     "pg": "^8.18.0",
-    "ws": "^8.18.0",
+    "ws": "^8.20.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "better-sqlite3": "12.9.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.19.11",
     "@types/pg": "^8.16.0",

--- a/packages/core/src/config/builders/database.ts
+++ b/packages/core/src/config/builders/database.ts
@@ -19,9 +19,12 @@ export function buildDatabaseConfig(
     };
   }
   const exe = typeof db.sqlite3Executable === "string" ? db.sqlite3Executable.trim() : "";
+  const driver =
+    db.driver === "auto" || db.driver === "native" || db.driver === "cli" ? db.driver : undefined;
   return {
     type: "sqlite",
     path: db.path || undefined,
     ...(exe ? { sqlite3Executable: exe } : {}),
+    ...(driver ? { driver } : {}),
   };
 }

--- a/packages/core/src/database/create-sqlite-driver.ts
+++ b/packages/core/src/database/create-sqlite-driver.ts
@@ -1,0 +1,38 @@
+/**
+ * SQLite driver factory for the database worker (native vs CLI selection).
+ */
+
+import { SqliteCliDriver } from "./drivers/sqlite-cli";
+import { SqliteNativeDriver } from "./drivers/sqlite-native";
+import { Logger } from "../utils/logger";
+import type { SqliteDriverConfig, DatabaseDriver } from "./types";
+
+const log = Logger.getInstance();
+
+export async function createSqliteDriver(config: SqliteDriverConfig): Promise<DatabaseDriver> {
+  if (config.driver === "cli") {
+    const d = new SqliteCliDriver(config);
+    await d.initialize();
+    return d;
+  }
+
+  const tryNative = async (): Promise<DatabaseDriver> => {
+    const d = new SqliteNativeDriver(config);
+    await d.initialize();
+    return d;
+  };
+
+  if (config.driver === "native") {
+    return tryNative();
+  }
+
+  try {
+    return await tryNative();
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    log.warn(`[DatabaseWorker] Native driver unavailable, falling back to CLI: ${detail}`);
+    const d = new SqliteCliDriver(config);
+    await d.initialize();
+    return d;
+  }
+}

--- a/packages/core/src/database/database-worker.ts
+++ b/packages/core/src/database/database-worker.ts
@@ -10,8 +10,15 @@
  */
 
 import { parentPort } from "worker_threads";
-import { SqliteCliDriver } from "./drivers/sqlite-cli";
-import type { RequestLog, LogFilter, RequestStatus, SqliteDriverConfig, StatsQuery } from "./types";
+import { createSqliteDriver } from "./create-sqlite-driver";
+import type {
+  RequestLog,
+  LogFilter,
+  RequestStatus,
+  SqliteDriverConfig,
+  StatsQuery,
+  DatabaseDriver,
+} from "./types";
 
 // Message types
 type WorkerMessageType =
@@ -44,7 +51,7 @@ interface WorkerResponse {
 }
 
 // Driver instance
-let driver: SqliteCliDriver | null = null;
+let driver: DatabaseDriver | null = null;
 
 /**
  * Handle incoming message from main thread
@@ -56,9 +63,7 @@ async function handleMessage(message: WorkerMessage): Promise<WorkerResponse> {
     switch (type) {
       case "init": {
         const config = payload as SqliteDriverConfig;
-        const d = new SqliteCliDriver(config);
-        await d.initialize();
-        driver = d;
+        driver = await createSqliteDriver(config);
         return { id, success: true };
       }
 

--- a/packages/core/src/database/drivers/index.ts
+++ b/packages/core/src/database/drivers/index.ts
@@ -7,4 +7,5 @@ export {
   isSqliteCliUnavailableError,
   SQLITE_CLI_NOT_FOUND_MESSAGE,
 } from "./sqlite-cli";
+export { SqliteNativeDriver } from "./sqlite-native";
 export { PostgresDriver } from "./postgres";

--- a/packages/core/src/database/drivers/sqlite-cli.ts
+++ b/packages/core/src/database/drivers/sqlite-cli.ts
@@ -20,6 +20,14 @@ import type {
   RequestStatus,
   StatsQuery,
 } from "../types";
+import {
+  MAX_LOG_ROWS,
+  MAX_LOG_AGE_DAYS,
+  encodeForStorage,
+  buildInsertSql,
+  dbRowToLogWithoutBody,
+  dbRowToLog,
+} from "./sqlite-utils";
 
 /** Thrown when the `sqlite3` executable is absent; callers may degrade to disabled log storage. */
 export const SQLITE_CLI_NOT_FOUND_MESSAGE = "sqlite3 CLI not found. Please install SQLite3.";
@@ -55,36 +63,6 @@ export function resolveSqlite3ExecutableFromEnv(): string | null {
   } catch {
     return null;
   }
-}
-
-const MAX_LOG_ROWS = 10000;
-const MAX_LOG_AGE_DAYS = 30;
-
-/**
- * Base64 encoding helpers for storage
- * Uses a prefix to distinguish encoded data from legacy plain text
- */
-const BASE64_PREFIX = "B64:";
-
-function encodeForStorage(value: string | undefined): string | null {
-  if (value === undefined || value === null) {
-    return null;
-  }
-  return BASE64_PREFIX + Buffer.from(value, "utf-8").toString("base64");
-}
-
-function decodeFromStorage(value: string | undefined): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-  if (value.startsWith(BASE64_PREFIX)) {
-    try {
-      return Buffer.from(value.slice(BASE64_PREFIX.length), "base64").toString("utf-8");
-    } catch {
-      return value; // Fallback if decode fails
-    }
-  }
-  return value; // Return as-is (legacy plain text)
 }
 
 /**
@@ -156,199 +134,6 @@ function interpolateSql(
   }
 
   return result;
-}
-
-/**
- * Build an INSERT SQL statement for a RequestLog
- */
-function buildInsertSql(
-  log: RequestLog,
-  status: string = "completed"
-): {
-  sql: string;
-  params: (string | number | boolean | null | undefined)[];
-} {
-  return {
-    sql: `INSERT INTO request_logs (
-      timestamp, provider_id, provider_name, method, path, target_url,
-      request_body, response_body, original_request_body, original_response_body,
-      status_code, duration, success, error_message, client_id, status, route_type,
-      input_tokens, output_tokens, cache_tokens, ttfb
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    params: [
-      log.timestamp,
-      log.providerId,
-      log.providerName,
-      log.method,
-      log.path,
-      log.targetUrl ?? null,
-      encodeForStorage(log.requestBody),
-      encodeForStorage(log.responseBody),
-      encodeForStorage(log.originalRequestBody),
-      encodeForStorage(log.originalResponseBody),
-      log.statusCode ?? null,
-      log.duration,
-      log.success ? 1 : 0,
-      encodeForStorage(log.errorMessage),
-      log.clientId ?? null,
-      status,
-      log.routeType ?? null,
-      log.inputTokens ?? null,
-      log.outputTokens ?? null,
-      log.cacheTokens ?? null,
-      log.ttfb ?? null,
-    ],
-  };
-}
-
-/**
- * Extract model name from a JSON body that may be truncated.
- * Tries JSON.parse first; falls back to regex for partial JSON.
- */
-function extractModelFromPartialJson(body: string): string | undefined {
-  try {
-    const parsed = JSON.parse(body) as { model?: string; data?: { model?: string } };
-    return (typeof parsed.model === "string" && parsed.model) || parsed.data?.model || undefined;
-  } catch {
-    // Truncated JSON — extract "model":"value" via regex
-    const match = body.match(/"model"\s*:\s*"([^"]+)"/);
-    return match?.[1];
-  }
-}
-
-/**
- * Convert a database row to RequestLog (without body fields for list view)
- */
-function dbRowToLogWithoutBody(row: Record<string, unknown>): RequestLog {
-  const log: RequestLog = {
-    id: row.id as number,
-    timestamp: row.timestamp as number,
-    providerId: row.provider_id as string,
-    providerName: row.provider_name as string,
-    method: row.method as string,
-    path: row.path as string,
-    statusCode: row.status_code as number | undefined,
-    duration: row.duration as number,
-    success: (row.success as number) !== 0,
-    errorMessage: row.error_message as string | undefined,
-    clientId: row.client_id as string | undefined,
-    status: row.status as RequestLog["status"],
-    routeType: row.route_type as RequestLog["routeType"],
-    inputTokens: row.input_tokens as number | undefined,
-    outputTokens: row.output_tokens as number | undefined,
-    cacheTokens: row.cache_tokens as number | undefined,
-    ttfb: row.ttfb as number | undefined,
-  };
-
-  if (log.errorMessage) {
-    log.errorMessage = decodeFromStorage(log.errorMessage);
-  }
-
-  // Extract original model (what the client sent) from original_request_body
-  const rawOriginalBody = row.original_request_body as string | undefined;
-  if (rawOriginalBody) {
-    const originalBody = decodeFromStorage(rawOriginalBody);
-    if (originalBody) {
-      log.model = extractModelFromPartialJson(originalBody);
-    }
-  }
-
-  // Extract mapped model (what was sent upstream) from request_body
-  const rawRequestBody = row.request_body as string | undefined;
-  if (rawRequestBody) {
-    const requestBody = decodeFromStorage(rawRequestBody);
-    if (requestBody) {
-      const model = extractModelFromPartialJson(requestBody);
-      if (model) {
-        log.mappedModel = model;
-        if (!log.model) {
-          log.model = model;
-        }
-      }
-    }
-  }
-
-  if (!log.model) {
-    const pathModelMatch = log.path.match(/\/models\/([^\/\?]+)/);
-    if (pathModelMatch) {
-      log.model = pathModelMatch[1];
-    }
-  }
-
-  return log;
-}
-
-/**
- * Shared helper: populate model/mappedModel from stored bodies
- */
-function extractModelsFromBodies(
-  row: Record<string, unknown>
-): Pick<RequestLog, "model" | "mappedModel"> {
-  const result: Pick<RequestLog, "model" | "mappedModel"> = {};
-
-  const rawOriginalBody = row.original_request_body as string | undefined;
-  if (rawOriginalBody) {
-    const originalBody = decodeFromStorage(rawOriginalBody);
-    if (originalBody) {
-      result.model = extractModelFromPartialJson(originalBody);
-    }
-  }
-
-  const rawRequestBody = row.request_body as string | undefined;
-  if (rawRequestBody) {
-    const requestBody = decodeFromStorage(rawRequestBody);
-    if (requestBody) {
-      const model = extractModelFromPartialJson(requestBody);
-      if (model) {
-        result.mappedModel = model;
-        if (!result.model) {
-          result.model = model;
-        }
-      }
-    }
-  }
-
-  if (!result.model) {
-    const path = (row.path as string) || "";
-    const pathModelMatch = path.match(/\/models\/([^\/\?]+)/);
-    if (pathModelMatch) {
-      result.model = pathModelMatch[1];
-    }
-  }
-
-  return result;
-}
-
-/**
- * Convert database row to RequestLog (with body fields for detail view)
- */
-function dbRowToLog(row: Record<string, unknown>): RequestLog {
-  const models = extractModelsFromBodies(row);
-  return {
-    id: row.id as number,
-    timestamp: row.timestamp as number,
-    providerId: row.provider_id as string,
-    providerName: row.provider_name as string,
-    method: row.method as string,
-    path: row.path as string,
-    targetUrl: row.target_url as string | undefined,
-    requestBody: decodeFromStorage(row.request_body as string | undefined),
-    responseBody: decodeFromStorage(row.response_body as string | undefined),
-    originalRequestBody: decodeFromStorage(row.original_request_body as string | undefined),
-    originalResponseBody: decodeFromStorage(row.original_response_body as string | undefined),
-    statusCode: row.status_code as number | undefined,
-    duration: row.duration as number,
-    success: (row.success as number) !== 0,
-    errorMessage: decodeFromStorage(row.error_message as string | undefined),
-    clientId: row.client_id as string | undefined,
-    status: row.status as RequestLog["status"],
-    routeType: row.route_type as RequestLog["routeType"],
-    inputTokens: row.input_tokens as number | undefined,
-    outputTokens: row.output_tokens as number | undefined,
-    cacheTokens: row.cache_tokens as number | undefined,
-    ttfb: row.ttfb as number | undefined,
-    ...models,
-  };
 }
 
 interface PendingQuery {

--- a/packages/core/src/database/drivers/sqlite-native.ts
+++ b/packages/core/src/database/drivers/sqlite-native.ts
@@ -1,0 +1,538 @@
+/* eslint-disable @typescript-eslint/require-await -- Interface requires Promise returns but native driver is synchronous */
+/**
+ * SQLite Native Driver
+ * Uses better-sqlite3 for in-process SQLite access (no IPC overhead).
+ * Designed for Electron Desktop; falls back to SqliteCliDriver elsewhere.
+ */
+
+import * as path from "path";
+import * as fsSync from "fs";
+import type Database from "better-sqlite3";
+import { Logger } from "../../utils/logger";
+import type {
+  DatabaseDriver,
+  SqliteDriverConfig,
+  RequestLog,
+  LogFilter,
+  LogQueryResult,
+  DatabaseStats,
+  ProviderStatRow,
+  RequestStatus,
+  StatsQuery,
+} from "../types";
+import {
+  MAX_LOG_ROWS,
+  MAX_LOG_AGE_DAYS,
+  encodeForStorage,
+  buildInsertSql,
+  dbRowToLogWithoutBody,
+  dbRowToLog,
+} from "./sqlite-utils";
+
+export class SqliteNativeDriver implements DatabaseDriver {
+  private readonly config: SqliteDriverConfig;
+  private readonly log = Logger.getInstance();
+  private db: Database.Database | null = null;
+  private isEnabled = false;
+
+  constructor(config: SqliteDriverConfig) {
+    this.config = config;
+  }
+
+  /** Returns db with non-null assertion; safe because all callers check isEnabled first. */
+  private get d(): Database.Database {
+    return this.db!;
+  }
+
+  async initialize(): Promise<void> {
+    const dbPath = this.config.path;
+    const dir = path.dirname(dbPath);
+
+    if (!fsSync.existsSync(dir)) {
+      fsSync.mkdirSync(dir, { recursive: true });
+    }
+
+    // Dynamic require — esbuild keeps this as require("better-sqlite3") for the desktop bundle
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/naming-convention
+    const BetterSqlite3 = require("better-sqlite3") as typeof import("better-sqlite3");
+    this.db = new BetterSqlite3(dbPath);
+
+    this.d.pragma("journal_mode = WAL");
+    this.d.pragma("synchronous = NORMAL");
+    this.d.pragma("busy_timeout = 30000");
+    this.d.pragma("cache_size = -8000");
+    this.d.pragma("temp_store = MEMORY");
+    this.d.pragma("mmap_size = 16777216");
+
+    this.log.info(`[SqliteNative] Database path: ${dbPath}`);
+
+    this.createSchema();
+    this.isEnabled = true;
+
+    setTimeout(() => {
+      this.cleanOldLogs().catch(err => {
+        this.log.error("[SqliteNative] Background cleanup failed:", err);
+      });
+    }, 0);
+  }
+
+  private createSchema(): void {
+    this.d.exec(`
+      CREATE TABLE IF NOT EXISTS request_logs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp INTEGER NOT NULL,
+        provider_id TEXT NOT NULL,
+        provider_name TEXT NOT NULL,
+        method TEXT NOT NULL,
+        path TEXT NOT NULL,
+        target_url TEXT,
+        request_body TEXT,
+        response_body TEXT,
+        original_request_body TEXT,
+        original_response_body TEXT,
+        status_code INTEGER,
+        duration INTEGER NOT NULL,
+        success INTEGER NOT NULL,
+        error_message TEXT,
+        client_id TEXT,
+        status TEXT DEFAULT 'completed',
+        route_type TEXT,
+        input_tokens INTEGER,
+        output_tokens INTEGER,
+        cache_tokens INTEGER,
+        ttfb INTEGER
+      )
+    `);
+
+    const indexes = [
+      "CREATE INDEX IF NOT EXISTS idx_timestamp ON request_logs(timestamp)",
+      "CREATE INDEX IF NOT EXISTS idx_provider_id ON request_logs(provider_id)",
+      "CREATE INDEX IF NOT EXISTS idx_path ON request_logs(path)",
+      "CREATE INDEX IF NOT EXISTS idx_success ON request_logs(success)",
+      "CREATE INDEX IF NOT EXISTS idx_client_id ON request_logs(client_id)",
+      "CREATE INDEX IF NOT EXISTS idx_status ON request_logs(status)",
+    ];
+
+    for (const sql of indexes) {
+      this.d.exec(sql);
+    }
+
+    try {
+      const columns: Array<{ name: string }> = this.d.pragma("table_info(request_logs)") as Array<{
+        name: string;
+      }>;
+      const columnNames = columns.map(c => c.name);
+
+      const migrations: Array<{ column: string; sql: string }> = [
+        { column: "target_url", sql: "ALTER TABLE request_logs ADD COLUMN target_url TEXT" },
+        {
+          column: "original_request_body",
+          sql: "ALTER TABLE request_logs ADD COLUMN original_request_body TEXT",
+        },
+        {
+          column: "original_response_body",
+          sql: "ALTER TABLE request_logs ADD COLUMN original_response_body TEXT",
+        },
+        { column: "client_id", sql: "ALTER TABLE request_logs ADD COLUMN client_id TEXT" },
+        {
+          column: "status",
+          sql: "ALTER TABLE request_logs ADD COLUMN status TEXT DEFAULT 'completed'",
+        },
+        { column: "route_type", sql: "ALTER TABLE request_logs ADD COLUMN route_type TEXT" },
+        { column: "input_tokens", sql: "ALTER TABLE request_logs ADD COLUMN input_tokens INTEGER" },
+        {
+          column: "output_tokens",
+          sql: "ALTER TABLE request_logs ADD COLUMN output_tokens INTEGER",
+        },
+        { column: "cache_tokens", sql: "ALTER TABLE request_logs ADD COLUMN cache_tokens INTEGER" },
+        { column: "ttfb", sql: "ALTER TABLE request_logs ADD COLUMN ttfb INTEGER" },
+      ];
+
+      for (const migration of migrations) {
+        if (!columnNames.includes(migration.column)) {
+          this.d.exec(migration.sql);
+        }
+      }
+    } catch {
+      // Table might not exist yet
+    }
+  }
+
+  // ---- Write operations ----------------------------------------------------
+
+  insertLog(log: RequestLog): void {
+    if (!this.isEnabled) {
+      return;
+    }
+    const { sql, params } = buildInsertSql(log);
+    try {
+      this.d.prepare(sql).run(...params);
+    } catch (err) {
+      this.log.error("[SqliteNative] Failed to insert log:", err);
+    }
+  }
+
+  insertLogPending(log: RequestLog): void {
+    if (!this.isEnabled) {
+      return;
+    }
+    const { sql, params } = buildInsertSql(log, "pending");
+    try {
+      this.d.prepare(sql).run(...params);
+    } catch (err) {
+      this.log.error("[SqliteNative] Failed to insert pending log:", err);
+    }
+  }
+
+  updateLogCompleted(
+    clientId: string,
+    statusCode: number,
+    responseBody: string | undefined,
+    duration: number,
+    success: boolean,
+    errorMessage: string | undefined,
+    originalResponseBody?: string,
+    inputTokens?: number,
+    outputTokens?: number,
+    cacheTokens?: number,
+    ttfb?: number
+  ): void {
+    if (!this.isEnabled) {
+      return;
+    }
+    try {
+      const stmt = this.d.prepare(`
+        UPDATE request_logs
+        SET status_code = ?,
+            response_body = ?,
+            original_response_body = ?,
+            duration = ?,
+            success = ?,
+            error_message = ?,
+            status = 'completed',
+            input_tokens = ?,
+            output_tokens = ?,
+            cache_tokens = ?,
+            ttfb = ?
+        WHERE client_id = ?
+      `);
+      stmt.run(
+        statusCode,
+        encodeForStorage(responseBody),
+        encodeForStorage(originalResponseBody),
+        duration,
+        success ? 1 : 0,
+        encodeForStorage(errorMessage),
+        inputTokens ?? null,
+        outputTokens ?? null,
+        cacheTokens ?? null,
+        ttfb ?? null,
+        clientId
+      );
+    } catch (err) {
+      this.log.error("[SqliteNative] Failed to update log:", err);
+    }
+  }
+
+  updateLogStatus(
+    clientId: string,
+    status: RequestStatus,
+    statusCode: number,
+    duration: number,
+    errorMessage: string | undefined
+  ): void {
+    if (!this.isEnabled) {
+      return;
+    }
+    try {
+      const stmt = this.d.prepare(`
+        UPDATE request_logs
+        SET status_code = ?,
+            duration = ?,
+            success = ?,
+            error_message = ?,
+            status = ?
+        WHERE client_id = ?
+      `);
+      stmt.run(statusCode, duration, 0, encodeForStorage(errorMessage), status, clientId);
+    } catch (err) {
+      this.log.error("[SqliteNative] Failed to update log status:", err);
+    }
+  }
+
+  async writeBatch(logs: RequestLog[]): Promise<void> {
+    if (!this.isEnabled || logs.length === 0) {
+      return;
+    }
+
+    const stmt = this.d.prepare(buildInsertSql(logs[0]).sql);
+    const insertMany = this.d.transaction((items: RequestLog[]) => {
+      for (const log of items) {
+        const { params } = buildInsertSql(log);
+        stmt.run(...params);
+      }
+    });
+    insertMany(logs);
+  }
+
+  async deleteLogs(ids: number[]): Promise<void> {
+    if (!this.isEnabled || ids.length === 0) {
+      return;
+    }
+    const placeholders = ids.map(() => "?").join(",");
+    this.d.prepare(`DELETE FROM request_logs WHERE id IN (${placeholders})`).run(...ids);
+  }
+
+  async clearAllLogs(): Promise<void> {
+    if (!this.isEnabled) {
+      return;
+    }
+    this.d.exec("DELETE FROM request_logs");
+    this.d.exec("VACUUM");
+  }
+
+  async cleanOldLogs(): Promise<void> {
+    if (!this.isEnabled) {
+      return;
+    }
+    const cutoff = Date.now() - MAX_LOG_AGE_DAYS * 24 * 60 * 60 * 1000;
+    this.d.prepare("DELETE FROM request_logs WHERE timestamp < ?").run(cutoff);
+    this.d
+      .prepare(
+        `DELETE FROM request_logs WHERE id NOT IN (SELECT id FROM request_logs ORDER BY timestamp DESC LIMIT ?)`
+      )
+      .run(MAX_LOG_ROWS);
+  }
+
+  // ---- Read operations -----------------------------------------------------
+
+  async queryLogs(filter: LogFilter = {}): Promise<LogQueryResult> {
+    if (!this.isEnabled) {
+      return { logs: [], total: 0 };
+    }
+
+    const conditions: string[] = [];
+    const params: (string | number | boolean | null | undefined)[] = [];
+
+    if (filter.providerId) {
+      conditions.push("provider_id = ?");
+      params.push(filter.providerId);
+    }
+    if (filter.method) {
+      conditions.push("method = ?");
+      params.push(filter.method);
+    }
+    if (filter.pathPattern) {
+      conditions.push("path LIKE ?");
+      params.push(`%${filter.pathPattern}%`);
+    }
+    if (filter.minDuration !== undefined) {
+      conditions.push("duration >= ?");
+      params.push(filter.minDuration);
+    }
+    if (filter.maxDuration !== undefined) {
+      conditions.push("duration <= ?");
+      params.push(filter.maxDuration);
+    }
+    if (filter.hasError !== undefined) {
+      conditions.push("success = ?");
+      params.push(filter.hasError ? 0 : 1);
+    }
+    if (filter.startTime !== undefined) {
+      conditions.push("timestamp >= ?");
+      params.push(filter.startTime);
+    }
+    if (filter.endTime !== undefined) {
+      conditions.push("timestamp <= ?");
+      params.push(filter.endTime);
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+    const countRow = this.d
+      .prepare(`SELECT COUNT(*) as count FROM request_logs ${whereClause}`)
+      .get(...params) as Record<string, unknown> | undefined;
+    const total = (countRow?.count as number) ?? 0;
+
+    const limit = filter.limit || 100;
+    const offset = filter.offset || 0;
+
+    const rows = this.d
+      .prepare(
+        `SELECT id, timestamp, provider_id, provider_name, method, path,
+                status_code, duration, success, error_message, client_id,
+                status, route_type,
+                input_tokens, output_tokens, cache_tokens, ttfb,
+                SUBSTR(request_body, 1, 500) as request_body,
+                SUBSTR(original_request_body, 1, 500) as original_request_body
+         FROM request_logs ${whereClause} ORDER BY timestamp DESC LIMIT ? OFFSET ?`
+      )
+      .all(...params, limit, offset) as Record<string, unknown>[];
+
+    return { logs: rows.map(dbRowToLogWithoutBody), total };
+  }
+
+  async getLogById(id: number): Promise<RequestLog | null> {
+    if (!this.isEnabled) {
+      return null;
+    }
+    const row = this.d.prepare("SELECT * FROM request_logs WHERE id = ?").get(id) as
+      | Record<string, unknown>
+      | undefined;
+    return row ? dbRowToLog(row) : null;
+  }
+
+  async getStats(query?: StatsQuery): Promise<DatabaseStats> {
+    const empty: DatabaseStats = {
+      totalLogs: 0,
+      successCount: 0,
+      errorCount: 0,
+      avgDuration: 0,
+      byProvider: {},
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCacheTokens: 0,
+      cacheHitRate: 0,
+      avgTtfb: 0,
+      outputTps: 0,
+      outputTpsSampleCount: 0,
+      p50Duration: 0,
+      p90Duration: 0,
+      providerBreakdown: [],
+    };
+
+    if (!this.isEnabled) {
+      return empty;
+    }
+
+    const since = query?.since;
+    const sinceParam = since ? since : null;
+    const timeFilter = since ? "(? IS NULL OR timestamp >= ?)" : "1=1";
+    const timeParams = since ? [sinceParam, sinceParam] : [];
+
+    // 1. Base stats + token aggregation
+    const base = this.d
+      .prepare(
+        `SELECT COUNT(*) as totalLogs,
+                SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END) as successCount,
+                SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END) as errorCount,
+                AVG(duration) as avgDuration,
+                COALESCE(SUM(input_tokens), 0) as totalInputTokens,
+                COALESCE(SUM(output_tokens), 0) as totalOutputTokens,
+                COALESCE(SUM(cache_tokens), 0) as totalCacheTokens,
+                AVG(ttfb) as avgTtfb
+         FROM request_logs
+         WHERE ${timeFilter}`
+      )
+      .get(...timeParams) as Record<string, unknown>;
+
+    const totalInput = (base.totalInputTokens as number) ?? 0;
+    const totalOutput = (base.totalOutputTokens as number) ?? 0;
+    const totalCache = (base.totalCacheTokens as number) ?? 0;
+    const denominator = totalInput + totalCache;
+
+    // 2. Filtered TPS (only genuinely streamed: genTime > 500ms)
+    const tps = this.d
+      .prepare(
+        `SELECT COALESCE(SUM(output_tokens), 0) as filteredTokens,
+                COALESCE(SUM(duration - ttfb), 0) as filteredGenTime,
+                COUNT(*) as filteredCount
+         FROM request_logs
+         WHERE ${timeFilter}
+           AND ttfb IS NOT NULL
+           AND output_tokens IS NOT NULL
+           AND output_tokens > 0
+           AND (duration - ttfb) > 500`
+      )
+      .get(...timeParams) as Record<string, unknown>;
+
+    const filteredTokens = (tps.filteredTokens as number) ?? 0;
+    const filteredGenTime = (tps.filteredGenTime as number) ?? 0;
+    const filteredCount = (tps.filteredCount as number) ?? 0;
+    const outputTps = filteredGenTime > 0 ? (filteredTokens / filteredGenTime) * 1000 : 0;
+
+    // 3. Percentiles via LIMIT/OFFSET
+    let p50Duration = 0;
+    let p90Duration = 0;
+    const totalLogs = (base.totalLogs as number) ?? 0;
+    if (totalLogs > 0) {
+      const p50Offset = Math.floor(0.5 * (totalLogs - 1));
+      const p90Offset = Math.floor(0.9 * (totalLogs - 1));
+      const p50Row = this.d
+        .prepare(
+          `SELECT duration FROM request_logs WHERE ${timeFilter} ORDER BY duration ASC LIMIT 1 OFFSET ?`
+        )
+        .get(...timeParams, p50Offset) as Record<string, unknown> | undefined;
+      const p90Row = this.d
+        .prepare(
+          `SELECT duration FROM request_logs WHERE ${timeFilter} ORDER BY duration ASC LIMIT 1 OFFSET ?`
+        )
+        .get(...timeParams, p90Offset) as Record<string, unknown> | undefined;
+      p50Duration = Math.round((p50Row?.duration as number) ?? 0);
+      p90Duration = Math.round((p90Row?.duration as number) ?? 0);
+    }
+
+    // 4. Provider breakdown
+    const providerRows = this.d
+      .prepare(
+        `SELECT provider_id, provider_name, COUNT(*) as count,
+                COALESCE(SUM(input_tokens), 0) as totalInputTokens,
+                COALESCE(SUM(output_tokens), 0) as totalOutputTokens,
+                COALESCE(SUM(cache_tokens), 0) as totalCacheTokens
+         FROM request_logs
+         WHERE ${timeFilter}
+         GROUP BY provider_id, provider_name`
+      )
+      .all(...timeParams) as Record<string, unknown>[];
+
+    const byProvider: Record<string, number> = {};
+    const providerBreakdown: ProviderStatRow[] = [];
+    for (const r of providerRows) {
+      byProvider[r.provider_id as string] = r.count as number;
+      providerBreakdown.push({
+        providerId: r.provider_id as string,
+        providerName: (r.provider_name as string) || (r.provider_id as string),
+        count: r.count as number,
+        totalInputTokens: (r.totalInputTokens as number) ?? 0,
+        totalOutputTokens: (r.totalOutputTokens as number) ?? 0,
+        totalCacheTokens: (r.totalCacheTokens as number) ?? 0,
+      });
+    }
+
+    return {
+      totalLogs,
+      successCount: (base.successCount as number) ?? 0,
+      errorCount: (base.errorCount as number) ?? 0,
+      avgDuration: Math.round((base.avgDuration as number) ?? 0),
+      byProvider,
+      totalInputTokens: totalInput,
+      totalOutputTokens: totalOutput,
+      totalCacheTokens: totalCache,
+      cacheHitRate: denominator > 0 ? Math.round((totalCache / denominator) * 100) : 0,
+      avgTtfb: Math.round((base.avgTtfb as number) ?? 0),
+      outputTps: Math.round(outputTps * 10) / 10,
+      outputTpsSampleCount: filteredCount,
+      p50Duration,
+      p90Duration,
+      providerBreakdown,
+    };
+  }
+
+  // ---- Properties ----------------------------------------------------------
+
+  get enabled(): boolean {
+    return this.isEnabled;
+  }
+
+  forceFlush(): void {
+    // Native driver writes synchronously — nothing to flush
+  }
+
+  async close(): Promise<void> {
+    this.isEnabled = false;
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+    }
+  }
+}

--- a/packages/core/src/database/drivers/sqlite-utils.ts
+++ b/packages/core/src/database/drivers/sqlite-utils.ts
@@ -1,0 +1,225 @@
+/**
+ * Shared SQLite utilities used by both SqliteCliDriver and SqliteNativeDriver.
+ */
+
+import type { RequestLog } from "../types";
+
+export const MAX_LOG_ROWS = 10000;
+export const MAX_LOG_AGE_DAYS = 30;
+
+/**
+ * Base64 encoding helpers for storage.
+ * Uses a prefix to distinguish encoded data from legacy plain text.
+ */
+const BASE64_PREFIX = "B64:";
+
+export function encodeForStorage(value: string | undefined): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  return BASE64_PREFIX + Buffer.from(value, "utf-8").toString("base64");
+}
+
+export function decodeFromStorage(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  if (value.startsWith(BASE64_PREFIX)) {
+    try {
+      return Buffer.from(value.slice(BASE64_PREFIX.length), "base64").toString("utf-8");
+    } catch {
+      return value;
+    }
+  }
+  return value;
+}
+
+/**
+ * Build an INSERT SQL statement for a RequestLog.
+ * Returns the SQL template and parameter array for use with prepared statements.
+ */
+export function buildInsertSql(
+  log: RequestLog,
+  status: string = "completed"
+): {
+  sql: string;
+  params: (string | number | boolean | null | undefined)[];
+} {
+  return {
+    sql: `INSERT INTO request_logs (
+      timestamp, provider_id, provider_name, method, path, target_url,
+      request_body, response_body, original_request_body, original_response_body,
+      status_code, duration, success, error_message, client_id, status, route_type,
+      input_tokens, output_tokens, cache_tokens, ttfb
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    params: [
+      log.timestamp,
+      log.providerId,
+      log.providerName,
+      log.method,
+      log.path,
+      log.targetUrl ?? null,
+      encodeForStorage(log.requestBody),
+      encodeForStorage(log.responseBody),
+      encodeForStorage(log.originalRequestBody),
+      encodeForStorage(log.originalResponseBody),
+      log.statusCode ?? null,
+      log.duration,
+      log.success ? 1 : 0,
+      encodeForStorage(log.errorMessage),
+      log.clientId ?? null,
+      status,
+      log.routeType ?? null,
+      log.inputTokens ?? null,
+      log.outputTokens ?? null,
+      log.cacheTokens ?? null,
+      log.ttfb ?? null,
+    ],
+  };
+}
+
+/**
+ * Extract model name from a JSON body that may be truncated.
+ */
+export function extractModelFromPartialJson(body: string): string | undefined {
+  try {
+    const parsed = JSON.parse(body) as { model?: string; data?: { model?: string } };
+    return (typeof parsed.model === "string" && parsed.model) || parsed.data?.model || undefined;
+  } catch {
+    const match = body.match(/"model"\s*:\s*"([^"]+)"/);
+    return match?.[1];
+  }
+}
+
+/**
+ * Populate model/mappedModel from stored bodies.
+ */
+export function extractModelsFromBodies(
+  row: Record<string, unknown>
+): Pick<RequestLog, "model" | "mappedModel"> {
+  const result: Pick<RequestLog, "model" | "mappedModel"> = {};
+
+  const rawOriginalBody = row.original_request_body as string | undefined;
+  if (rawOriginalBody) {
+    const originalBody = decodeFromStorage(rawOriginalBody);
+    if (originalBody) {
+      result.model = extractModelFromPartialJson(originalBody);
+    }
+  }
+
+  const rawRequestBody = row.request_body as string | undefined;
+  if (rawRequestBody) {
+    const requestBody = decodeFromStorage(rawRequestBody);
+    if (requestBody) {
+      const model = extractModelFromPartialJson(requestBody);
+      if (model) {
+        result.mappedModel = model;
+        if (!result.model) {
+          result.model = model;
+        }
+      }
+    }
+  }
+
+  if (!result.model) {
+    const p = (row.path as string) || "";
+    const pathMatch = p.match(/\/models\/([^\/\?]+)/);
+    if (pathMatch) {
+      result.model = pathMatch[1];
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Convert a database row to RequestLog (without body fields for list view).
+ */
+export function dbRowToLogWithoutBody(row: Record<string, unknown>): RequestLog {
+  const log: RequestLog = {
+    id: row.id as number,
+    timestamp: row.timestamp as number,
+    providerId: row.provider_id as string,
+    providerName: row.provider_name as string,
+    method: row.method as string,
+    path: row.path as string,
+    statusCode: row.status_code as number | undefined,
+    duration: row.duration as number,
+    success: (row.success as number) !== 0,
+    errorMessage: row.error_message as string | undefined,
+    clientId: row.client_id as string | undefined,
+    status: row.status as RequestLog["status"],
+    routeType: row.route_type as RequestLog["routeType"],
+    inputTokens: row.input_tokens as number | undefined,
+    outputTokens: row.output_tokens as number | undefined,
+    cacheTokens: row.cache_tokens as number | undefined,
+    ttfb: row.ttfb as number | undefined,
+  };
+
+  if (log.errorMessage) {
+    log.errorMessage = decodeFromStorage(log.errorMessage);
+  }
+
+  const rawOriginalBody = row.original_request_body as string | undefined;
+  if (rawOriginalBody) {
+    const originalBody = decodeFromStorage(rawOriginalBody);
+    if (originalBody) {
+      log.model = extractModelFromPartialJson(originalBody);
+    }
+  }
+
+  const rawRequestBody = row.request_body as string | undefined;
+  if (rawRequestBody) {
+    const requestBody = decodeFromStorage(rawRequestBody);
+    if (requestBody) {
+      const model = extractModelFromPartialJson(requestBody);
+      if (model) {
+        log.mappedModel = model;
+        if (!log.model) {
+          log.model = model;
+        }
+      }
+    }
+  }
+
+  if (!log.model) {
+    const pathMatch = log.path.match(/\/models\/([^\/\?]+)/);
+    if (pathMatch) {
+      log.model = pathMatch[1];
+    }
+  }
+
+  return log;
+}
+
+/**
+ * Convert database row to RequestLog (with body fields for detail view).
+ */
+export function dbRowToLog(row: Record<string, unknown>): RequestLog {
+  const models = extractModelsFromBodies(row);
+  return {
+    id: row.id as number,
+    timestamp: row.timestamp as number,
+    providerId: row.provider_id as string,
+    providerName: row.provider_name as string,
+    method: row.method as string,
+    path: row.path as string,
+    targetUrl: row.target_url as string | undefined,
+    requestBody: decodeFromStorage(row.request_body as string | undefined),
+    responseBody: decodeFromStorage(row.response_body as string | undefined),
+    originalRequestBody: decodeFromStorage(row.original_request_body as string | undefined),
+    originalResponseBody: decodeFromStorage(row.original_response_body as string | undefined),
+    statusCode: row.status_code as number | undefined,
+    duration: row.duration as number,
+    success: (row.success as number) !== 0,
+    errorMessage: decodeFromStorage(row.error_message as string | undefined),
+    clientId: row.client_id as string | undefined,
+    status: row.status as RequestLog["status"],
+    routeType: row.route_type as RequestLog["routeType"],
+    inputTokens: row.input_tokens as number | undefined,
+    outputTokens: row.output_tokens as number | undefined,
+    cacheTokens: row.cache_tokens as number | undefined,
+    ttfb: row.ttfb as number | undefined,
+    ...models,
+  };
+}

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -226,6 +226,11 @@ export function setLogDatabaseDriverConfigResolver(
   logDatabaseDriverResolver = fn;
 }
 
+/** True when a host (e.g. desktop) registered a driver resolver before {@link ProxyServer} starts. */
+export function hasLogDatabaseDriverConfigResolver(): boolean {
+  return logDatabaseDriverResolver !== undefined;
+}
+
 /**
  * Get the database singleton (uses default SQLite ~/.ccrelay/logs.db unless resolver was set).
  */

--- a/packages/core/src/database/logging-driver-config.ts
+++ b/packages/core/src/database/logging-driver-config.ts
@@ -40,9 +40,14 @@ export function loggingDatabaseConfigToDriver(
   const raw = ldb.path?.trim();
   const dbPath = raw ? expandLoggingDbPath(raw) : defaultPath;
   const exe = ldb.sqlite3Executable?.trim();
+  const driver =
+    ldb.driver === "auto" || ldb.driver === "native" || ldb.driver === "cli"
+      ? ldb.driver
+      : undefined;
   return {
     type: "sqlite",
     path: dbPath,
     ...(exe ? { sqlite3Executable: exe } : {}),
+    ...(driver ? { driver } : {}),
   };
 }

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -115,6 +115,8 @@ export interface SqliteDriverConfig {
   readonly type: "sqlite";
   readonly path: string;
   readonly sqlite3Executable?: string;
+  /** Driver selection: "auto" (default) prefers native, falls back to CLI; "native" forces better-sqlite3; "cli" forces sqlite3 CLI. */
+  readonly driver?: "auto" | "native" | "cli";
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,3 +30,9 @@ export {
 } from "./api/version.generated";
 
 export * from "./types";
+
+export {
+  setLogDatabaseDriverConfigResolver,
+  hasLogDatabaseDriverConfigResolver,
+  loggingDatabaseConfigToDriver,
+} from "./database";

--- a/packages/core/src/server/handler.ts
+++ b/packages/core/src/server/handler.ts
@@ -21,6 +21,7 @@ import { ScopedLogger } from "../utils/logger";
 import {
   getDatabase,
   LogDatabase,
+  hasLogDatabaseDriverConfigResolver,
   setLogDatabaseDriverConfigResolver,
   loggingDatabaseConfigToDriver,
 } from "../database";
@@ -82,9 +83,11 @@ export class ProxyServer {
   constructor(config: ConfigManager, leaderElection: LeaderElection | null = null) {
     this.config = config;
     this.router = new Router(config);
-    setLogDatabaseDriverConfigResolver(() =>
-      loggingDatabaseConfigToDriver(this.config.configValue.logging.database)
-    );
+    if (!hasLogDatabaseDriverConfigResolver()) {
+      setLogDatabaseDriverConfigResolver(() =>
+        loggingDatabaseConfigToDriver(this.config.configValue.logging.database)
+      );
+    }
     this.database = getDatabase();
     this.leaderElection = leaderElection;
     this.instanceId = `Server-${process.pid}-${Math.random().toString(36).substring(2, 6)}`;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -186,6 +186,8 @@ export const SqliteConfigSchema = z.object({
   path: z.string().optional(),
   /** Optional path to sqlite3 CLI; empty/not set resolves `sqlite3` from PATH only. */
   sqlite3Executable: z.string().optional(),
+  /** SQLite backend: auto (native with CLI fallback), native (better-sqlite3), or cli (sqlite3 subprocess). */
+  driver: z.enum(["auto", "native", "cli"]).optional(),
 });
 
 export type SqliteConfigInput = z.infer<typeof SqliteConfigSchema>;
@@ -271,6 +273,8 @@ export interface SqliteDatabaseConfig {
   path?: string;
   /** Optional absolute or relative path to the sqlite3 executable; omit to use PATH. */
   sqlite3Executable?: string;
+  /** SQLite backend: auto (native with CLI fallback), native (better-sqlite3), or cli (sqlite3 subprocess). */
+  driver?: "auto" | "native" | "cli";
 }
 
 /**

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -9,6 +9,7 @@
   "main": "out/main.js",
   "scripts": {
     "compile": "tsc --noEmit -p tsconfig.json",
+    "postinstall": "electron-rebuild -f -w better-sqlite3",
     "build": "node ../../scripts/esbuild.desktop.mjs",
     "start": "electron .",
     "pack": "electron-builder --publish never",
@@ -18,9 +19,11 @@
     "pack:win:all": "electron-builder --win --x64 --arm64 --publish never"
   },
   "dependencies": {
-    "@ccrelay/core": "*"
+    "@ccrelay/core": "*",
+    "better-sqlite3": "12.9.0"
   },
   "devDependencies": {
+    "@electron/rebuild": "^3.7.0",
     "@types/node": "^22.19.11",
     "electron": "^41.5.0",
     "electron-builder": "^26.8.1",
@@ -56,7 +59,8 @@
       }
     ],
     "asarUnpack": [
-      "out/database-worker.cjs"
+      "out/database-worker.cjs",
+      "node_modules/better-sqlite3/**"
     ],
     "mac": {
       "extendInfo": {

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -12,6 +12,8 @@ import {
   LeaderElection,
   Logger,
   ProxyServer,
+  loggingDatabaseConfigToDriver,
+  setLogDatabaseDriverConfigResolver,
   setWebDistPath,
 } from "@ccrelay/core";
 import { createTray } from "./tray";
@@ -72,6 +74,13 @@ void app.whenReady().then(async () => {
   setWebDistPath(resolveWebDist());
 
   const configManager = new ConfigManager();
+  setLogDatabaseDriverConfigResolver(() => {
+    const base = loggingDatabaseConfigToDriver(configManager.configValue.logging.database);
+    if (base?.type === "sqlite") {
+      return { ...base, driver: base.driver === "cli" ? "cli" : "native" };
+    }
+    return base;
+  });
   const leaderElection = new LeaderElection(configManager.port, configManager.host, () =>
     configManager.getApiBearerToken()
   );

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -10,6 +10,8 @@ import {
   LeaderElection,
   Logger,
   ProxyServer,
+  loggingDatabaseConfigToDriver,
+  setLogDatabaseDriverConfigResolver,
   setWebDistPath,
 } from "@ccrelay/core";
 import { StatusBarManager } from "./vscode/statusBar";
@@ -60,6 +62,14 @@ export function activate(context: vscode.ExtensionContext) {
   logger.info(
     `[Extension:${instanceId}] LeaderElection initialized in ${Date.now() - leaderElectionStart}ms`
   );
+
+  setLogDatabaseDriverConfigResolver(() => {
+    const base = loggingDatabaseConfigToDriver(cm.configValue.logging.database);
+    if (base?.type === "sqlite") {
+      return { ...base, driver: base.driver ?? "cli" };
+    }
+    return base;
+  });
 
   const serverStart = Date.now();
   server = new ProxyServer(configManager, leaderElection);

--- a/scripts/esbuild.desktop.mjs
+++ b/scripts/esbuild.desktop.mjs
@@ -20,6 +20,7 @@ const commonOptions = {
   format: "cjs",
   external: [
     "electron",
+    "better-sqlite3",
     "pg",
     "pg-*",
     "pgpass",

--- a/tests/unit/config/builders/database.test.ts
+++ b/tests/unit/config/builders/database.test.ts
@@ -23,6 +23,15 @@ describe("buildDatabaseConfig", () => {
     ).toEqual({ type: "sqlite", path: "/tmp/x.db", sqlite3Executable: "/bin/sqlite3" });
   });
 
+  it("builds sqlite config with driver", () => {
+    expect(
+      buildDatabaseConfig({
+        enabled: true,
+        database: { type: "sqlite", driver: "native" },
+      })
+    ).toEqual({ type: "sqlite", path: undefined, driver: "native" });
+  });
+
   it("builds postgres with defaults", () => {
     expect(
       buildDatabaseConfig({

--- a/tests/unit/database/create-sqlite-driver.test.ts
+++ b/tests/unit/database/create-sqlite-driver.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockNativeInitialize, mockCliInitialize } = vi.hoisted(() => ({
+  mockNativeInitialize: vi.fn(),
+  mockCliInitialize: vi.fn(),
+}));
+
+vi.mock("@/database/drivers/sqlite-native", () => {
+  class MockSqliteNativeDriver {
+    initialize = mockNativeInitialize;
+    enabled = true;
+    close = vi.fn().mockResolvedValue(undefined);
+  }
+  return { SqliteNativeDriver: MockSqliteNativeDriver }; // eslint-disable-line @typescript-eslint/naming-convention -- matches export name
+});
+
+vi.mock("@/database/drivers/sqlite-cli", () => {
+  class MockSqliteCliDriver {
+    initialize = mockCliInitialize;
+    enabled = true;
+    close = vi.fn().mockResolvedValue(undefined);
+  }
+  return { SqliteCliDriver: MockSqliteCliDriver }; // eslint-disable-line @typescript-eslint/naming-convention -- matches export name
+});
+
+describe("createSqliteDriver", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockNativeInitialize.mockResolvedValue(undefined);
+    mockCliInitialize.mockResolvedValue(undefined);
+  });
+
+  it("uses CLI driver when driver is cli", async () => {
+    const { createSqliteDriver } = await import("@/database/create-sqlite-driver");
+
+    await createSqliteDriver({ type: "sqlite", path: "/tmp/x.db", driver: "cli" });
+
+    expect(mockCliInitialize).toHaveBeenCalled();
+    expect(mockNativeInitialize).not.toHaveBeenCalled();
+  });
+
+  it("uses native driver when driver is native", async () => {
+    const { createSqliteDriver } = await import("@/database/create-sqlite-driver");
+
+    await createSqliteDriver({ type: "sqlite", path: "/tmp/x.db", driver: "native" });
+
+    expect(mockNativeInitialize).toHaveBeenCalled();
+    expect(mockCliInitialize).not.toHaveBeenCalled();
+  });
+
+  it("auto: falls back to CLI when native initialize fails", async () => {
+    mockNativeInitialize.mockRejectedValueOnce(new Error("Cannot find module 'better-sqlite3'"));
+    const { createSqliteDriver } = await import("@/database/create-sqlite-driver");
+
+    await createSqliteDriver({ type: "sqlite", path: "/tmp/x.db", driver: "auto" });
+
+    expect(mockNativeInitialize).toHaveBeenCalled();
+    expect(mockCliInitialize).toHaveBeenCalled();
+  });
+
+  it("native: propagates initialize failure", async () => {
+    mockNativeInitialize.mockRejectedValueOnce(new Error("native broken"));
+    const { createSqliteDriver } = await import("@/database/create-sqlite-driver");
+
+    await expect(
+      createSqliteDriver({ type: "sqlite", path: "/tmp/x.db", driver: "native" })
+    ).rejects.toThrow("native broken");
+  });
+});

--- a/tests/unit/database/logging-driver-config.test.ts
+++ b/tests/unit/database/logging-driver-config.test.ts
@@ -29,6 +29,13 @@ describe("loggingDatabaseConfigToDriver", () => {
     });
   });
 
+  it("sqlite: passes driver when set", () => {
+    expect(loggingDatabaseConfigToDriver({ type: "sqlite", driver: "cli" })).toMatchObject({
+      type: "sqlite",
+      driver: "cli",
+    });
+  });
+
   it("postgres: maps name -> database field", () => {
     expect(
       loggingDatabaseConfigToDriver({

--- a/tests/unit/database/sqlite-native.test.ts
+++ b/tests/unit/database/sqlite-native.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs";
+import { SqliteNativeDriver } from "@/database/drivers/sqlite-native";
+
+function isBetterSqlite3AvailableForNode(): boolean {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/naming-convention -- probe better-sqlite3 availability
+    const BetterSqlite3Ctor = require("better-sqlite3") as new (path: string) => { close(): void };
+    const db = new BetterSqlite3Ctor(":memory:");
+    db.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Skips when better-sqlite3 was rebuilt for Electron (e.g. after desktop postinstall). */
+const nativeForNode = isBetterSqlite3AvailableForNode();
+
+describe.skipIf(!nativeForNode)("SqliteNativeDriver", () => {
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `ccrelay-native-test-${Date.now()}.db`);
+  });
+
+  afterEach(() => {
+    try {
+      fs.unlinkSync(dbPath);
+    } catch {
+      // ignore
+    }
+  });
+
+  it("inserts and queries logs", async () => {
+    const driver = new SqliteNativeDriver({ type: "sqlite", path: dbPath });
+    await driver.initialize();
+
+    driver.insertLog({
+      timestamp: Date.now(),
+      providerId: "p1",
+      providerName: "Provider",
+      method: "POST",
+      path: "/v1/messages",
+      duration: 100,
+      success: true,
+    });
+
+    const { logs, total } = await driver.queryLogs({ limit: 10 });
+    expect(total).toBe(1);
+    expect(logs[0]?.providerId).toBe("p1");
+
+    await driver.close();
+  });
+});

--- a/web/src/features/logs/Logs.tsx
+++ b/web/src/features/logs/Logs.tsx
@@ -158,6 +158,7 @@ export default function Logs() {
     "analysis"
   );
   const [responseTab, setResponseTab] = useState<"analysis" | "converted" | "original">("analysis");
+  const [refreshing, setRefreshing] = useState(false);
 
   // Use ref for stable data access in callbacks
   const stateRef = useRef({
@@ -214,7 +215,44 @@ export default function Logs() {
       });
     },
     enabled: currentOffset === 0,
+    staleTime: 0,
   });
+
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    setState(state => ({
+      ...state,
+      allLogs: [],
+      totalCount: 0,
+      lastLogId: null,
+      isLoadingMore: false,
+    }));
+    try {
+      await queryClient.invalidateQueries({ queryKey: ["logs"] });
+      const result = await queryClient.fetchQuery({
+        queryKey: ["logs", filter, 0],
+        queryFn: () =>
+          api.getLogs({
+            ...filter,
+            limit: PAGE_SIZE,
+            offset: 0,
+          }),
+        staleTime: 0,
+      });
+      setState(state => ({
+        ...state,
+        allLogs: result.logs,
+        totalCount: result.total,
+        lastLogId: result.logs[result.logs.length - 1]?.id ?? null,
+        isLoadingMore: false,
+      }));
+      await queryClient.invalidateQueries({ queryKey: ["stats"] });
+    } catch (error) {
+      console.error("[Logs] Refresh failed:", error);
+    } finally {
+      setRefreshing(false);
+    }
+  }, [filter, queryClient]);
 
   // Append new logs when data changes
   useEffect(() => {
@@ -671,13 +709,14 @@ export default function Logs() {
               variant="outline"
               size="sm"
               className="h-7 text-xs"
-              onClick={() => {
-                setState(state => ({ ...state, allLogs: [], totalCount: 0, lastLogId: null }));
-                queryClient.refetchQueries({ queryKey: ["logs"] });
-                queryClient.refetchQueries({ queryKey: ["stats"] });
-              }}
+              onClick={() => void handleRefresh()}
+              disabled={refreshing}
             >
-              <RefreshCw className="h-3 w-3 mr-1" />
+              {refreshing ? (
+                <Loader2 className="h-3 w-3 mr-1 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3 w-3 mr-1" />
+              )}
               {t("common.refresh")}
             </Button>
           </div>


### PR DESCRIPTION
## Summary

- **Desktop request logs** use in-process SQLite (`better-sqlite3` 12.9.0) instead of the CLI subprocess driver for lower write/query latency on Electron.
- **Worker driver selection** prefers native on Desktop and CLI on VS Code, with `auto` falling back to CLI when native init fails; optional `logging.database.driver` in config.
- **Logs page refresh** always fetches the latest entries from the server (fixes stale React Query cache within the global 5s `staleTime`).
- **CI / deps**: Desktop build job uses Node 22; `ws` and `fast-uri` bumped for audit fixes.

## Test plan

- [ ] `npm install` and `cd packages/desktop && npx electron-rebuild -f -w better-sqlite3` succeed on macOS
- [ ] `npm run desktop:build && npm run desktop:start` — logs show `[SqliteNative]` and leader starts without errors
- [ ] Send proxied requests; completed rows appear in Logs after **manual refresh** immediately
- [ ] `npm run test:all` passes
- [ ] Packaged Desktop app (`npm run desktop:pack:mac`) starts and persists logs with native driver


Made with [Cursor](https://cursor.com)