### PR TITLE
fix(tauri): bundle sidecar resources with full directory layout

### DIFF
--- a/packages/desktop-tauri/src-tauri/tauri.conf.json
+++ b/packages/desktop-tauri/src-tauri/tauri.conf.json
@@ -26,12 +26,12 @@
       "icons/icon.ico"
     ],
     "externalBin": ["binaries/ccrelay-server"],
-    "resources": [
-      "../web/**/*",
-      "../out/ccrelay-server.js",
-      "../out/database-worker.cjs",
-      "../out/native/node_modules/better-sqlite3/**/*"
-    ],
+    "resources": {
+      "../web/": "web/",
+      "../out/ccrelay-server.js": "out/ccrelay-server.js",
+      "../out/database-worker.cjs": "out/database-worker.cjs",
+      "../out/native/": "native/"
+    },
     "windows": {
       "webviewInstallMode": {
         "silent": true,

--- a/scripts/esbuild.tauri.mjs
+++ b/scripts/esbuild.tauri.mjs
@@ -42,29 +42,48 @@ await esbuild.build({
   outfile: path.join(outDir, "database-worker.cjs"),
 });
 
-// Copy better-sqlite3 native addon for sidecar (resolved via NODE_PATH at runtime)
-function resolveBetterSqlite3Dir() {
-  const candidates = [
-    path.join(tauriDir, "node_modules/better-sqlite3"),
-    path.join(rootDir, "node_modules/better-sqlite3"),
-    path.join(coreDir, "node_modules/better-sqlite3"),
-  ];
-  for (const dir of candidates) {
-    if (fs.existsSync(path.join(dir, "package.json"))) {
-      return dir;
+// Copy better-sqlite3 and runtime deps for sidecar (resolved via NODE_PATH at runtime)
+function resolvePackageDir(packageName, anchorDirs) {
+  const seen = new Set();
+  for (const anchor of anchorDirs) {
+    const candidates = [
+      path.join(anchor, "node_modules", packageName),
+      path.join(path.dirname(anchor), "node_modules", packageName),
+      path.join(rootDir, "node_modules", packageName),
+    ];
+    for (const dir of candidates) {
+      if (seen.has(dir)) {
+        continue;
+      }
+      seen.add(dir);
+      if (fs.existsSync(path.join(dir, "package.json"))) {
+        return dir;
+      }
     }
   }
   throw new Error(
-    "better-sqlite3 not found. Run npm install from the repo root (desktop-tauri depends on it)."
+    `${packageName} not found. Run npm install from the repo root (desktop-tauri depends on it).`
   );
 }
 
+function copyIntoNativeNodeModules(packageName, anchorDirs) {
+  const src = resolvePackageDir(packageName, anchorDirs);
+  const dest = path.join(outDir, "native/node_modules", packageName);
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.cpSync(src, dest, { recursive: true });
+}
+
+const nativeAnchors = [
+  path.join(tauriDir, "node_modules/better-sqlite3"),
+  path.join(rootDir, "node_modules/better-sqlite3"),
+  path.join(coreDir, "node_modules/better-sqlite3"),
+];
+
 execSync("npm rebuild better-sqlite3", { cwd: rootDir, stdio: "inherit" });
 
-const betterSqlite3Src = resolveBetterSqlite3Dir();
-const betterSqlite3Dest = path.join(outDir, "native/node_modules/better-sqlite3");
-fs.mkdirSync(path.dirname(betterSqlite3Dest), { recursive: true });
-fs.cpSync(betterSqlite3Src, betterSqlite3Dest, { recursive: true });
+copyIntoNativeNodeModules("better-sqlite3", nativeAnchors);
+copyIntoNativeNodeModules("bindings", nativeAnchors);
+copyIntoNativeNodeModules("file-uri-to-path", nativeAnchors);
 
 // Sidecar binary: copy Node executable (Tauri externalBin)
 const targetTriple = execSync("rustc --print host-tuple").toString().trim();


### PR DESCRIPTION
## Summary

- Fix Tauri app bundle resource paths so sidecar JS, native modules, and web UI land under `Resources/out/`, `Resources/native/`, and `Resources/web/` (matching `sidecar.rs` resolution).
- Copy full `out/native/` tree and use directory-based resource maps instead of `**/*` globs, which flattened `better-sqlite3` and `web/assets` in CI builds.
- Bundle `bindings` and `file-uri-to-path` alongside `better-sqlite3` for the Node sidecar `NODE_PATH`.

## Test plan

- [x] Local `npm run tauri:pack:mac` — sidecar starts, `[DatabaseWorker] Initialized`, dashboard loads CSS/JS
- [ ] CI `build-tauri` produces installable macOS/Windows artifacts
- [ ] CI-built DMG runs without `Sidecar JS not found`, missing `bindings`, or `[Static] File not found` for `web/assets/*`


Made with [Cursor](https://cursor.com)