### PR TITLE
fix(ci): rebuild better-sqlite3 for Node before unit tests

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Rebuild better-sqlite3 for Node (unit tests)
+        run: npm rebuild better-sqlite3
+
       - name: Run lint
         run: npm run lint
 

--- a/tests/unit/database/log-db-migration.test.ts
+++ b/tests/unit/database/log-db-migration.test.ts
@@ -1,14 +1,19 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
-const hasBetterSqlite3 = ((): boolean => {
+/** Skips when better-sqlite3 was rebuilt for Electron (e.g. after desktop postinstall). */
+function isBetterSqlite3AvailableForNode(): boolean {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require("better-sqlite3");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/naming-convention
+    const BetterSqlite3Ctor = require("better-sqlite3") as new (path: string) => { close(): void };
+    const db = new BetterSqlite3Ctor(":memory:");
+    db.close();
     return true;
   } catch {
     return false;
   }
-})();
+}
+
+const nativeForNode = isBetterSqlite3AvailableForNode();
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -18,7 +23,7 @@ function encodeForStorageLegacy(value: string): string {
   return "B64:" + Buffer.from(value, "utf-8").toString("base64");
 }
 
-describe.skipIf(!hasBetterSqlite3)("log-db-migration", () => {
+describe.skipIf(!nativeForNode)("log-db-migration", () => {
   let tmpDir: string;
   let dbPath: string;
 


### PR DESCRIPTION
## Summary

- Rebuild `better-sqlite3` for system Node in the CI test job after `npm install`, so Vitest is not broken when desktop `postinstall` compiles the module for Electron.
- Align `log-db-migration` tests with `sqlite-native` by probing with `:memory:`; skip the suite when only an Electron-built binary is available.

Follow-up to #72 (Electron rebuild for desktop dev/pack).

## Test plan

- [x] `npm run test:unit -- tests/unit/database/log-db-migration.test.ts` passes locally
- [ ] CI `test` job passes on Ubuntu (no `Module did not self-register` in `log-db-migration.test.ts`)


Made with [Cursor](https://cursor.com)