### PR TITLE
fix(desktop): rebuild better-sqlite3 for Electron ABI in CI and local pack

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -279,7 +279,7 @@ jobs:
         run: npm install
 
       - name: Rebuild native modules for Electron
-        run: npx electron-rebuild -f -w better-sqlite3 --arch ${{ matrix.arch }}
+        run: npx electron-builder install-app-deps --arch ${{ matrix.arch }}
         working-directory: packages/desktop
 
       - name: Build desktop

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -278,6 +278,10 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Rebuild native modules for Electron
+        run: npx electron-rebuild -f -w better-sqlite3 --arch ${{ matrix.arch }}
+        working-directory: packages/desktop
+
       - name: Build desktop
         run: npm run desktop:build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10354,7 +10354,7 @@
         "@types/node": "^22.19.11",
         "@types/pg": "^8.16.0",
         "@types/ws": "^8.5.13",
-        "better-sqlite3": "12.9.0",
+        "better-sqlite3": "^12.9.0",
         "typescript": "^5.0.4"
       }
     },
@@ -10401,10 +10401,9 @@
       "license": "MIT",
       "dependencies": {
         "@ccrelay/core": "*",
-        "better-sqlite3": "12.9.0"
+        "better-sqlite3": "^12.9.0"
       },
       "devDependencies": {
-        "@electron/rebuild": "^3.7.0",
         "@types/node": "^22.19.11",
         "electron": "^41.5.0",
         "electron-builder": "^26.8.1",
@@ -10417,7 +10416,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@ccrelay/core": "*",
-        "better-sqlite3": "12.9.0"
+        "better-sqlite3": "^12.9.0"
       },
       "devDependencies": {
         "@tauri-apps/api": "^2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
-    "better-sqlite3": "12.9.0",
+    "better-sqlite3": "^12.9.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.19.11",
     "@types/pg": "^8.16.0",

--- a/packages/desktop-tauri/package.json
+++ b/packages/desktop-tauri/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@ccrelay/core": "*",
-    "better-sqlite3": "12.9.0"
+    "better-sqlite3": "^12.9.0"
   },
   "devDependencies": {
     "@tauri-apps/api": "^2",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -12,11 +12,11 @@
     "postinstall": "electron-rebuild -f -w better-sqlite3",
     "build": "node ../../scripts/esbuild.desktop.mjs",
     "start": "electron .",
-    "pack": "electron-builder --publish never",
-    "pack:mac": "electron-builder --mac --publish never",
-    "pack:mac:all": "electron-builder --mac --x64 --arm64 --publish never",
-    "pack:win": "electron-builder --win --publish never",
-    "pack:win:all": "electron-builder --win --x64 --arm64 --publish never"
+    "pack": "electron-rebuild -f -w better-sqlite3 && electron-builder --publish never",
+    "pack:mac": "electron-rebuild -f -w better-sqlite3 && electron-builder --mac --publish never",
+    "pack:mac:all": "electron-rebuild -f -w better-sqlite3 && electron-builder --mac --x64 --arm64 --publish never",
+    "pack:win": "electron-rebuild -f -w better-sqlite3 && electron-builder --win --publish never",
+    "pack:win:all": "electron-rebuild -f -w better-sqlite3 && electron-builder --win --x64 --arm64 --publish never"
   },
   "dependencies": {
     "@ccrelay/core": "*",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -9,21 +9,20 @@
   "main": "out/main.js",
   "scripts": {
     "compile": "tsc --noEmit -p tsconfig.json",
-    "postinstall": "electron-rebuild -f -w better-sqlite3",
+    "postinstall": "electron-builder install-app-deps",
     "build": "node ../../scripts/esbuild.desktop.mjs",
     "start": "electron .",
-    "pack": "electron-rebuild -f -w better-sqlite3 && electron-builder --publish never",
-    "pack:mac": "electron-rebuild -f -w better-sqlite3 && electron-builder --mac --publish never",
-    "pack:mac:all": "electron-rebuild -f -w better-sqlite3 && electron-builder --mac --x64 --arm64 --publish never",
-    "pack:win": "electron-rebuild -f -w better-sqlite3 && electron-builder --win --publish never",
-    "pack:win:all": "electron-rebuild -f -w better-sqlite3 && electron-builder --win --x64 --arm64 --publish never"
+    "pack": "electron-builder --publish never",
+    "pack:mac": "electron-builder --mac --publish never",
+    "pack:mac:all": "electron-builder --mac --x64 --arm64 --publish never",
+    "pack:win": "electron-builder --win --publish never",
+    "pack:win:all": "electron-builder --win --x64 --arm64 --publish never"
   },
   "dependencies": {
     "@ccrelay/core": "*",
-    "better-sqlite3": "12.9.0"
+    "better-sqlite3": "^12.9.0"
   },
   "devDependencies": {
-    "@electron/rebuild": "^3.7.0",
     "@types/node": "^22.19.11",
     "electron": "^41.5.0",
     "electron-builder": "^26.8.1",


### PR DESCRIPTION
## Summary

- Fixes Electron desktop builds shipping `better-sqlite3` compiled for Node 22 (ABI 127) while Electron 41 requires ABI 145, causing LogDatabase init failures at runtime.
- Adds explicit `electron-builder install-app-deps` in CI before desktop pack, and switches local `postinstall` / pack flow to the same mechanism.
- Aligns `better-sqlite3` to `^12.9.0` across packages to avoid npm `ELSPROBLEMS` in electron-builder dependency collection.
- Removes redundant `@electron/rebuild` devDependency (already bundled with electron-builder).

## Related

- Builds on merged PR #70 (Tauri `.node` codesign for notarization).

## Test plan

- [ ] Re-run CI `build-desktop` for macOS arm64 and verify packaged app starts with LogDatabase initialized
- [ ] Re-run CI `build-tauri` for macOS arm64 and confirm notarization passes
- [ ] Local: `npm run desktop:pack:mac` produces a DMG that launches without `NODE_MODULE_VERSION` errors
- [ ] Local: `npm run tauri:pack:mac` (or `CI=true` if needed for DMG) completes successfully


Made with [Cursor](https://cursor.com)