### PR TITLE
fix(ci): sign better-sqlite3 .node binaries before Tauri notarization

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -433,6 +433,17 @@ jobs:
           rm -f "$P12_FILE"
           echo "signed=true" >> "$GITHUB_OUTPUT"
 
+      - name: Sign native .node binaries for notarization
+        if: matrix.platform == 'mac' && steps.tauri_mac_signing.outputs.signed == 'true'
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          find packages/desktop-tauri/out -name "*.node" -exec \
+            codesign --sign "$APPLE_SIGNING_IDENTITY" \
+                     --timestamp \
+                     --options runtime \
+                     --force {} \;
+
       - name: Pack Tauri (${{ matrix.platform }} ${{ matrix.arch }})
         run: npx tauri build --target ${{ matrix.rust_target }}
         working-directory: packages/desktop-tauri


### PR DESCRIPTION
## Summary

- Fixes macOS Tauri arm64 CI failures during Apple notarization.
- `better_sqlite3.node` is bundled as a Tauri resource but was not signed; notarization rejects unsigned Mach-O binaries in the app bundle.
- Adds a CI step to codesign all `.node` files under `packages/desktop-tauri/out` with Developer ID, secure timestamp, and hardened runtime before `npx tauri build`.

## Test plan

- [ ] Re-run the failed `build-tauri` macOS arm64 workflow job
- [ ] Confirm notarization passes (no errors on `better_sqlite3.node`)
- [ ] Verify the produced `.dmg` installs and runs on Apple Silicon


Made with [Cursor](https://cursor.com)