### PR TITLE
feat(web): client config tab, queue status, and proxy streaming fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cross-protocol streaming now forwards upstream errors as native SSE events for Anthropic, OpenAI Chat, and OpenAI Responses clients instead of returning a misleading 502.
 - Streaming requests that finish normally (e.g. Codex on Azure Responses API ending with `response.completed`) are no longer mislogged as 499 "Client disconnected" when the client tears down the connection after reading the final event, even when the upstream FIN is delayed.
+- Cross-protocol Responses to OpenAI Chat now strips unsupported hosted tools on GLM, MiMo, DeepSeek, Gemini, and MiniMax; Codex `apply_patch` freeform tools are downgraded to string-arg functions so Chat-only upstreams no longer reject requests with `Param Incorrect`.
+- Request logs for cross-protocol streaming (Chat SSE to Responses SSE) now update from `pending` to `completed` when the stream finishes, matching passthrough streaming behavior.
+- Cross-protocol streaming request logs now store the converted Responses SSE sent to the client and the upstream wire body, not only status and duration.
 
 ## [0.2.5] - 2026-05-26 (pre-release)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-05-26 (pre-release)
+
+Pre-release line for 0.2.5.
+
 ## [0.2.4] - 2026-05-19
 
 Admin UI on shadcn/ui, Claude Desktop and Web search controls, and **DeepSeek** / **Astraflow (UCloud)** add-provider presets. Request logs move to a compact v2 table with automatic migration; desktop apps use in-process SQLite and Tauri bundles a Node sidecar. Reasoning-effort mapping updates and macOS Tahoe fixes for desktop, VS Code, and proxy streaming.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Cross-protocol streaming now forwards upstream errors as native SSE events for Anthropic, OpenAI Chat, and OpenAI Responses clients instead of returning a misleading 502.
+- Streaming requests that finish normally (e.g. Codex on Azure Responses API ending with `response.completed`) are no longer mislogged as 499 "Client disconnected" when the client tears down the connection after reading the final event, even when the upstream FIN is delayed.
+
 ## [0.2.5] - 2026-05-26 (pre-release)
 
 Pre-release line for 0.2.5.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccrelay-monorepo",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccrelay-monorepo",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -10340,7 +10340,7 @@
     },
     "packages/core": {
       "name": "@ccrelay/core",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.1",
@@ -10396,7 +10396,7 @@
     },
     "packages/desktop": {
       "name": "ccrelay-desktop",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -10412,7 +10412,7 @@
     },
     "packages/desktop-tauri": {
       "name": "@ccrelay/desktop-tauri",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "hasInstallScript": true,
       "dependencies": {
         "@ccrelay/core": "*",
@@ -11108,7 +11108,7 @@
     },
     "packages/vscode": {
       "name": "ccrelay-vscode",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@ccrelay/core": "*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "ccrelay-monorepo",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "license": "MIT",
   "packageManager": "npm@10.9.4",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ccrelay/core",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "description": "CCRelay proxy server core (Node.js)",
   "license": "MIT",

--- a/packages/core/src/api/clientConfig.ts
+++ b/packages/core/src/api/clientConfig.ts
@@ -9,6 +9,7 @@ import * as http from "http";
 import * as os from "os";
 import * as path from "path";
 import type { ProxyServer } from "../server/handler";
+import { CCRELAY_MODEL_ALIAS_HEADER } from "../converter/models-fallback";
 
 function sendJson(res: http.ServerResponse, status: number, data: unknown): void {
   // eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP response header
@@ -55,16 +56,94 @@ function claudeDesktopDir(): string | null {
 
 export type ClientConfigItemStatus = "ok" | "missing" | "wrong_target" | "invalid";
 
+export interface ClientConfigField {
+  key: string;
+  expected: string;
+  current?: string;
+  ok: boolean;
+}
+
 export interface ClientConfigItem {
   status: ClientConfigItemStatus;
   filePath: string;
+  fields: ClientConfigField[];
   /** e.g. ANTHROPIC_BASE_URL or Codex base_url */
   currentValue?: string;
+  /** Claude Desktop inferenceCustomHeaders when readable */
+  customHeaders?: Record<string, string>;
+  /** Expected Claude Desktop inferenceCustomHeaders for Cowork alias mode */
+  expectedCustomHeaders?: Record<string, string>;
   /** For Codex, which model_provider is selected */
   modelProvider?: string;
   /** For Codex, the current model value from config.toml */
   model?: string;
   message?: string;
+}
+
+function formatScalarFieldValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return undefined;
+}
+
+function resolveStatusFromFields(
+  fields: ClientConfigField[],
+  options: { baseUrlKey?: string; hasInvalidBaseType?: boolean }
+): ClientConfigItemStatus {
+  if (options.hasInvalidBaseType) {
+    return "wrong_target";
+  }
+  const baseKey = options.baseUrlKey;
+  if (baseKey) {
+    const baseField = fields.find(f => f.key === baseKey);
+    if (baseField && !baseField.ok && baseField.current !== undefined && baseField.current !== "") {
+      return "wrong_target";
+    }
+  }
+  if (fields.every(f => f.ok)) {
+    return "ok";
+  }
+  return "missing";
+}
+
+function itemFromFields(
+  filePath: string,
+  fields: ClientConfigField[],
+  options?: {
+    baseUrlKey?: string;
+    hasInvalidBaseType?: boolean;
+    message?: string;
+    currentValue?: string;
+    customHeaders?: Record<string, string>;
+    expectedCustomHeaders?: Record<string, string>;
+    modelProvider?: string;
+    model?: string;
+  }
+): ClientConfigItem {
+  const status = resolveStatusFromFields(fields, {
+    baseUrlKey: options?.baseUrlKey,
+    hasInvalidBaseType: options?.hasInvalidBaseType,
+  });
+  return {
+    status,
+    filePath,
+    fields,
+    ...(options?.currentValue !== undefined ? { currentValue: options.currentValue } : {}),
+    ...(options?.customHeaders !== undefined ? { customHeaders: options.customHeaders } : {}),
+    ...(options?.expectedCustomHeaders !== undefined
+      ? { expectedCustomHeaders: options.expectedCustomHeaders }
+      : {}),
+    ...(options?.modelProvider !== undefined ? { modelProvider: options.modelProvider } : {}),
+    ...(options?.model !== undefined ? { model: options.model } : {}),
+    ...(options?.message !== undefined ? { message: options.message } : {}),
+  };
 }
 
 /** Optional Claude Code env overrides (CCRelay modelMap usually enough). */
@@ -139,6 +218,99 @@ function buildClaudeDefaultEnv(port: number): Record<string, string | number> {
     API_TIMEOUT_MS: "3000000",
     CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: 1,
   };
+}
+
+function isNonEmptyScalar(v: unknown): boolean {
+  if (v === undefined || v === null) {
+    return false;
+  }
+  if (typeof v === "string") {
+    return v.trim() !== "";
+  }
+  if (typeof v === "number" || typeof v === "boolean") {
+    return true;
+  }
+  return false;
+}
+
+function isTruthyEnvFlag(v: unknown): boolean {
+  if (v === true || v === 1) {
+    return true;
+  }
+  if (typeof v === "string") {
+    const t = v.trim().toLowerCase();
+    return t === "1" || t === "true";
+  }
+  return false;
+}
+
+function isPositiveNumericString(v: unknown): boolean {
+  if (v === undefined || v === null) {
+    return false;
+  }
+  const n = typeof v === "number" ? v : typeof v === "string" ? Number(v.trim()) : NaN;
+  return Number.isFinite(n) && n > 0;
+}
+
+function findHeaderValueCaseInsensitive(
+  headers: Record<string, string>,
+  canonicalKey: string
+): string | undefined {
+  const target = canonicalKey.toLowerCase();
+  for (const [k, v] of Object.entries(headers)) {
+    if (k.toLowerCase() === target) {
+      return String(v);
+    }
+  }
+  return undefined;
+}
+
+export function buildClaudeCodeFields(
+  env: Record<string, unknown> | undefined,
+  port: number
+): ClientConfigField[] {
+  const baseUrlRaw = env?.ANTHROPIC_BASE_URL;
+  const baseUrlStr = formatScalarFieldValue(baseUrlRaw)?.trim();
+  const baseOk = baseUrlStr ? isLocalProxyAnthropicBase(baseUrlStr, port) : false;
+  const authToken = env?.ANTHROPIC_AUTH_TOKEN;
+  const timeout = env?.API_TIMEOUT_MS;
+  const disableTraffic = env?.CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC;
+
+  return [
+    {
+      key: "ANTHROPIC_BASE_URL",
+      expected: `http://127.0.0.1:${port}/anthropic`,
+      current: baseUrlStr,
+      ok: baseOk,
+    },
+    {
+      key: "ANTHROPIC_AUTH_TOKEN",
+      expected: "(non-empty)",
+      current: formatScalarFieldValue(authToken),
+      ok: isNonEmptyScalar(authToken),
+    },
+    {
+      key: "API_TIMEOUT_MS",
+      expected: "(positive number)",
+      current: formatScalarFieldValue(timeout),
+      ok: isPositiveNumericString(timeout),
+    },
+    {
+      key: "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+      expected: "(truthy)",
+      current: formatScalarFieldValue(disableTraffic),
+      ok: isTruthyEnvFlag(disableTraffic),
+    },
+  ];
+}
+
+export function getClaudeCodeEnvGaps(
+  env: Record<string, unknown> | undefined,
+  port: number
+): string[] {
+  return buildClaudeCodeFields(env, port)
+    .filter(f => !f.ok)
+    .map(f => f.key);
 }
 /* eslint-enable @typescript-eslint/naming-convention */
 
@@ -227,64 +399,109 @@ export function parseTomlLite(content: string): ParsedTomlLite {
 function detectClaude(claudePath: string, port: number): ClientConfigItem {
   const filePath = claudePath;
   if (!fs.existsSync(claudePath)) {
-    return { status: "missing", filePath };
+    return itemFromFields(filePath, buildClaudeCodeFields(undefined, port), {
+      baseUrlKey: "ANTHROPIC_BASE_URL",
+    });
   }
   const raw = fs.readFileSync(claudePath, "utf-8");
   let parsed: { env?: Record<string, unknown> };
   try {
     parsed = JSON.parse(raw) as { env?: Record<string, unknown> };
   } catch {
-    return { status: "invalid", filePath, message: "Invalid JSON" };
+    return { status: "invalid", filePath, fields: [], message: "Invalid JSON" };
   }
-  const base = parsed.env?.ANTHROPIC_BASE_URL;
-  if (base === undefined || base === null) {
-    return { status: "missing", filePath, message: "ANTHROPIC_BASE_URL not set in env" };
+
+  const env = parsed.env;
+  const base = env?.ANTHROPIC_BASE_URL;
+  const baseStr =
+    base === undefined || base === null
+      ? undefined
+      : typeof base === "string" || typeof base === "number"
+        ? String(base).trim()
+        : undefined;
+
+  const fields = buildClaudeCodeFields(env, port);
+
+  if (baseStr === undefined) {
+    if (base !== undefined && base !== null) {
+      return itemFromFields(filePath, fields, {
+        baseUrlKey: "ANTHROPIC_BASE_URL",
+        hasInvalidBaseType: true,
+        currentValue: JSON.stringify(base),
+        message: "ANTHROPIC_BASE_URL must be a string",
+      });
+    }
+    return itemFromFields(filePath, fields, {
+      baseUrlKey: "ANTHROPIC_BASE_URL",
+      message: "ANTHROPIC_BASE_URL not set in env",
+    });
   }
-  if (typeof base !== "string" && typeof base !== "number") {
-    return {
-      status: "wrong_target",
-      filePath,
-      currentValue: JSON.stringify(base),
-      message: "ANTHROPIC_BASE_URL must be a string",
-    };
+
+  if (baseStr === "") {
+    return itemFromFields(filePath, fields, {
+      baseUrlKey: "ANTHROPIC_BASE_URL",
+      message: "ANTHROPIC_BASE_URL not set in env",
+    });
   }
-  const s = String(base).trim();
-  if (s === "") {
-    return { status: "missing", filePath, message: "ANTHROPIC_BASE_URL not set in env" };
-  }
-  if (isLocalProxyAnthropicBase(s, port)) {
-    return { status: "ok", filePath, currentValue: s };
-  }
-  return { status: "wrong_target", filePath, currentValue: s };
+
+  return itemFromFields(filePath, fields, {
+    baseUrlKey: "ANTHROPIC_BASE_URL",
+    currentValue: baseStr,
+  });
+}
+
+export function buildCodexFields(toml: ParsedTomlLite, port: number): ClientConfigField[] {
+  const expectedBase = `http://127.0.0.1:${port}/openai`;
+  const modelProvider = toml.top.model_provider;
+  const model = toml.top.model;
+  const baseUrl = modelProvider
+    ? toml.sections[`model_providers.${modelProvider}`]?.base_url
+    : undefined;
+
+  return [
+    {
+      key: "model_provider",
+      expected: "ccrelay",
+      current: modelProvider,
+      ok: modelProvider === "ccrelay",
+    },
+    {
+      key: "model_providers.ccrelay.base_url",
+      expected: expectedBase,
+      current: baseUrl,
+      ok: baseUrl ? isLocalProxyCodexBase(baseUrl, port) : false,
+    },
+    {
+      key: "model",
+      expected: "(any non-empty)",
+      current: model?.trim() || undefined,
+      ok: Boolean(model?.trim()),
+    },
+  ];
 }
 
 function detectCodex(codexPath: string, port: number): ClientConfigItem {
   const filePath = codexPath;
   if (!fs.existsSync(codexPath)) {
-    return { status: "missing", filePath };
+    return itemFromFields(filePath, buildCodexFields({ top: {}, sections: {} }, port), {
+      baseUrlKey: "model_providers.ccrelay.base_url",
+    });
   }
   const raw = fs.readFileSync(codexPath, "utf-8");
   const toml = parseTomlLite(raw);
   const modelProvider = toml.top.model_provider;
   const model = toml.top.model;
-  if (!modelProvider) {
-    return { status: "missing", filePath, model, message: "model_provider not set" };
-  }
-  const sec = toml.sections[`model_providers.${modelProvider}`];
-  const baseUrl = sec?.base_url;
-  if (!baseUrl) {
-    return {
-      status: "missing",
-      filePath,
-      modelProvider,
-      model,
-      message: "base_url not set for provider",
-    };
-  }
-  if (isLocalProxyCodexBase(baseUrl, port)) {
-    return { status: "ok", filePath, currentValue: baseUrl, modelProvider, model };
-  }
-  return { status: "wrong_target", filePath, currentValue: baseUrl, modelProvider, model };
+  const fields = buildCodexFields(toml, port);
+  const baseUrl = modelProvider
+    ? toml.sections[`model_providers.${modelProvider}`]?.base_url
+    : undefined;
+
+  return itemFromFields(filePath, fields, {
+    baseUrlKey: "model_providers.ccrelay.base_url",
+    currentValue: baseUrl,
+    modelProvider,
+    model,
+  });
 }
 
 interface ClaudeDesktopMeta {
@@ -309,39 +526,198 @@ function readClaudeDesktopMeta(dir: string): ClaudeDesktopMeta | null {
   }
 }
 
+function readClaudeDesktopCustomHeaders(
+  parsed: Record<string, unknown>
+): Record<string, string> | undefined {
+  const custom = parsed.inferenceCustomHeaders;
+  if (!custom || typeof custom !== "object" || Array.isArray(custom)) {
+    return undefined;
+  }
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(custom as Record<string, unknown>)) {
+    if (typeof value === "string" || typeof value === "number") {
+      out[key] = String(value);
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+export function expectedClaudeDesktopCustomHeaders(): Record<string, string> {
+  return { [CCRELAY_MODEL_ALIAS_HEADER]: "1" };
+}
+
+export function hasExpectedClaudeDesktopCustomHeaders(
+  headers: Record<string, string> | undefined
+): boolean {
+  if (!headers) {
+    return false;
+  }
+  const alias = findHeaderValueCaseInsensitive(headers, CCRELAY_MODEL_ALIAS_HEADER);
+  return alias !== undefined && alias.trim() !== "";
+}
+
+export function isCoworkEgressAllowed(hosts: unknown): boolean {
+  return Array.isArray(hosts) && hosts.length > 0 && hosts.some(entry => String(entry) === "*");
+}
+
+export function buildClaudeDesktopFields(
+  parsed: Record<string, unknown>,
+  port: number,
+  deploymentMode?: string
+): ClientConfigField[] {
+  const customHeaders = readClaudeDesktopCustomHeaders(parsed);
+
+  const baseUrl = parsed.inferenceGatewayBaseUrl;
+  let trimmedBase: string | undefined;
+  let baseOk = false;
+  if (typeof baseUrl === "string" && baseUrl.trim()) {
+    trimmedBase = baseUrl.trim();
+    baseOk = isLocalProxyAnthropicBase(trimmedBase, port);
+  }
+
+  const fields: ClientConfigField[] = [
+    {
+      key: "inferenceGatewayBaseUrl",
+      expected: `http://127.0.0.1:${port}/anthropic`,
+      current: trimmedBase,
+      ok: baseOk,
+    },
+    {
+      key: "inferenceProvider",
+      expected: "gateway",
+      current: formatScalarFieldValue(parsed.inferenceProvider),
+      ok: parsed.inferenceProvider === "gateway",
+    },
+    {
+      key: "inferenceGatewayApiKey",
+      expected: "(non-empty)",
+      current: formatScalarFieldValue(parsed.inferenceGatewayApiKey),
+      ok:
+        typeof parsed.inferenceGatewayApiKey === "string" &&
+        String(parsed.inferenceGatewayApiKey).trim() !== "",
+    },
+    {
+      key: "coworkEgressAllowedHosts",
+      expected: '(non-empty array including "*")',
+      current: formatScalarFieldValue(parsed.coworkEgressAllowedHosts),
+      ok: isCoworkEgressAllowed(parsed.coworkEgressAllowedHosts),
+    },
+    {
+      key: "inferenceCustomHeaders",
+      expected: "x-ccrelay-model-alias: (non-empty, key case-insensitive)",
+      current: customHeaders ? JSON.stringify(customHeaders) : undefined,
+      ok: hasExpectedClaudeDesktopCustomHeaders(customHeaders),
+    },
+    {
+      key: "inferenceGatewayHeaders",
+      expected: "(absent)",
+      current:
+        parsed.inferenceGatewayHeaders === undefined
+          ? undefined
+          : formatScalarFieldValue(parsed.inferenceGatewayHeaders),
+      ok: parsed.inferenceGatewayHeaders === undefined,
+    },
+    {
+      key: "disableEssentialTelemetry",
+      expected: "true",
+      current: formatScalarFieldValue(parsed.disableEssentialTelemetry),
+      ok: parsed.disableEssentialTelemetry === true,
+    },
+    {
+      key: "disableNonessentialTelemetry",
+      expected: "true",
+      current: formatScalarFieldValue(parsed.disableNonessentialTelemetry),
+      ok: parsed.disableNonessentialTelemetry === true,
+    },
+    {
+      key: "deploymentMode",
+      expected: "3p",
+      current: deploymentMode,
+      ok: deploymentMode === "3p",
+    },
+  ];
+
+  return fields;
+}
+
+export function getClaudeDesktopConfigGaps(
+  parsed: Record<string, unknown>,
+  port: number,
+  deploymentMode?: string
+): { baseOk: boolean; trimmedBase?: string; gaps: string[] } {
+  const fields = buildClaudeDesktopFields(parsed, port, deploymentMode);
+  const baseField = fields.find(f => f.key === "inferenceGatewayBaseUrl");
+  return {
+    baseOk: baseField?.ok ?? false,
+    trimmedBase: baseField?.current,
+    gaps: fields.filter(f => !f.ok).map(f => f.key),
+  };
+}
+
+function readClaudeDesktopDeploymentMode(dir: string): string | undefined {
+  const desktopConfigPath = path.join(dir, "claude_desktop_config.json");
+  if (!fs.existsSync(desktopConfigPath)) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(desktopConfigPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    return typeof parsed.deploymentMode === "string" ? parsed.deploymentMode : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function evaluateClaudeDesktopConfig(
+  configPath: string,
+  parsed: Record<string, unknown>,
+  port: number,
+  deploymentMode?: string
+): ClientConfigItem {
+  const expectedCustomHeaders = expectedClaudeDesktopCustomHeaders();
+  const customHeaders = readClaudeDesktopCustomHeaders(parsed);
+  const fields = buildClaudeDesktopFields(parsed, port, deploymentMode);
+  const baseField = fields.find(f => f.key === "inferenceGatewayBaseUrl");
+
+  return itemFromFields(configPath, fields, {
+    baseUrlKey: "inferenceGatewayBaseUrl",
+    currentValue: baseField?.current,
+    customHeaders,
+    expectedCustomHeaders,
+  });
+}
+
 function detectClaudeDesktop(dir: string | null, port: number): ClientConfigItem | null {
   if (!dir) {
     return null;
   }
   const filePath = path.join(dir, "configLibrary");
   if (!fs.existsSync(dir)) {
-    return { status: "missing", filePath };
+    return itemFromFields(filePath, buildClaudeDesktopFields({}, port), {
+      baseUrlKey: "inferenceGatewayBaseUrl",
+    });
   }
   const meta = readClaudeDesktopMeta(dir);
   if (!meta) {
-    return { status: "missing", filePath: path.join(filePath, "_meta.json") };
+    return itemFromFields(path.join(filePath, "_meta.json"), buildClaudeDesktopFields({}, port), {
+      baseUrlKey: "inferenceGatewayBaseUrl",
+    });
   }
   const configPath = path.join(filePath, `${meta.appliedId}.json`);
   if (!fs.existsSync(configPath)) {
-    return { status: "missing", filePath: configPath };
+    return itemFromFields(configPath, buildClaudeDesktopFields({}, port), {
+      baseUrlKey: "inferenceGatewayBaseUrl",
+    });
   }
   try {
     const raw = fs.readFileSync(configPath, "utf-8");
     const parsed = JSON.parse(raw) as Record<string, unknown>;
-    const baseUrl = parsed.inferenceGatewayBaseUrl;
-    if (typeof baseUrl !== "string" || !baseUrl.trim()) {
-      return {
-        status: "missing",
-        filePath: configPath,
-        message: "inferenceGatewayBaseUrl not set",
-      };
-    }
-    if (isLocalProxyAnthropicBase(baseUrl.trim(), port)) {
-      return { status: "ok", filePath: configPath, currentValue: baseUrl.trim() };
-    }
-    return { status: "wrong_target", filePath: configPath, currentValue: baseUrl.trim() };
+    const deploymentMode = readClaudeDesktopDeploymentMode(dir);
+    return evaluateClaudeDesktopConfig(configPath, parsed, port, deploymentMode);
   } catch {
-    return { status: "invalid", filePath: configPath, message: "Invalid JSON" };
+    return { status: "invalid", filePath: configPath, fields: [], message: "Invalid JSON" };
   }
 }
 
@@ -692,7 +1068,6 @@ export async function handleApplyClientConfig(
       }
 
       // 1. developer_settings.json — merge
-      /* eslint-disable @typescript-eslint/naming-convention -- Claude Desktop settings keys */
       const devSettingsPath = path.join(dir, "developer_settings.json");
       let devSettings: Record<string, unknown> = {};
       if (fs.existsSync(devSettingsPath)) {
@@ -754,12 +1129,14 @@ export async function handleApplyClientConfig(
       ccConfig.inferenceProvider = "gateway";
       ccConfig.inferenceGatewayBaseUrl = `http://127.0.0.1:${port}/anthropic`;
       ccConfig.inferenceGatewayApiKey = "1";
-      ccConfig.inferenceGatewayHeaders = {
-        "x-ccrelay-model-alias": "1",
+      const existingHeaders = readClaudeDesktopCustomHeaders(ccConfig) ?? {};
+      ccConfig.inferenceCustomHeaders = {
+        ...existingHeaders,
+        ...expectedClaudeDesktopCustomHeaders(),
       };
+      delete ccConfig.inferenceGatewayHeaders;
       ccConfig.disableEssentialTelemetry = true;
       ccConfig.disableNonessentialTelemetry = true;
-      /* eslint-enable @typescript-eslint/naming-convention */
       fs.writeFileSync(configPath, `${JSON.stringify(ccConfig, null, 2)}\n`, "utf-8");
 
       sendJson(res, 200, { status: "ok", message: `Updated Claude Desktop config in ${dir}` });

--- a/packages/core/src/api/queue.ts
+++ b/packages/core/src/api/queue.ts
@@ -5,7 +5,7 @@
 
 import * as http from "http";
 import type { ProxyServer } from "../server/handler";
-import type { QueueStats } from "../types";
+import type { QueueOverview } from "../types";
 import { sendJson } from "./index";
 
 let serverInstance: ProxyServer | null = null;
@@ -38,23 +38,13 @@ export function handleQueueStats(
     return;
   }
 
-  // Get queue stats from server
-  const queueStats: QueueStats | null = serverInstance.getQueueStats?.() ?? null;
+  const overview: QueueOverview = serverInstance.getQueueOverview?.() ?? {
+    enabled: false,
+    message: "Concurrency control is not enabled",
+    routes: {},
+  };
 
-  if (queueStats === null) {
-    // Concurrency is not enabled
-    sendJson(res, 200, {
-      enabled: false,
-      message: "Concurrency control is not enabled",
-    });
-    return;
-  }
-
-  // Concurrency is enabled, return stats
-  sendJson(res, 200, {
-    enabled: true,
-    ...queueStats,
-  });
+  sendJson(res, 200, overview);
 }
 
 /**

--- a/packages/core/src/converter/index.ts
+++ b/packages/core/src/converter/index.ts
@@ -152,6 +152,11 @@ export {
 export {
   formatOpenAIResponsesSse,
   formatOpenAIChatCompletionsSse,
+  formatAnthropicSseError,
+  formatOpenAIChatSseError,
+  formatOpenAIResponsesSseError,
+  extractUpstreamSseError,
+  type UpstreamSseErrorInfo,
 } from "./streaming/sse-formatters";
 
 export {

--- a/packages/core/src/converter/platform-transforms/index.ts
+++ b/packages/core/src/converter/platform-transforms/index.ts
@@ -62,6 +62,8 @@ export {
   normalizeGeminiEffort,
   passthroughTransform,
   isPlainObject,
+  customToFunctionShim,
+  openaiChatStrictToolsSanitize,
   TOOL_TRANSFORM_REGISTRY,
   MESSAGE_TRANSFORM_REGISTRY,
   REQUEST_OVERRIDE_REGISTRY,

--- a/packages/core/src/converter/platform-transforms/openai-chat-strict-tools.ts
+++ b/packages/core/src/converter/platform-transforms/openai-chat-strict-tools.ts
@@ -1,0 +1,185 @@
+/**
+ * Chat Completions strict tools sanitize: drop unsupported Responses hosted tools and
+ * shim `custom` freeform tools to string-arg `function` entries for Chat-only upstreams.
+ */
+
+import { ScopedLogger } from "../../utils/logger";
+import { normalizedHostnameFromBaseUrl } from "./hostname";
+import { isPlainObject } from "./passthrough";
+import { ruleHostnameMatches } from "./ruleHostname";
+import { PLATFORM_TRANSFORM_RULES, type HostedToolRule } from "./rules";
+
+function matchRuleForBaseUrl(baseUrl: string): HostedToolRule | undefined {
+  const hostname = normalizedHostnameFromBaseUrl(baseUrl);
+  if (!hostname) {
+    return undefined;
+  }
+  for (const rule of PLATFORM_TRANSFORM_RULES) {
+    if (ruleHostnameMatches(hostname, rule)) {
+      return rule;
+    }
+  }
+  return undefined;
+}
+
+const log = new ScopedLogger("PlatformStrictTools");
+
+function formatHint(format: unknown): string | undefined {
+  if (!isPlainObject(format)) {
+    return undefined;
+  }
+  const typ = format.type;
+  if (typ === "grammar" && typeof format.definition === "string") {
+    return `Output format (grammar):\n${format.definition}`;
+  }
+  if (typeof format.syntax === "string") {
+    return `Output format: ${format.syntax}`;
+  }
+  return undefined;
+}
+
+/** Responses `custom` tool → Chat `function` with a single string `input` argument. */
+export function customToFunctionShim(tool: Record<string, unknown>): Record<string, unknown> {
+  const name = typeof tool.name === "string" ? tool.name : "custom_tool";
+  const descParts = [
+    typeof tool.description === "string" ? tool.description : undefined,
+    formatHint(tool.format),
+  ].filter((s): s is string => typeof s === "string" && s.length > 0);
+
+  return {
+    type: "function",
+    function: {
+      name,
+      description: descParts.length > 0 ? descParts.join("\n\n") : undefined,
+      parameters: {
+        type: "object",
+        properties: {
+          input: {
+            type: "string",
+            description: "Freeform tool input.",
+          },
+        },
+        required: ["input"],
+      },
+    },
+  };
+}
+
+function isValidFunctionTool(tool: Record<string, unknown>): boolean {
+  if (tool.type !== "function") {
+    return false;
+  }
+  const fn = tool.function;
+  if (!isPlainObject(fn)) {
+    return false;
+  }
+  return typeof fn.name === "string" && fn.name.length > 0;
+}
+
+function toolDisplayName(tool: Record<string, unknown>): string {
+  if (typeof tool.name === "string") {
+    return tool.name;
+  }
+  const fn = tool.function;
+  if (isPlainObject(fn) && typeof fn.name === "string") {
+    return fn.name;
+  }
+  return "";
+}
+
+function normalizeToolChoiceAfterDrop(
+  toolChoice: unknown,
+  keptFunctionNames: Set<string>
+): unknown {
+  if (toolChoice === undefined || toolChoice === null) {
+    return toolChoice;
+  }
+  if (typeof toolChoice === "string") {
+    return toolChoice;
+  }
+  if (!isPlainObject(toolChoice)) {
+    return toolChoice;
+  }
+  const tcType = typeof toolChoice.type === "string" ? toolChoice.type : "";
+  const fnBlock = toolChoice.function;
+  const fnName =
+    (isPlainObject(fnBlock) && typeof fnBlock.name === "string" ? fnBlock.name : undefined) ??
+    (typeof toolChoice.name === "string" ? toolChoice.name : undefined);
+
+  if (tcType === "function" && fnName && !keptFunctionNames.has(fnName)) {
+    return "auto";
+  }
+  if (tcType === "custom" && fnName) {
+    if (keptFunctionNames.has(fnName)) {
+      return { type: "function", function: { name: fnName } };
+    }
+    return "auto";
+  }
+  return toolChoice;
+}
+
+/**
+ * When the matched platform rule sets `strictTools`, filter `tools[]` to Chat-safe entries.
+ */
+export function openaiChatStrictToolsSanitize(
+  body: Record<string, unknown>,
+  baseUrl: string
+): void {
+  const rule = matchRuleForBaseUrl(baseUrl);
+  if (!rule?.strictTools) {
+    return;
+  }
+
+  const rawTools = body.tools;
+  if (!Array.isArray(rawTools) || rawTools.length === 0) {
+    return;
+  }
+
+  const keeplist = new Set<string>(["function", ...Object.keys(rule.tools ?? {})]);
+  const kept: Record<string, unknown>[] = [];
+  const keptFunctionNames = new Set<string>();
+
+  for (const entry of rawTools) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const tool = entry as Record<string, unknown>;
+    const typ = typeof tool.type === "string" ? tool.type : "";
+
+    if (isValidFunctionTool(tool)) {
+      kept.push(tool);
+      const fnName = (tool.function as Record<string, unknown>).name as string;
+      keptFunctionNames.add(fnName);
+      continue;
+    }
+
+    if (typ === "custom" && typeof tool.name === "string" && tool.name.length > 0) {
+      const shimmed = customToFunctionShim(tool);
+      kept.push(shimmed);
+      keptFunctionNames.add(tool.name);
+      continue;
+    }
+
+    if (keeplist.has(typ)) {
+      kept.push(tool);
+      const name = toolDisplayName(tool);
+      if (name) {
+        keptFunctionNames.add(name);
+      }
+      continue;
+    }
+
+    const name = toolDisplayName(tool) || "(unnamed)";
+    log.warn(`[strict-tools] dropped ${rule.provider}: type=${typ || "(missing)"} name=${name}`);
+  }
+
+  if (kept.length === 0) {
+    delete body.tools;
+  } else {
+    body.tools = kept;
+  }
+
+  if (body.tool_choice !== undefined) {
+    body.tool_choice = normalizeToolChoiceAfterDrop(body.tool_choice, keptFunctionNames);
+  }
+}

--- a/packages/core/src/converter/platform-transforms/registries.ts
+++ b/packages/core/src/converter/platform-transforms/registries.ts
@@ -108,6 +108,7 @@ export {
 export { geminiThoughtTagsResponseTransform } from "./gemini/response-thoughts";
 export { minimaxChatSanitize } from "./minimax/request-sanitize";
 export { minimaxReasoningDetailsResponseTransform } from "./minimax/response-reasoning";
+export { customToFunctionShim, openaiChatStrictToolsSanitize } from "./openai-chat-strict-tools";
 
 /** @deprecated Prefer `TOOL_TRANSFORM_REGISTRY`. */
 export const TRANSFORM_REGISTRY = TOOL_TRANSFORM_REGISTRY;

--- a/packages/core/src/converter/platform-transforms/rules.ts
+++ b/packages/core/src/converter/platform-transforms/rules.ts
@@ -29,6 +29,11 @@ export interface PlatformTransformRule {
   requestOverride?: string;
   /** Strip client query string from outbound upstream URL when matched (e.g. Gemini rejects unknown params). */
   stripQuery?: boolean;
+  /**
+   * After hosted-tool transforms: keep only `function` tools plus types listed in `tools`,
+   * shim Responses `custom` to string-arg `function`, drop other hosted/built-in tools.
+   */
+  strictTools?: boolean;
   /** Outbound Chat Completions JSON sanitize registry key (runs after tools/messages transforms). */
   requestSanitize?: string;
 }
@@ -61,18 +66,26 @@ export const PLATFORM_TRANSFORM_RULES: readonly PlatformTransformRule[] = [
     responses: "glm-web-search-response",
     anthropicSse: "glm-web-search-prime-normalize",
     requestSanitize: "glm-chat-sanitize",
+    strictTools: true,
   },
   {
     provider: "xiaomimimo",
     domains: ["api.xiaomimimo.com"],
     tools: { web_search: "mimo-web-search" },
     responses: "mimo-annotations-web-search",
+    strictTools: true,
+  },
+  {
+    provider: "xiaomimimo-token-plan",
+    domainParents: ["xiaomimimo.com"],
+    strictTools: true,
   },
   {
     provider: "minimax",
     domains: ["api.minimax.io", "api.minimaxi.com"],
     requestSanitize: "minimax-chat-sanitize",
     responses: "minimax-reasoning-details",
+    strictTools: true,
   },
   {
     provider: "azure-openai",
@@ -87,10 +100,12 @@ export const PLATFORM_TRANSFORM_RULES: readonly PlatformTransformRule[] = [
     stripQuery: true,
     requestSanitize: "gemini-chat-sanitize",
     responses: "gemini-thought-tags",
+    strictTools: true,
   },
   {
     provider: "deepseek",
     domains: ["api.deepseek.com"],
     requestSanitize: "deepseek-chat-sanitize",
+    strictTools: true,
   },
 ];

--- a/packages/core/src/converter/streaming/sse-formatters.ts
+++ b/packages/core/src/converter/streaming/sse-formatters.ts
@@ -332,3 +332,157 @@ export function formatOpenAIChatCompletionsSse(response: OpenAIChatCompletionRes
   lines.push("data: [DONE]\n\n");
   return lines.join("");
 }
+
+/** Parsed upstream error fields for cross-protocol SSE error projection. */
+export interface UpstreamSseErrorInfo {
+  message: string;
+  code: string;
+  type?: string;
+}
+
+const UPSTREAM_ERROR_BODY_MAX = 2000;
+
+function errorInfoFromParsed(
+  parsed: Record<string, unknown>,
+  status: number
+): UpstreamSseErrorInfo | null {
+  const err = parsed.error;
+  if (err && typeof err === "object") {
+    const e = err as Record<string, unknown>;
+    const message =
+      (typeof e.message === "string" ? e.message : null) ??
+      (typeof parsed.message === "string" ? parsed.message : null);
+    if (message) {
+      return {
+        message,
+        code: typeof e.code === "string" ? e.code : String(status),
+        type: typeof e.type === "string" ? e.type : undefined,
+      };
+    }
+  }
+  if (typeof parsed.message === "string") {
+    return {
+      message: parsed.message,
+      code: String(status),
+      type: typeof parsed.type === "string" ? parsed.type : undefined,
+    };
+  }
+  return null;
+}
+
+/**
+ * Extract error message/code from upstream SSE-wrapped or JSON error bodies.
+ */
+export function extractUpstreamSseError(body: string, status: number): UpstreamSseErrorInfo {
+  for (const line of body.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("data:")) {
+      continue;
+    }
+    const payload = trimmed.slice(5).trim();
+    if (!payload || payload === "[DONE]") {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(payload) as Record<string, unknown>;
+      const info = errorInfoFromParsed(parsed, status);
+      if (info) {
+        return info;
+      }
+    } catch {
+      /* try next line */
+    }
+  }
+
+  const trimmedBody = body.trim();
+  if (trimmedBody.length > 0) {
+    try {
+      const parsed = JSON.parse(trimmedBody) as Record<string, unknown>;
+      const info = errorInfoFromParsed(parsed, status);
+      if (info) {
+        return info;
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+
+  const truncated =
+    body.length > UPSTREAM_ERROR_BODY_MAX ? `${body.slice(0, UPSTREAM_ERROR_BODY_MAX)}...` : body;
+  return {
+    message: truncated.length > 0 ? truncated : `HTTP ${status}`,
+    code: String(status),
+    type: "api_error",
+  };
+}
+
+/** Anthropic Messages API SSE error stream (error + message_stop). */
+export function formatAnthropicSseError(_status: number, message: string, type?: string): string {
+  const errorType = type ?? "api_error";
+  const lines: string[] = [];
+  lines.push(
+    `event: error\ndata: ${JSON.stringify({ type: "error", error: { type: errorType, message } })}\n\n`
+  );
+  lines.push(`event: message_stop\ndata: ${JSON.stringify({ type: "message_stop" })}\n\n`);
+  return lines.join("");
+}
+
+/** OpenAI Chat Completions SSE error stream (data error + [DONE]). */
+export function formatOpenAIChatSseError(status: number, message: string, code?: string): string {
+  const errorCode = code ?? String(status);
+  const lines: string[] = [];
+  lines.push(
+    `data: ${JSON.stringify({ error: { message, type: "server_error", code: errorCode } })}\n\n`
+  );
+  lines.push("data: [DONE]\n\n");
+  return lines.join("");
+}
+
+/**
+ * OpenAI Responses API SSE error stream: lifecycle shells + top-level error event +
+ * response.failed + [DONE].
+ */
+export function formatOpenAIResponsesSseError(
+  status: number,
+  message: string,
+  code?: string,
+  model?: string
+): string {
+  let sequence_number = 0;
+  const lines: string[] = [];
+  const nextSeq = () => sequence_number++;
+  const push = (obj: Record<string, unknown>) => appendResponsesSseEvent(lines, nextSeq, obj);
+
+  const errorCode = code ?? String(status);
+  const responseId = `resp_${randomUUID().replace(/-/g, "")}`;
+  const modelName = model ?? "unknown";
+  const createdResponse = {
+    id: responseId,
+    object: "response",
+    created_at: Math.floor(Date.now() / 1000),
+    status: "in_progress" as const,
+    model: modelName,
+    output: [] as unknown[],
+    error: null,
+  };
+
+  push({ type: "response.created", response: createdResponse });
+  push({ type: "response.in_progress", response: { ...createdResponse } });
+
+  const errSeq = nextSeq();
+  lines.push(
+    `event: error\ndata: ${JSON.stringify({ type: "error", code: errorCode, message, sequence_number: errSeq })}\n\n`
+  );
+
+  push({
+    type: "response.failed",
+    response: {
+      ...createdResponse,
+      status: "failed",
+      error: { code: errorCode, message },
+    },
+  });
+
+  lines.push("data: [DONE]\n\n");
+  return lines.join("");
+}

--- a/packages/core/src/queue/concurrency-manager.ts
+++ b/packages/core/src/queue/concurrency-manager.ts
@@ -5,7 +5,13 @@
 
 import { Semaphore } from "./semaphore";
 import { PriorityQueue } from "./priority-queue";
-import type { RequestTask, ProxyResult, QueueStats, ConcurrencyConfig } from "../types";
+import type {
+  RequestTask,
+  ProxyResult,
+  QueueStats,
+  QueueDetailStats,
+  ConcurrencyConfig,
+} from "../types";
 import { ScopedLogger } from "../utils/logger";
 
 type TaskExecutor = (task: RequestTask) => Promise<ProxyResult>;
@@ -394,6 +400,35 @@ export class ConcurrencyManager {
       id: t.task.id,
       elapsed: now - t.startedAt,
     }));
+  }
+
+  /**
+   * Get tasks waiting in the queue (not yet assigned a worker)
+   */
+  getQueuedTasks(): Array<{ id: string; elapsed: number }> {
+    const now = Date.now();
+    return this.queue
+      .toArray()
+      .map(qt => ({
+        id: qt.task.id,
+        elapsed: now - qt.queuedAt,
+      }))
+      .sort((a, b) => b.elapsed - a.elapsed);
+  }
+
+  /**
+   * Queue stats with live task snapshots (for dashboard / API)
+   */
+  getDetailStats(): QueueDetailStats {
+    const maxQueueLimit =
+      this.config.maxQueueSize && this.config.maxQueueSize > 0 ? this.config.maxQueueSize : 10000;
+
+    return {
+      ...this.getStats(),
+      maxQueueSize: maxQueueLimit,
+      processingTasks: this.getProcessingTasks().sort((a, b) => b.elapsed - a.elapsed),
+      queuedTasks: this.getQueuedTasks(),
+    };
   }
 
   /**

--- a/packages/core/src/server/handler.ts
+++ b/packages/core/src/server/handler.ts
@@ -627,6 +627,13 @@ export class ProxyServer {
   }
 
   /**
+   * Get full queue overview (default + route queues, with live task snapshots)
+   */
+  getQueueOverview() {
+    return this.queueManager.getOverview();
+  }
+
+  /**
    * Clear the waiting queue if concurrency manager is enabled
    */
   clearQueue(): number {

--- a/packages/core/src/server/proxy/executor.ts
+++ b/packages/core/src/server/proxy/executor.ts
@@ -161,6 +161,29 @@ export class ProxyExecutor {
 
   constructor(private responseLogger: ResponseLogger) {}
 
+  /** Write converted SSE to the client and mirror into `ctx.responseChunks` when DB logging is on. */
+  private writeClientStreamForLog(
+    clientRes: http.ServerResponse,
+    chunk: string | Buffer,
+    ctx: ExecutionContext
+  ): void {
+    const buf = typeof chunk === "string" ? Buffer.from(chunk, "utf-8") : chunk;
+    clientRes.write(buf);
+    if (this.responseLogger.enabled) {
+      ctx.responseChunks.push(buf);
+    }
+  }
+
+  private recordUpstreamChunkForLog(chunk: Buffer, upstreamLog: Buffer[]): void {
+    if (this.responseLogger.enabled) {
+      upstreamLog.push(chunk);
+    }
+  }
+
+  private upstreamLogBody(upstreamLog: Buffer[]): string | undefined {
+    return upstreamLog.length > 0 ? Buffer.concat(upstreamLog).toString("utf-8") : undefined;
+  }
+
   /**
    * Set the execute function (for retry support, called after full initialization)
    */
@@ -743,15 +766,14 @@ export class ProxyExecutor {
     log.info(`[A->Chat SSE] ${clientId}: anthropic → OpenAI chunks (${provider.id})`);
     clientRes.writeHead(status, sseHeaders);
 
-    const startTime = Date.now();
-
     const chatState = createAnthropicToOpenAISseState(originalModel ?? task.originalModel ?? "");
+    const upstreamLog: Buffer[] = [];
 
     const sseBuffer = createAnthropicSseEnvelopeBuffer(envelope => {
       const fragments = processAnthropicStreamEnvelope(chatState, envelope);
       for (const line of fragments) {
         if (!ctx.clientDisconnected) {
-          clientRes.write(line);
+          this.writeClientStreamForLog(clientRes, line, ctx);
         }
       }
     });
@@ -760,6 +782,7 @@ export class ProxyExecutor {
       if (!ctx.upstreamTerminalSeen && chunkContainsTerminalMarker(chunk)) {
         ctx.upstreamTerminalSeen = true;
       }
+      this.recordUpstreamChunkForLog(chunk, upstreamLog);
       sseBuffer.push(chunk);
     });
 
@@ -769,7 +792,7 @@ export class ProxyExecutor {
       if (!ctx.clientDisconnected) {
         if (!chatState.streamingFinished) {
           for (const line of flushAnthropicToOpenAISseFinal(chatState)) {
-            clientRes.write(line);
+            this.writeClientStreamForLog(clientRes, line, ctx);
           }
         }
         clientRes.end();
@@ -779,10 +802,20 @@ export class ProxyExecutor {
       const aborted = ctx.clientDisconnected && !ctx.upstreamEndedNaturally;
       task.streamCompleted = !aborted;
       ctx.streamCompleted = task.streamCompleted;
+      const duration = Date.now() - ctx.startTime;
+      this.responseLogger.logResponse(
+        clientId,
+        duration,
+        aborted ? 499 : status,
+        ctx.responseChunks,
+        aborted ? "Client disconnected" : undefined,
+        this.upstreamLogBody(upstreamLog),
+        ctx.firstByteTime > 0 ? ctx.firstByteTime - ctx.startTime : undefined
+      );
       resolve({
         statusCode: aborted ? 499 : status,
         headers: sseHeaders,
-        duration: Date.now() - startTime,
+        duration,
         streamed: true,
         streamCompleted: task.streamCompleted,
         errorMessage: aborted ? "Client disconnected" : undefined,
@@ -828,9 +861,9 @@ export class ProxyExecutor {
     log.info(`[A->Responses SSE] anthropic sse → Responses (${provider.id})`);
     clientRes.writeHead(status, sseHeaders);
 
-    const startTime = Date.now();
     const chatState = createAnthropicToOpenAISseState(originalModel ?? task.originalModel ?? "");
     const respState = createStreamingState({ echo: task.originalResponsesEcho });
+    const upstreamLog: Buffer[] = [];
 
     const feedSyntheticChatCompletionChunk = (line: string): void => {
       const trimmed = line.trimEnd();
@@ -841,7 +874,7 @@ export class ProxyExecutor {
       const synth = processStreamingChunk(respState, payload);
       for (const ev of synth) {
         if (!ctx.clientDisconnected) {
-          clientRes.write(ev);
+          this.writeClientStreamForLog(clientRes, ev, ctx);
         }
       }
     };
@@ -857,6 +890,7 @@ export class ProxyExecutor {
       if (!ctx.upstreamTerminalSeen && chunkContainsTerminalMarker(chunk)) {
         ctx.upstreamTerminalSeen = true;
       }
+      this.recordUpstreamChunkForLog(chunk, upstreamLog);
       sseBuffer.push(chunk);
     });
 
@@ -870,7 +904,7 @@ export class ProxyExecutor {
       }
       if (!ctx.clientDisconnected && respState.phase !== "done") {
         for (const ev of processStreamingChunk(respState, "[DONE]")) {
-          clientRes.write(ev);
+          this.writeClientStreamForLog(clientRes, ev, ctx);
         }
       }
 
@@ -883,10 +917,22 @@ export class ProxyExecutor {
       task.streamCompleted = !aborted;
       ctx.streamCompleted = task.streamCompleted;
 
+      const duration = Date.now() - ctx.startTime;
+      const { clientId } = task;
+      this.responseLogger.logResponse(
+        clientId,
+        duration,
+        aborted ? 499 : status,
+        ctx.responseChunks,
+        aborted ? "Client disconnected" : undefined,
+        this.upstreamLogBody(upstreamLog),
+        ctx.firstByteTime > 0 ? ctx.firstByteTime - ctx.startTime : undefined
+      );
+
       resolve({
         statusCode: aborted ? 499 : status,
         headers: sseHeaders,
-        duration: Date.now() - startTime,
+        duration,
         streamed: true,
         streamCompleted: task.streamCompleted,
         errorMessage: aborted ? "Client disconnected" : undefined,
@@ -1469,7 +1515,7 @@ export class ProxyExecutor {
     _originalModel: string | undefined,
     resolve: (value: ProxyResult) => void
   ): void {
-    const { provider, res: clientRes } = task;
+    const { provider, res: clientRes, clientId } = task;
 
     const sseHeaders = headersForResponsesSse(responseHeaders);
     log.debug(
@@ -1483,13 +1529,16 @@ export class ProxyExecutor {
     let totalBytes = 0;
 
     const state = createStreamingState({ echo: task.originalResponsesEcho });
+    const upstreamLog: Buffer[] = [];
 
     const processLine = (line: string): void => {
       // Strip "data:" prefix — upstream SSE lines come as "data: {...}" or "data: [DONE]"
       const payload = line.startsWith("data:") ? line.slice(5).trim() : line;
       const events = processStreamingChunk(state, payload);
       for (const event of events) {
-        clientRes!.write(event);
+        if (!ctx.clientDisconnected) {
+          this.writeClientStreamForLog(clientRes!, event, ctx);
+        }
       }
     };
 
@@ -1501,6 +1550,7 @@ export class ProxyExecutor {
       if (!ctx.upstreamTerminalSeen && chunkContainsTerminalMarker(chunk)) {
         ctx.upstreamTerminalSeen = true;
       }
+      this.recordUpstreamChunkForLog(chunk, upstreamLog);
       if (chunkCount === 1) {
         firstChunkTime = Date.now() - startTime;
         log.debug(`[Chat->Responses SSE] First chunk: ${chunk.length} bytes`);
@@ -1509,6 +1559,7 @@ export class ProxyExecutor {
     });
 
     proxyRes.on("end", () => {
+      ctx.upstreamEndedNaturally = true;
       clientRes!.off("close", onClientDisconnect);
 
       // Flush any remaining partial line
@@ -1518,29 +1569,46 @@ export class ProxyExecutor {
       if (state.phase !== "done") {
         const remaining = processStreamingChunk(state, "[DONE]");
         for (const event of remaining) {
-          clientRes!.write(event);
+          if (!ctx.clientDisconnected) {
+            this.writeClientStreamForLog(clientRes!, event, ctx);
+          }
         }
       }
 
-      clientRes!.end();
+      if (!ctx.clientDisconnected) {
+        clientRes!.end();
+      }
 
-      task.streamCompleted = true;
-      ctx.streamCompleted = true;
+      const aborted = ctx.clientDisconnected && !ctx.upstreamEndedNaturally;
+      task.streamCompleted = !aborted;
+      ctx.streamCompleted = task.streamCompleted;
 
-      const duration = Date.now() - startTime;
+      const streamMs = Date.now() - startTime;
+      const duration = Date.now() - ctx.startTime;
       log.info(
         `[Chat->Responses SSE] ${provider.id}: ${chunkCount} upstream chunks, ` +
           `${totalBytes} bytes, ${state.seq} events emitted, ` +
-          `first_chunk=${firstChunkTime}ms, total=${duration}ms`
+          `first_chunk=${firstChunkTime}ms, stream=${streamMs}ms, total=${duration}ms`
+      );
+
+      this.responseLogger.logResponse(
+        clientId,
+        duration,
+        aborted ? 499 : status,
+        ctx.responseChunks,
+        aborted ? "Client disconnected" : undefined,
+        this.upstreamLogBody(upstreamLog),
+        ctx.firstByteTime > 0 ? ctx.firstByteTime - ctx.startTime : undefined
       );
 
       resolve({
-        statusCode: status,
+        statusCode: aborted ? 499 : status,
         headers: sseHeaders,
         duration,
         streamed: true,
-        streamCompleted: true,
+        streamCompleted: task.streamCompleted,
         responseBodyChunks: ctx.responseChunks,
+        errorMessage: aborted ? "Client disconnected" : undefined,
       });
     });
 

--- a/packages/core/src/server/proxy/executor.ts
+++ b/packages/core/src/server/proxy/executor.ts
@@ -15,6 +15,10 @@ import {
   convertChatCompletionToResponses,
   formatOpenAIResponsesSse,
   formatOpenAIChatCompletionsSse,
+  formatAnthropicSseError,
+  formatOpenAIChatSseError,
+  formatOpenAIResponsesSseError,
+  extractUpstreamSseError,
   convertResponseToAnthropic,
   convertResponsesApiJsonToAnthropicMessageResponse,
   isOpenAIResponsesApiResultBody,
@@ -121,8 +125,32 @@ interface ExecutionContext {
   responseChunks: Buffer[];
   originalResponseBody?: string;
   clientDisconnected: boolean;
+  /**
+   * Set true once the upstream Readable emitted `'end'` (i.e. fully delivered the response).
+   * Used to disambiguate "client closed after natural completion" from "client aborted mid-stream".
+   * The former is a normal 200; only the latter should be reported as 499.
+   */
+  upstreamEndedNaturally?: boolean;
+  /**
+   * Set true when the upstream SSE stream has emitted a known terminal event
+   * (`response.completed`, `response.failed`, Anthropic `message_stop`, OpenAI Chat `[DONE]`,
+   * top-level `event: error`). When the client closes immediately after the terminal event,
+   * the upstream request gets aborted before `proxyRes 'end'` fires, but the response is
+   * logically complete — should still be recorded as the upstream status, not 499.
+   */
+  upstreamTerminalSeen?: boolean;
   /** Chat->Responses SSE handler finished writing normally */
   streamCompleted?: boolean;
+}
+
+/** Cheap regex check for SSE terminal events across the supported protocols. */
+const TERMINAL_SSE_MARKER_RE =
+  /event:\s*(?:response\.completed|response\.failed|message_stop|error)\b|^data:\s*\[DONE\]/m;
+
+function chunkContainsTerminalMarker(chunk: Buffer): boolean {
+  // Decode as utf-8; SSE is text-based. A few bytes may be cut across UTF-8 boundaries
+  // but terminal markers are ASCII, so substring matching is safe even on partial decode.
+  return TERMINAL_SSE_MARKER_RE.test(chunk.toString("utf-8"));
 }
 
 /**
@@ -323,8 +351,14 @@ export class ProxyExecutor {
       clientDisconnected: false,
     };
 
-    // Track client disconnect during streaming
+    // Track client disconnect during streaming.
+    // Node's `'close'` event fires for BOTH abnormal aborts AND natural completion (after `end()`),
+    // so consult `writableFinished`/`writableEnded` to skip false positives where the response
+    // was already fully written.
     const onClientDisconnect = () => {
+      if (clientRes && (clientRes.writableFinished || clientRes.writableEnded)) {
+        return;
+      }
       ctx.clientDisconnected = true;
       log.info(`[${clientId}] Client disconnected during streaming`);
       abortController.abort();
@@ -468,21 +502,32 @@ export class ProxyExecutor {
     if (
       clientSurface === "openai_responses" &&
       upstreamWire === "openai" &&
-      status === 200 &&
       isSSEResponseEarly &&
       task.responsesStreamRequested &&
       clientRes
     ) {
-      this.handleOpenAISseToResponsesSse(
-        proxyRes,
-        task,
-        ctx,
-        onClientDisconnect,
-        status,
-        responseHeaders,
-        originalModel,
-        resolve
-      );
+      if (status === 200) {
+        this.handleOpenAISseToResponsesSse(
+          proxyRes,
+          task,
+          ctx,
+          onClientDisconnect,
+          status,
+          responseHeaders,
+          originalModel,
+          resolve
+        );
+      } else {
+        this.handleCrossProtocolSseError(
+          proxyRes,
+          task,
+          ctx,
+          onClientDisconnect,
+          status,
+          responseHeaders,
+          resolve
+        );
+      }
       return;
     }
 
@@ -571,40 +616,36 @@ export class ProxyExecutor {
     const isSSEResponse = proxyRes.headers["content-type"]?.includes("text/event-stream");
 
     // Anthropic upstream SSE → OpenAI Chat Completions SSE or Responses API SSE (true streaming).
-    if (
-      needsResponseConversion &&
-      upstreamWire === "anthropic" &&
-      isSSEResponse &&
-      status === 200 &&
-      clientRes
-    ) {
-      if (clientSurface === "openai") {
-        this.handleAnthropicSseToOpenAIChat(
-          proxyRes,
-          task,
-          ctx,
-          onClientDisconnect,
-          status,
-          responseHeaders,
-          originalModel,
-          resolve
-        );
-        return;
+    if (needsResponseConversion && upstreamWire === "anthropic" && isSSEResponse && clientRes) {
+      if (status === 200) {
+        if (clientSurface === "openai") {
+          this.handleAnthropicSseToOpenAIChat(
+            proxyRes,
+            task,
+            ctx,
+            onClientDisconnect,
+            status,
+            responseHeaders,
+            originalModel,
+            resolve
+          );
+          return;
+        }
+        if (clientSurface === "openai_responses") {
+          this.handleAnthropicSseToResponsesSseThroughChat(
+            proxyRes,
+            task,
+            ctx,
+            onClientDisconnect,
+            status,
+            responseHeaders,
+            originalModel,
+            resolve
+          );
+          return;
+        }
       }
-      if (clientSurface === "openai_responses") {
-        this.handleAnthropicSseToResponsesSseThroughChat(
-          proxyRes,
-          task,
-          ctx,
-          onClientDisconnect,
-          status,
-          responseHeaders,
-          originalModel,
-          resolve
-        );
-        return;
-      }
-      this.handleCrossProtocolSseRejection(
+      this.handleCrossProtocolSseError(
         proxyRes,
         task,
         ctx,
@@ -617,7 +658,7 @@ export class ProxyExecutor {
     }
 
     if (needsResponseConversion && isSSEResponse && clientRes) {
-      this.handleCrossProtocolSseRejection(
+      this.handleCrossProtocolSseError(
         proxyRes,
         task,
         ctx,
@@ -716,10 +757,14 @@ export class ProxyExecutor {
     });
 
     proxyRes.on("data", (chunk: Buffer) => {
+      if (!ctx.upstreamTerminalSeen && chunkContainsTerminalMarker(chunk)) {
+        ctx.upstreamTerminalSeen = true;
+      }
       sseBuffer.push(chunk);
     });
 
     proxyRes.on("end", () => {
+      ctx.upstreamEndedNaturally = true;
       sseBuffer.flush();
       if (!ctx.clientDisconnected) {
         if (!chatState.streamingFinished) {
@@ -731,15 +776,16 @@ export class ProxyExecutor {
       }
 
       clientRes.off("close", onClientDisconnect);
-      task.streamCompleted = !ctx.clientDisconnected;
+      const aborted = ctx.clientDisconnected && !ctx.upstreamEndedNaturally;
+      task.streamCompleted = !aborted;
       ctx.streamCompleted = task.streamCompleted;
       resolve({
-        statusCode: ctx.clientDisconnected ? 499 : status,
+        statusCode: aborted ? 499 : status,
         headers: sseHeaders,
         duration: Date.now() - startTime,
         streamed: true,
         streamCompleted: task.streamCompleted,
-        errorMessage: ctx.clientDisconnected ? "Client disconnected" : undefined,
+        errorMessage: aborted ? "Client disconnected" : undefined,
       });
     });
 
@@ -808,10 +854,14 @@ export class ProxyExecutor {
     });
 
     proxyRes.on("data", (chunk: Buffer) => {
+      if (!ctx.upstreamTerminalSeen && chunkContainsTerminalMarker(chunk)) {
+        ctx.upstreamTerminalSeen = true;
+      }
       sseBuffer.push(chunk);
     });
 
     proxyRes.on("end", () => {
+      ctx.upstreamEndedNaturally = true;
       sseBuffer.flush();
       if (!ctx.clientDisconnected && !chatState.streamingFinished) {
         for (const line of flushAnthropicToOpenAISseFinal(chatState)) {
@@ -829,16 +879,17 @@ export class ProxyExecutor {
         clientRes.end();
       }
 
-      task.streamCompleted = !ctx.clientDisconnected;
+      const aborted = ctx.clientDisconnected && !ctx.upstreamEndedNaturally;
+      task.streamCompleted = !aborted;
       ctx.streamCompleted = task.streamCompleted;
 
       resolve({
-        statusCode: ctx.clientDisconnected ? 499 : status,
+        statusCode: aborted ? 499 : status,
         headers: sseHeaders,
         duration: Date.now() - startTime,
         streamed: true,
         streamCompleted: task.streamCompleted,
-        errorMessage: ctx.clientDisconnected ? "Client disconnected" : undefined,
+        errorMessage: aborted ? "Client disconnected" : undefined,
       });
     });
 
@@ -856,9 +907,9 @@ export class ProxyExecutor {
   }
 
   /**
-   * Cross-protocol streaming is unsupported: reject after draining upstream
+   * Cross-protocol SSE error: buffer upstream body, extract error, emit client-native SSE error events.
    */
-  private handleCrossProtocolSseRejection(
+  private handleCrossProtocolSseError(
     proxyRes: http.IncomingMessage,
     task: RequestTask,
     ctx: ExecutionContext,
@@ -867,33 +918,115 @@ export class ProxyExecutor {
     responseHeaders: Record<string, string | string[]>,
     resolve: (value: ProxyResult) => void
   ): void {
-    const { clientId, res: clientRes } = task;
-    log.warn(
-      `[${clientId}] Cross-protocol streaming is not supported (client=${task.clientSurface}, upstream=${task.provider.providerType}); use stream=false in the request.`
-    );
-    proxyRes.on("data", () => {
-      // drain
-    });
-    proxyRes.on("end", () => {
-      if (clientRes) {
-        clientRes.off("close", onClientDisconnect);
+    const { clientId, provider, res: clientRes, clientSurface, originalModel } = task;
+
+    if (!clientRes) {
+      this.handleBufferedResponse(
+        proxyRes,
+        task,
+        ctx,
+        onClientDisconnect,
+        status,
+        responseHeaders,
+        resolve
+      );
+      return;
+    }
+
+    let upstreamBody = "";
+    proxyRes.on("data", (chunk: Buffer) => {
+      if (!ctx.upstreamTerminalSeen && chunkContainsTerminalMarker(chunk)) {
+        ctx.upstreamTerminalSeen = true;
       }
-      const errBody = JSON.stringify({
-        error: {
-          type: "api_error",
-          message:
-            "Cross-protocol conversion does not support streaming. Pass stream: false, or use the same API family as the upstream provider.",
-        },
-      });
-      ctx.responseChunks.push(Buffer.from(errBody, "utf-8"));
+      upstreamBody += chunk.toString();
+      if (this.responseLogger.enabled) {
+        ctx.responseChunks.push(chunk);
+      }
+    });
+
+    proxyRes.on("end", () => {
+      ctx.upstreamEndedNaturally = true;
+      clientRes.off("close", onClientDisconnect);
+
+      const err = extractUpstreamSseError(upstreamBody, status);
+      let sseBody: string;
+      let outHeaders: Record<string, string | string[]>;
+
+      if (clientSurface === "anthropic") {
+        sseBody = formatAnthropicSseError(status, err.message, err.type);
+        outHeaders = {
+          ...responseHeaders,
+          "content-type": "text/event-stream; charset=utf-8",
+        };
+      } else if (clientSurface === "openai_responses") {
+        sseBody = formatOpenAIResponsesSseError(
+          status,
+          err.message,
+          err.code,
+          originalModel ?? task.originalModel
+        );
+        outHeaders = headersForResponsesSse(responseHeaders);
+      } else {
+        sseBody = formatOpenAIChatSseError(status, err.message, err.code);
+        outHeaders = {
+          ...responseHeaders,
+          "content-type": "text/event-stream; charset=utf-8",
+        };
+      }
+
+      log.info(
+        `[SSE Error] ${clientId}: surface=${clientSurface} status=${status} upstream=${provider.id} message=${err.message}`
+      );
+
+      ctx.originalResponseBody = upstreamBody;
+      if (this.responseLogger.enabled) {
+        ctx.responseChunks = [Buffer.from(sseBody, "utf-8")];
+      }
+
+      if (!ctx.clientDisconnected) {
+        clientRes.writeHead(status, outHeaders);
+        clientRes.write(sseBody);
+        clientRes.end();
+      }
+
+      const aborted = ctx.clientDisconnected && !ctx.upstreamEndedNaturally;
+      task.streamCompleted = !aborted;
+      ctx.streamCompleted = task.streamCompleted;
+
+      const duration = Date.now() - ctx.startTime;
+      this.responseLogger.logResponse(
+        clientId,
+        duration,
+        aborted ? 499 : status,
+        ctx.responseChunks,
+        err.message,
+        upstreamBody,
+        ctx.firstByteTime > 0 ? ctx.firstByteTime - ctx.startTime : undefined
+      );
+
       resolve({
-        statusCode: 502,
-        headers: { "Content-Type": "application/json" },
-        body: errBody,
-        duration: Date.now() - ctx.startTime,
+        statusCode: aborted ? 499 : status,
+        headers: outHeaders,
+        body: sseBody,
+        duration,
+        streamed: true,
+        streamCompleted: task.streamCompleted,
         responseBodyChunks: ctx.responseChunks,
-        errorMessage: "Cross-protocol streaming not supported",
+        originalResponseBody: upstreamBody,
+        errorMessage: err.message,
       });
+    });
+
+    proxyRes.on("error", err => {
+      log.error(`[SSE Error] upstream error ${provider.id}`, err);
+      clientRes.off("close", onClientDisconnect);
+      if (!ctx.clientDisconnected && !clientRes.writableEnded) {
+        clientRes.end();
+      }
+    });
+
+    clientRes.on("error", () => {
+      proxyRes.destroy();
     });
   }
 
@@ -1365,6 +1498,9 @@ export class ProxyExecutor {
     proxyRes.on("data", (chunk: Buffer) => {
       chunkCount++;
       totalBytes += chunk.length;
+      if (!ctx.upstreamTerminalSeen && chunkContainsTerminalMarker(chunk)) {
+        ctx.upstreamTerminalSeen = true;
+      }
       if (chunkCount === 1) {
         firstChunkTime = Date.now() - startTime;
         log.debug(`[Chat->Responses SSE] First chunk: ${chunk.length} bytes`);
@@ -1559,6 +1695,9 @@ export class ProxyExecutor {
     const chunks: Buffer[] = [];
 
     proxyRes.on("data", (chunk: Buffer) => {
+      if (!ctx.upstreamTerminalSeen && chunkContainsTerminalMarker(chunk)) {
+        ctx.upstreamTerminalSeen = true;
+      }
       chunks.push(chunk);
       if (this.responseLogger.enabled) {
         ctx.responseChunks.push(chunk);
@@ -1710,6 +1849,10 @@ export class ProxyExecutor {
       ctx.streamChunkCount++;
       ctx.streamTotalBytes += chunk.length;
 
+      if (!ctx.upstreamTerminalSeen && chunkContainsTerminalMarker(chunk)) {
+        ctx.upstreamTerminalSeen = true;
+      }
+
       // Log first chunk (helps identify prefill delay)
       if (!ctx.firstChunkLogged) {
         ctx.firstChunkLogged = true;
@@ -1733,6 +1876,7 @@ export class ProxyExecutor {
     });
 
     proxyRes.on("end", () => {
+      ctx.upstreamEndedNaturally = true;
       const totalDuration = Date.now() - ctx.startTime;
       const avgChunkSize =
         ctx.streamChunkCount > 0 ? Math.round(ctx.streamTotalBytes / ctx.streamChunkCount) : 0;
@@ -1742,9 +1886,14 @@ export class ProxyExecutor {
         clientRes.off("close", onClientDisconnect);
       }
 
+      // Reaching `'end'` means upstream fully delivered the response. A late `'close'` from the
+      // client (e.g. Codex tearing down right after `response.completed`) is not an abort and
+      // must not be reported as 499.
+      const aborted = ctx.clientDisconnected && !ctx.upstreamEndedNaturally;
+
       if (ctx.clientDisconnected) {
         log.info(
-          `[Perf:${clientId}] StreamEnd (client disconnected): ${ctx.streamChunkCount} chunks, ${ctx.streamTotalBytes} bytes, total: ${totalDuration}ms`
+          `[Perf:${clientId}] StreamEnd (client closed after upstream finished): ${ctx.streamChunkCount} chunks, ${ctx.streamTotalBytes} bytes, total: ${totalDuration}ms`
         );
       } else {
         log.info(
@@ -1754,23 +1903,23 @@ export class ProxyExecutor {
       this.responseLogger.logResponse(
         clientId,
         totalDuration,
-        ctx.clientDisconnected ? 499 : status,
+        aborted ? 499 : status,
         ctx.responseChunks,
-        ctx.clientDisconnected ? "Client disconnected" : undefined,
+        aborted ? "Client disconnected" : undefined,
         undefined,
         ctx.firstByteTime > 0 ? ctx.firstByteTime - ctx.startTime : undefined
       );
-      if (!ctx.clientDisconnected) {
+      if (!aborted) {
         task.streamCompleted = true;
       }
       resolve({
-        statusCode: ctx.clientDisconnected ? 499 : status,
+        statusCode: aborted ? 499 : status,
         headers: responseHeaders,
         duration: totalDuration,
         responseBodyChunks: ctx.responseChunks,
         streamed: true,
-        streamCompleted: !ctx.clientDisconnected,
-        errorMessage: ctx.clientDisconnected ? "Client disconnected" : undefined,
+        streamCompleted: !aborted,
+        errorMessage: aborted ? "Client disconnected" : undefined,
       });
     });
   }
@@ -1999,6 +2148,33 @@ export class ProxyExecutor {
 
       // Check if aborted by client disconnect
       if (abortSignal.aborted) {
+        // The upstream had already streamed its terminal SSE event before the client closed —
+        // the response is logically complete, just the tail TCP FIN never reached us.
+        // Record as success so dashboards/queues don't treat well-formed completions as 499.
+        if (ctx.upstreamTerminalSeen) {
+          log.info(
+            `[${clientId}] Client closed after upstream terminal event (${duration}ms) — recording as success`
+          );
+          this.responseLogger.logResponse(
+            clientId,
+            duration,
+            200,
+            ctx.responseChunks,
+            undefined,
+            undefined,
+            ctx.firstByteTime > 0 ? ctx.firstByteTime - ctx.startTime : undefined
+          );
+          resolve({
+            statusCode: 200,
+            headers: {},
+            duration,
+            streamed: true,
+            streamCompleted: true,
+            responseBodyChunks: ctx.responseChunks,
+          });
+          return;
+        }
+
         log.info(`[${clientId}] Request aborted (client disconnect) after ${duration}ms`);
         this.responseLogger.logResponse(
           clientId,

--- a/packages/core/src/server/queueManager.ts
+++ b/packages/core/src/server/queueManager.ts
@@ -5,7 +5,7 @@
 import { ScopedLogger } from "../utils/logger";
 import { ConcurrencyManager } from "../queue";
 import type { ConfigManager } from "../config";
-import type { RequestTask, QueueStats, ProxyResult } from "../types";
+import type { RequestTask, QueueStats, QueueOverview, ProxyResult } from "../types";
 
 const log = new ScopedLogger("QueueManager");
 
@@ -131,6 +131,30 @@ export class QueueManager {
    */
   getStats(): QueueStats | null {
     return this.defaultQueue?.getStats() ?? null;
+  }
+
+  /**
+   * Get full queue overview (default + route queues, with live task snapshots)
+   */
+  getOverview(): QueueOverview {
+    if (!this.enabled) {
+      return {
+        enabled: false,
+        message: "Concurrency control is not enabled",
+        routes: {},
+      };
+    }
+
+    const routes: QueueOverview["routes"] = {};
+    for (const [name, queue] of this.routeQueues) {
+      routes[name] = queue.getDetailStats();
+    }
+
+    return {
+      enabled: true,
+      default: this.defaultQueue?.getDetailStats() ?? null,
+      routes,
+    };
   }
 
   /**

--- a/packages/core/src/server/request/bodyProcessor.ts
+++ b/packages/core/src/server/request/bodyProcessor.ts
@@ -23,6 +23,7 @@ import {
   applyPlatformRequestOverride,
   applyPlatformRequestSanitize,
   matchAnthropicSseRule,
+  openaiChatStrictToolsSanitize,
 } from "../../converter/platform-transforms";
 import { anthropicBodyHasHostedTool } from "../../converter/hosted-tools";
 import { ScopedLogger } from "../../utils/logger";
@@ -72,6 +73,7 @@ function applyPlatformTransformsToOpenAiChatBody(body: Buffer, baseUrl: string):
       return body;
     }
     applyHostedToolsToOpenAiChatRecord(data, baseUrl);
+    openaiChatStrictToolsSanitize(data, baseUrl);
     applyPlatformMessagesToOpenAiChatRecord(data, baseUrl);
     applyPlatformRequestSanitize(data, baseUrl);
     return Buffer.from(JSON.stringify(data), "utf-8");

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -736,6 +736,27 @@ export interface QueueStats {
   avgProcessTime: number;
 }
 
+/** Snapshot of a single task in the concurrency queue (processing or waiting). */
+export interface QueueTaskSnapshot {
+  id: string;
+  elapsed: number;
+}
+
+/** Queue stats plus live task snapshots for dashboard / API. */
+export interface QueueDetailStats extends QueueStats {
+  maxQueueSize: number;
+  processingTasks: QueueTaskSnapshot[];
+  queuedTasks: QueueTaskSnapshot[];
+}
+
+/** Full queue overview (default queue + route-specific queues). */
+export interface QueueOverview {
+  enabled: boolean;
+  message?: string;
+  default?: QueueDetailStats | null;
+  routes: Record<string, QueueDetailStats>;
+}
+
 /**
  * Semaphore lease for automatic release
  */

--- a/packages/desktop-tauri/package.json
+++ b/packages/desktop-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ccrelay/desktop-tauri",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "description": "CCRelay desktop app (Tauri)",
   "scripts": {

--- a/packages/desktop-tauri/src-tauri/Cargo.toml
+++ b/packages/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccrelay"
-version = "0.2.4"
+version = "0.2.5"
 description = "CCRelay desktop app"
 authors = ["Inflab"]
 edition = "2021"

--- a/packages/desktop-tauri/src-tauri/tauri.conf.json
+++ b/packages/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CCRelay",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "identifier": "org.inflab.ccrelay",
   "build": {
     "frontendDist": "../web",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccrelay-desktop",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "private": true,
   "description": "CCRelay desktop tray app",
   "license": "MIT",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "CCRelay",
   "icon": "assets/icon-128.png",
   "description": "VSCode extension with built-in API proxy server - switch between AI providers seamlessly",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "publisher": "inflab",
   "license": "MIT",
   "repository": {

--- a/tests/unit/api/client-config.test.ts
+++ b/tests/unit/api/client-config.test.ts
@@ -3,7 +3,16 @@ import {
   isLocalProxyAnthropicBase,
   isLocalProxyCodexBase,
   parseTomlLite,
+  expectedClaudeDesktopCustomHeaders,
+  hasExpectedClaudeDesktopCustomHeaders,
+  isCoworkEgressAllowed,
+  getClaudeCodeEnvGaps,
+  getClaudeDesktopConfigGaps,
+  buildClaudeCodeFields,
+  buildClaudeDesktopFields,
+  buildCodexFields,
 } from "@/api/clientConfig";
+import { CCRELAY_MODEL_ALIAS_HEADER } from "@/converter/models-fallback";
 
 describe("clientConfig URL helpers", () => {
   it("isLocalProxyAnthropicBase requires localhost/127.0.0.1, port, and /anthropic path", () => {
@@ -31,5 +40,205 @@ base_url = "http://127.0.0.1:7575/openai"
     const t = parseTomlLite(raw);
     expect(t.top.model_provider).toBe("ccrelay");
     expect(t.sections["model_providers.ccrelay"]?.base_url).toBe("http://127.0.0.1:7575/openai");
+  });
+});
+
+describe("Claude Desktop custom headers", () => {
+  it("expectedClaudeDesktopCustomHeaders includes x-ccrelay-model-alias", () => {
+    expect(expectedClaudeDesktopCustomHeaders()).toEqual({
+      [CCRELAY_MODEL_ALIAS_HEADER]: "1",
+    });
+  });
+
+  it("hasExpectedClaudeDesktopCustomHeaders requires non-empty alias header", () => {
+    expect(hasExpectedClaudeDesktopCustomHeaders(undefined)).toBe(false);
+    expect(hasExpectedClaudeDesktopCustomHeaders({})).toBe(false);
+    expect(hasExpectedClaudeDesktopCustomHeaders({ [CCRELAY_MODEL_ALIAS_HEADER]: "" })).toBe(false);
+    expect(hasExpectedClaudeDesktopCustomHeaders({ [CCRELAY_MODEL_ALIAS_HEADER]: "1" })).toBe(true);
+  });
+
+  it("hasExpectedClaudeDesktopCustomHeaders is case-insensitive on header key", () => {
+    expect(hasExpectedClaudeDesktopCustomHeaders({ "X-CCRelay-Model-Alias": "1" })).toBe(true); // eslint-disable-line @typescript-eslint/naming-convention -- HTTP header wire name
+    expect(hasExpectedClaudeDesktopCustomHeaders({ "X-CCRELAY-MODEL-ALIAS": "yes" })).toBe(true); // eslint-disable-line @typescript-eslint/naming-convention -- HTTP header wire name
+  });
+
+  it("getClaudeDesktopConfigGaps reports missing inferenceCustomHeaders", () => {
+    const gaps = getClaudeDesktopConfigGaps(
+      {
+        inferenceGatewayBaseUrl: "http://127.0.0.1:7575/anthropic",
+        inferenceProvider: "gateway",
+        inferenceGatewayApiKey: "1",
+        coworkEgressAllowedHosts: ["*"],
+        disableEssentialTelemetry: true,
+        disableNonessentialTelemetry: true,
+      },
+      7575,
+      "3p"
+    );
+    expect(gaps.gaps).toContain("inferenceCustomHeaders");
+    expect(gaps.baseOk).toBe(true);
+  });
+
+  it("getClaudeDesktopConfigGaps passes when template fields are complete", () => {
+    const gaps = getClaudeDesktopConfigGaps(
+      {
+        inferenceGatewayBaseUrl: "http://127.0.0.1:7575/anthropic",
+        inferenceProvider: "gateway",
+        inferenceGatewayApiKey: "1",
+        coworkEgressAllowedHosts: ["*"],
+        inferenceCustomHeaders: { [CCRELAY_MODEL_ALIAS_HEADER]: "1" },
+        disableEssentialTelemetry: true,
+        disableNonessentialTelemetry: true,
+      },
+      7575,
+      "3p"
+    );
+    expect(gaps.gaps).toEqual([]);
+  });
+});
+
+describe("coworkEgressAllowedHosts", () => {
+  it("isCoworkEgressAllowed requires non-empty array including *", () => {
+    expect(isCoworkEgressAllowed(["*"])).toBe(true);
+    expect(isCoworkEgressAllowed(["example.com", "*"])).toBe(true);
+    expect(isCoworkEgressAllowed([])).toBe(false);
+    expect(isCoworkEgressAllowed(["example.com"])).toBe(false);
+    expect(isCoworkEgressAllowed(undefined)).toBe(false);
+  });
+});
+
+describe("Claude Code env gaps", () => {
+  const port = 7575;
+
+  /* eslint-disable @typescript-eslint/naming-convention -- Claude Code settings.json env keys */
+  it("getClaudeCodeEnvGaps requires semantic env rules when only base URL is set", () => {
+    expect(
+      getClaudeCodeEnvGaps(
+        {
+          ANTHROPIC_BASE_URL: "http://127.0.0.1:7575/anthropic",
+        },
+        port
+      )
+    ).toEqual([
+      "ANTHROPIC_AUTH_TOKEN",
+      "API_TIMEOUT_MS",
+      "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+    ]);
+  });
+
+  it("buildClaudeCodeFields accepts localhost base URL", () => {
+    const fields = buildClaudeCodeFields(
+      {
+        ANTHROPIC_BASE_URL: "http://localhost:7575/anthropic",
+      },
+      port
+    );
+    const base = fields.find(f => f.key === "ANTHROPIC_BASE_URL");
+    expect(base?.ok).toBe(true);
+  });
+
+  it("buildClaudeCodeFields accepts any non-empty auth token", () => {
+    const fields = buildClaudeCodeFields(
+      {
+        ANTHROPIC_BASE_URL: "http://127.0.0.1:7575/anthropic",
+        ANTHROPIC_AUTH_TOKEN: "my-token",
+        API_TIMEOUT_MS: "600000",
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: true,
+      },
+      port
+    );
+    expect(fields.every(f => f.ok)).toBe(true);
+    expect(fields.find(f => f.key === "ANTHROPIC_AUTH_TOKEN")?.expected).toBe("(non-empty)");
+  });
+
+  it("buildClaudeCodeFields rejects invalid API_TIMEOUT_MS", () => {
+    const fields = buildClaudeCodeFields(
+      {
+        ANTHROPIC_BASE_URL: "http://127.0.0.1:7575/anthropic",
+        ANTHROPIC_AUTH_TOKEN: "t",
+        API_TIMEOUT_MS: "0",
+        CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: 1,
+      },
+      port
+    );
+    expect(fields.find(f => f.key === "API_TIMEOUT_MS")?.ok).toBe(false);
+  });
+
+  it("buildClaudeCodeFields gaps align with fields filter", () => {
+    const env = {
+      ANTHROPIC_BASE_URL: "http://127.0.0.1:7575/anthropic",
+      ANTHROPIC_AUTH_TOKEN: "t",
+    };
+    const fields = buildClaudeCodeFields(env, port);
+    const gapKeys = fields.filter(f => !f.ok).map(f => f.key);
+    expect(getClaudeCodeEnvGaps(env, port)).toEqual(gapKeys);
+  });
+  /* eslint-enable @typescript-eslint/naming-convention */
+});
+
+describe("Claude Desktop fields", () => {
+  const fullTemplate = {
+    inferenceGatewayBaseUrl: "http://127.0.0.1:7575/anthropic",
+    inferenceProvider: "gateway",
+    inferenceGatewayApiKey: "1",
+    coworkEgressAllowedHosts: ["*"],
+    inferenceCustomHeaders: { [CCRELAY_MODEL_ALIAS_HEADER]: "1" },
+    disableEssentialTelemetry: true,
+    disableNonessentialTelemetry: true,
+  };
+
+  it("buildClaudeDesktopFields marks all fields ok for full template with deploymentMode 3p", () => {
+    const fields = buildClaudeDesktopFields(fullTemplate, 7575, "3p");
+    expect(fields.every(f => f.ok)).toBe(true);
+    expect(fields.map(f => f.key)).toContain("deploymentMode");
+  });
+
+  it("buildClaudeDesktopFields uses rule hints for custom headers and egress", () => {
+    const fields = buildClaudeDesktopFields(fullTemplate, 7575, "3p");
+    expect(fields.find(f => f.key === "inferenceCustomHeaders")?.expected).toBe(
+      "x-ccrelay-model-alias: (non-empty, key case-insensitive)"
+    );
+    expect(fields.find(f => f.key === "coworkEgressAllowedHosts")?.expected).toBe(
+      '(non-empty array including "*")'
+    );
+  });
+
+  it("buildClaudeDesktopFields reports inferenceCustomHeaders gap when empty", () => {
+    const fields = buildClaudeDesktopFields(
+      { ...fullTemplate, inferenceCustomHeaders: {} },
+      7575,
+      "3p"
+    );
+    const gapKeys = fields.filter(f => !f.ok).map(f => f.key);
+    expect(gapKeys).toEqual(["inferenceCustomHeaders"]);
+    expect(
+      getClaudeDesktopConfigGaps({ ...fullTemplate, inferenceCustomHeaders: {} }, 7575, "3p").gaps
+    ).toEqual(gapKeys);
+  });
+
+  it("buildClaudeDesktopFields accepts egress array with * among other hosts", () => {
+    const fields = buildClaudeDesktopFields(
+      { ...fullTemplate, coworkEgressAllowedHosts: ["example.com", "*"] },
+      7575,
+      "3p"
+    );
+    expect(fields.find(f => f.key === "coworkEgressAllowedHosts")?.ok).toBe(true);
+  });
+});
+
+describe("Codex fields", () => {
+  it("buildCodexFields reports model gap when provider is set but model is empty", () => {
+    const toml = parseTomlLite(`model_provider = "ccrelay"
+[model_providers.ccrelay]
+base_url = "http://127.0.0.1:7575/openai"
+`);
+    const fields = buildCodexFields(toml, 7575);
+    expect(fields.map(f => f.key)).toEqual([
+      "model_provider",
+      "model_providers.ccrelay.base_url",
+      "model",
+    ]);
+    const gapKeys = fields.filter(f => !f.ok).map(f => f.key);
+    expect(gapKeys).toEqual(["model"]);
   });
 });

--- a/tests/unit/api/queue.test.ts
+++ b/tests/unit/api/queue.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for api/queue.ts
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { handleQueueStats, setServer } from "@/api/queue";
+import type { QueueOverview } from "@/types";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { EventEmitter } from "node:events";
+
+class MockIncomingMessage extends EventEmitter {
+  url: string;
+  method: string;
+
+  constructor(url: string, method: string = "GET") {
+    super();
+    this.url = url;
+    this.method = method;
+  }
+}
+
+class MockServerResponse extends EventEmitter {
+  statusCode = 200;
+  headers: Record<string, string> = {};
+  body = "";
+
+  writeHead(statusCode: number, headers?: Record<string, string>): this {
+    this.statusCode = statusCode;
+    if (headers) {
+      this.headers = { ...this.headers, ...headers };
+    }
+    return this;
+  }
+
+  end(data?: string): this {
+    if (data) {
+      this.body += data;
+    }
+    this.emit("finish");
+    return this;
+  }
+}
+
+describe("api/queue", () => {
+  beforeEach(() => {
+    setServer(null as unknown as import("@/server/handler").ProxyServer);
+  });
+
+  it("returns 503 when server is not initialized", () => {
+    const req = new MockIncomingMessage("/ccrelay/api/queue");
+    const res = new MockServerResponse();
+
+    handleQueueStats(req as unknown as IncomingMessage, res as unknown as ServerResponse, {});
+
+    expect(res.statusCode).toBe(503);
+    expect(JSON.parse(res.body)).toEqual({ error: "Server not available" });
+  });
+
+  it("returns queue overview when concurrency is enabled", () => {
+    const overview: QueueOverview = {
+      enabled: true,
+      default: {
+        queueLength: 2,
+        activeWorkers: 1,
+        maxWorkers: 3,
+        maxQueueSize: 100,
+        totalProcessed: 10,
+        totalFailed: 1,
+        avgWaitTime: 500,
+        avgProcessTime: 2000,
+        processingTasks: [{ id: "req-1", elapsed: 1200 }],
+        queuedTasks: [{ id: "req-2", elapsed: 800 }],
+      },
+      routes: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- route queue name from config
+        count_tokens: {
+          queueLength: 0,
+          activeWorkers: 0,
+          maxWorkers: 30,
+          maxQueueSize: 1000,
+          totalProcessed: 5,
+          totalFailed: 0,
+          avgWaitTime: 0,
+          avgProcessTime: 100,
+          processingTasks: [],
+          queuedTasks: [],
+        },
+      },
+    };
+
+    setServer({
+      getQueueOverview: () => overview,
+    } as never);
+
+    const req = new MockIncomingMessage("/ccrelay/api/queue");
+    const res = new MockServerResponse();
+
+    handleQueueStats(req as unknown as IncomingMessage, res as unknown as ServerResponse, {});
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual(overview);
+  });
+
+  it("returns disabled overview when concurrency is off", () => {
+    setServer({
+      getQueueOverview: () => ({
+        enabled: false,
+        message: "Concurrency control is not enabled",
+        routes: {},
+      }),
+    } as never);
+
+    const req = new MockIncomingMessage("/ccrelay/api/queue");
+    const res = new MockServerResponse();
+
+    handleQueueStats(req as unknown as IncomingMessage, res as unknown as ServerResponse, {});
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      enabled: false,
+      message: "Concurrency control is not enabled",
+      routes: {},
+    });
+  });
+});

--- a/tests/unit/converter/platform-transforms/index.test.ts
+++ b/tests/unit/converter/platform-transforms/index.test.ts
@@ -119,14 +119,19 @@ describe("matchHostedToolRuleForBaseUrl", () => {
     expect(r?.responses).toBe("minimax-reasoning-details");
   });
 
-  it("does not match MiMo for token-plan-sgp host (no web_search)", () => {
-    expect(
-      matchHostedToolRuleForBaseUrl("https://token-plan-sgp.xiaomimimo.com/v1/chat/completions")
-    ).toBeUndefined();
+  it("hits xiaomimimo-token-plan for token-plan-sgp host (strictTools, no web_search)", () => {
+    const r = matchHostedToolRuleForBaseUrl(
+      "https://token-plan-sgp.xiaomimimo.com/v1/chat/completions"
+    );
+    expect(r?.provider).toBe("xiaomimimo-token-plan");
+    expect(r?.strictTools).toBe(true);
+    expect(r?.tools).toBeUndefined();
   });
 
-  it("does not match MiMo for other xiaomimimo.com hosts", () => {
-    expect(matchHostedToolRuleForBaseUrl("https://staging.xiaomimimo.com/v1")).toBeUndefined();
+  it("hits xiaomimimo-token-plan for other xiaomimimo.com subdomains", () => {
+    const r = matchHostedToolRuleForBaseUrl("https://staging.xiaomimimo.com/v1");
+    expect(r?.provider).toBe("xiaomimimo-token-plan");
+    expect(r?.strictTools).toBe(true);
   });
 
   it("hits DeepSeek rule for api.deepseek.com", () => {

--- a/tests/unit/converter/platform-transforms/openai-chat-strict-tools.test.ts
+++ b/tests/unit/converter/platform-transforms/openai-chat-strict-tools.test.ts
@@ -1,0 +1,142 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import {
+  customToFunctionShim,
+  matchHostedToolRuleForBaseUrl,
+  openaiChatStrictToolsSanitize,
+} from "@/converter/platform-transforms";
+import { describe, expect, it } from "vitest";
+
+const MIMO_API = "https://api.xiaomimimo.com/v1/chat/completions";
+const MIMO_TOKEN_PLAN = "https://token-plan-sgp.xiaomimimo.com/v1/chat/completions";
+const UNKNOWN = "https://api.openai.com/v1/chat/completions";
+
+function fnTool(name: string): Record<string, unknown> {
+  return {
+    type: "function",
+    function: {
+      name,
+      description: "d",
+      parameters: { type: "object", properties: {} },
+    },
+  };
+}
+
+describe("matchHostedToolRuleForBaseUrl — xiaomimimo token-plan", () => {
+  it("matches api.xiaomimimo.com to xiaomimimo rule", () => {
+    const r = matchHostedToolRuleForBaseUrl(MIMO_API);
+    expect(r?.provider).toBe("xiaomimimo");
+    expect(r?.strictTools).toBe(true);
+  });
+
+  it("matches token-plan subdomain to xiaomimimo-token-plan rule", () => {
+    const r = matchHostedToolRuleForBaseUrl(MIMO_TOKEN_PLAN);
+    expect(r?.provider).toBe("xiaomimimo-token-plan");
+    expect(r?.strictTools).toBe(true);
+    expect(r?.tools).toBeUndefined();
+  });
+});
+
+describe("customToFunctionShim", () => {
+  it("maps custom apply_patch to function with string input and grammar in description", () => {
+    const shimmed = customToFunctionShim({
+      type: "custom",
+      name: "apply_patch",
+      description: "Use apply_patch for edits.",
+      format: { type: "grammar", syntax: "lark", definition: "start: patch" },
+    });
+    expect(shimmed.type).toBe("function");
+    const fn = shimmed.function as Record<string, unknown>;
+    expect(fn.name).toBe("apply_patch");
+    expect(String(fn.description)).toContain("grammar");
+    expect(String(fn.description)).toContain("start: patch");
+    const params = fn.parameters as Record<string, unknown>;
+    const props = params.properties as Record<string, unknown>;
+    expect((props.input as Record<string, unknown>).type).toBe("string");
+    expect(params.required).toEqual(["input"]);
+  });
+});
+
+describe("openaiChatStrictToolsSanitize", () => {
+  it("no-ops when baseUrl has no strictTools rule", () => {
+    const body: Record<string, unknown> = {
+      tools: [{ type: "web_search" }, fnTool("a")],
+    };
+    openaiChatStrictToolsSanitize(body, UNKNOWN);
+    expect(body.tools).toHaveLength(2);
+  });
+
+  it("keeps function + web_search on api.xiaomimimo.com, drops other hosted types", () => {
+    const body: Record<string, unknown> = {
+      tools: [
+        fnTool("exec_command"),
+        { type: "custom", name: "apply_patch", description: "patch" },
+        { type: "tool_search", name: "search" },
+        { type: "web_search", external_web_access: true },
+        { type: "image_generation", output_format: "png" },
+      ],
+    };
+    openaiChatStrictToolsSanitize(body, MIMO_API);
+    const tools = body.tools as Record<string, unknown>[];
+    expect(tools).toHaveLength(3);
+    expect(tools.some(t => (t.function as Record<string, unknown>)?.name === "exec_command")).toBe(
+      true
+    );
+    expect(tools.some(t => (t.function as Record<string, unknown>)?.name === "apply_patch")).toBe(
+      true
+    );
+    expect(tools.some(t => t.type === "web_search")).toBe(true);
+    expect(tools.some(t => t.type === "tool_search")).toBe(false);
+    expect(tools.some(t => t.type === "image_generation")).toBe(false);
+  });
+
+  it("on token-plan host keeps only function tools (drops web_search)", () => {
+    const body: Record<string, unknown> = {
+      tools: [fnTool("a"), { type: "web_search" }, { type: "image_generation" }],
+    };
+    openaiChatStrictToolsSanitize(body, MIMO_TOKEN_PLAN);
+    const tools = body.tools as Record<string, unknown>[];
+    expect(tools).toHaveLength(1);
+    expect((tools[0].function as Record<string, unknown>).name).toBe("a");
+  });
+
+  it("shims custom apply_patch to function on token-plan", () => {
+    const body: Record<string, unknown> = {
+      tools: [
+        fnTool("exec"),
+        { type: "custom", name: "apply_patch", description: "freeform patch tool" },
+      ],
+    };
+    openaiChatStrictToolsSanitize(body, MIMO_TOKEN_PLAN);
+    const tools = body.tools as Record<string, unknown>[];
+    expect(tools).toHaveLength(2);
+    const patch = tools.find(t => (t.function as Record<string, unknown>)?.name === "apply_patch");
+    expect(patch?.type).toBe("function");
+  });
+
+  it("falls back tool_choice to auto when named tool was dropped", () => {
+    const body: Record<string, unknown> = {
+      tools: [fnTool("keep_me"), { type: "tool_search" }],
+      tool_choice: { type: "function", function: { name: "missing_tool" } },
+    };
+    openaiChatStrictToolsSanitize(body, MIMO_TOKEN_PLAN);
+    expect(body.tool_choice).toBe("auto");
+  });
+
+  it("rewrites custom tool_choice to function when custom was shimmed", () => {
+    const body: Record<string, unknown> = {
+      tools: [{ type: "custom", name: "apply_patch", description: "x" }],
+      tool_choice: { type: "custom", name: "apply_patch" },
+    };
+    openaiChatStrictToolsSanitize(body, MIMO_TOKEN_PLAN);
+    expect(body.tool_choice).toEqual({ type: "function", function: { name: "apply_patch" } });
+  });
+
+  it("removes tools field when every entry is dropped", () => {
+    const body: Record<string, unknown> = {
+      tools: [{ type: "tool_search" }, { type: "image_generation" }],
+    };
+    openaiChatStrictToolsSanitize(body, MIMO_TOKEN_PLAN);
+    expect(body.tools).toBeUndefined();
+  });
+});

--- a/tests/unit/converter/streaming/sse-error-formatters.test.ts
+++ b/tests/unit/converter/streaming/sse-error-formatters.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractUpstreamSseError,
+  formatAnthropicSseError,
+  formatOpenAIChatSseError,
+  formatOpenAIResponsesSseError,
+} from "@/converter/streaming/sse-formatters";
+
+function parseSseBlocks(sse: string): string[] {
+  return sse.split("\n\n").filter(b => b.trim().length > 0);
+}
+
+function parseResponsesDataEvents(sse: string): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = [];
+  for (const block of parseSseBlocks(sse)) {
+    if (block.trim() === "data: [DONE]") {
+      continue;
+    }
+    const dataLine = block.split("\n").find(l => l.startsWith("data: "));
+    if (!dataLine) {
+      continue;
+    }
+    const json = dataLine.slice("data: ".length).trimStart();
+    out.push(JSON.parse(json) as Record<string, unknown>);
+  }
+  return out;
+}
+
+describe("extractUpstreamSseError", () => {
+  it("parses error from SSE data line", () => {
+    const body =
+      'data: {"error":{"message":"webSearchEnabled is false","type":"invalid_request_error"}}\n\n';
+    const err = extractUpstreamSseError(body, 400);
+    expect(err.message).toBe("webSearchEnabled is false");
+    expect(err.code).toBe("400");
+    expect(err.type).toBe("invalid_request_error");
+  });
+
+  it("parses error from plain JSON body", () => {
+    const body = JSON.stringify({ error: { message: "rate limited", code: "429" } });
+    const err = extractUpstreamSseError(body, 429);
+    expect(err.message).toBe("rate limited");
+    expect(err.code).toBe("429");
+  });
+
+  it("falls back to truncated body when unparseable", () => {
+    const err = extractUpstreamSseError("upstream exploded", 502);
+    expect(err.message).toBe("upstream exploded");
+    expect(err.code).toBe("502");
+  });
+});
+
+describe("formatAnthropicSseError", () => {
+  it("emits error and message_stop events with valid JSON", () => {
+    const sse = formatAnthropicSseError(400, "bad request", "invalid_request_error");
+    expect(sse).toContain("event: error\n");
+    expect(sse).toContain("event: message_stop\n");
+    const errorBlock = parseSseBlocks(sse).find(b => b.startsWith("event: error"));
+    expect(errorBlock).toBeDefined();
+    const dataLine = errorBlock!.split("\n").find(l => l.startsWith("data: "))!;
+    const parsed = JSON.parse(dataLine.slice("data: ".length)) as {
+      type: string;
+      error: { type: string; message: string };
+    };
+    expect(parsed.type).toBe("error");
+    expect(parsed.error.type).toBe("invalid_request_error");
+    expect(parsed.error.message).toBe("bad request");
+  });
+});
+
+describe("formatOpenAIChatSseError", () => {
+  it("ends with data error and [DONE]", () => {
+    const sse = formatOpenAIChatSseError(400, "webSearchEnabled is false", "400");
+    const blocks = parseSseBlocks(sse);
+    expect(blocks[0]).toMatch(/^data: /);
+    const parsed = JSON.parse(blocks[0].slice("data: ".length)) as {
+      error: { message: string; code: string; type: string };
+    };
+    expect(parsed.error.message).toBe("webSearchEnabled is false");
+    expect(parsed.error.code).toBe("400");
+    expect(parsed.error.type).toBe("server_error");
+    expect(sse.trim().endsWith("data: [DONE]")).toBe(true);
+  });
+});
+
+describe("formatOpenAIResponsesSseError", () => {
+  it("emits lifecycle, top-level error, response.failed, and [DONE] with monotonic sequence_number", () => {
+    const sse = formatOpenAIResponsesSseError(400, "webSearchEnabled is false", "400", "mimo-v2");
+    const events = parseResponsesDataEvents(sse);
+    const seqs = events.map(e => e.sequence_number as number);
+    for (let i = 1; i < seqs.length; i++) {
+      const prev = seqs[i - 1];
+      if (prev !== undefined) {
+        expect(seqs[i]).toBeGreaterThan(prev);
+      }
+    }
+    expect(events.some(e => e.type === "response.created")).toBe(true);
+    expect(events.some(e => e.type === "response.in_progress")).toBe(true);
+    expect(events.some(e => e.type === "response.failed")).toBe(true);
+
+    const failed = events.find(e => e.type === "response.failed") as {
+      response?: { status?: string; error?: { message?: string; code?: string } };
+    };
+    expect(failed?.response?.status).toBe("failed");
+    expect(failed?.response?.error?.message).toBe("webSearchEnabled is false");
+    expect(failed?.response?.error?.code).toBe("400");
+
+    expect(sse).toContain("event: error\n");
+    const errorBlock = parseSseBlocks(sse).find(b => b.startsWith("event: error"));
+    expect(errorBlock).toBeDefined();
+    const errorData = errorBlock!.split("\n").find(l => l.startsWith("data: "))!;
+    const topError = JSON.parse(errorData.slice("data: ".length)) as {
+      type: string;
+      message: string;
+      code: string;
+    };
+    expect(topError.type).toBe("error");
+    expect(topError.message).toBe("webSearchEnabled is false");
+    expect(topError.code).toBe("400");
+
+    expect(sse.trim().endsWith("data: [DONE]")).toBe(true);
+  });
+});

--- a/tests/unit/queue/concurrency-manager.test.ts
+++ b/tests/unit/queue/concurrency-manager.test.ts
@@ -1187,4 +1187,43 @@ describe("ConcurrencyManager", () => {
       global.clearTimeout = originalClearTimeout;
     });
   });
+
+  describe("CM019: Detail stats and queued tasks", () => {
+    it("CM019: should expose processing and queued task snapshots", async () => {
+      config.maxWorkers = 1;
+
+      let releaseTask1: () => void;
+      const blockingExecutor = vi.fn().mockImplementation(
+        () =>
+          new Promise<ProxyResult>(resolve => {
+            releaseTask1 = () => resolve({ statusCode: 200 } as ProxyResult);
+          })
+      );
+
+      manager = new ConcurrencyManager(config, blockingExecutor);
+
+      const p1 = manager.submit(createMockTask("task-processing"));
+      p1.catch(() => {});
+
+      await new Promise(r => setTimeout(r, 10));
+
+      const p2 = manager.submit(createMockTask("task-queued"));
+      p2.catch(() => {});
+
+      await new Promise(r => setTimeout(r, 10));
+
+      const detail = manager.getDetailStats();
+      expect(detail.activeWorkers).toBe(1);
+      expect(detail.queueLength).toBe(1);
+      expect(detail.processingTasks).toHaveLength(1);
+      expect(detail.processingTasks[0]?.id).toBe("task-processing");
+      expect(detail.queuedTasks).toHaveLength(1);
+      expect(detail.queuedTasks[0]?.id).toBe("task-queued");
+      expect(detail.queuedTasks[0]?.elapsed).toBeGreaterThanOrEqual(0);
+
+      manager.shutdown();
+      releaseTask1!();
+      await Promise.allSettled([p1, p2]);
+    });
+  });
 });

--- a/tests/unit/server/proxy/crossProtocolSseError.test.ts
+++ b/tests/unit/server/proxy/crossProtocolSseError.test.ts
@@ -1,0 +1,117 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import * as http from "http";
+import type { AddressInfo } from "net";
+import { PassThrough } from "stream";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ProxyExecutor } from "@/server/proxy/executor";
+import { ResponseLogger } from "@/server/responseLogger";
+import type { LogDatabase } from "@/database";
+import type { ApiSurface, Provider, RequestTask } from "@/types";
+
+const UPSTREAM_ERROR_SSE =
+  'data: {"error":{"message":"webSearchEnabled is false","type":"invalid_request_error"}}\n\n';
+
+function mockClientResponse(): http.ServerResponse & { written: string } {
+  const pt = new PassThrough();
+  const chunks: string[] = [];
+  pt.on("data", (c: Buffer) => {
+    chunks.push(c.toString());
+  });
+  const mock = pt as unknown as http.ServerResponse & { written: string };
+  Object.defineProperty(mock, "written", {
+    get: () => chunks.join(""),
+    configurable: true,
+  });
+  Object.defineProperty(mock, "writableEnded", { value: false, writable: true });
+  mock.writeHead = () => mock;
+  return mock;
+}
+
+describe("ProxyExecutor cross-protocol SSE errors", () => {
+  let mockUpstream: http.Server;
+  let upstreamBaseUrl: string;
+  let targetUrl: string;
+
+  beforeEach(async () => {
+    mockUpstream = http.createServer((_req, res) => {
+      res.writeHead(400, { "Content-Type": "text/event-stream" });
+      res.end(UPSTREAM_ERROR_SSE);
+    });
+    await new Promise<void>(resolve => mockUpstream.listen(0, "127.0.0.1", () => resolve()));
+    const addr = mockUpstream.address() as AddressInfo;
+    upstreamBaseUrl = `http://127.0.0.1:${addr.port}`;
+    targetUrl = `${upstreamBaseUrl}/v1/chat/completions`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      mockUpstream.close(err => (err ? reject(err) : resolve()));
+    });
+  });
+
+  async function executeWithSurface(
+    clientSurface: ApiSurface,
+    providerType: Provider["providerType"]
+  ): Promise<{ result: Awaited<ReturnType<ProxyExecutor["execute"]>>; written: string }> {
+    const clientRes = mockClientResponse();
+    const provider: Provider = {
+      id: "test-openai",
+      name: "Test",
+      baseUrl: upstreamBaseUrl,
+      mode: "passthrough",
+      providerType,
+      headers: {},
+    };
+
+    const task: RequestTask = {
+      id: "cross-sse-err",
+      clientId: "cross-sse-err",
+      method: "POST",
+      targetUrl,
+      headers: { "content-type": "application/json" },
+      body: Buffer.from(JSON.stringify({ model: "m", messages: [], stream: true })),
+      provider,
+      inboundPath: "/openai/responses",
+      requestPath: "/v1/chat/completions",
+      isOpenAIProvider: providerType !== "anthropic",
+      clientSurface,
+      responsesStreamRequested: clientSurface === "openai_responses",
+      originalModel: "mimo-v2",
+      res: clientRes,
+      createdAt: Date.now(),
+    };
+
+    const db = { enabled: false } as unknown as LogDatabase;
+    const executor = new ProxyExecutor(new ResponseLogger(db));
+    const result = await executor.execute(task);
+    return { result, written: clientRes.written };
+  }
+
+  it("openai_responses client receives Responses SSE errors at upstream status (not 502)", async () => {
+    const { result, written } = await executeWithSurface("openai_responses", "openai_chat");
+    expect(result.statusCode).toBe(400);
+    expect(result.errorMessage).toBe("webSearchEnabled is false");
+    expect(written).toContain("event: error");
+    expect(written).toContain("response.failed");
+    expect(written).toContain("webSearchEnabled is false");
+    expect(written).not.toContain("Cross-protocol conversion does not support streaming");
+    expect(result.headers?.["content-type"]).toContain("text/event-stream");
+  });
+
+  it("openai chat client receives upstream Chat SSE error passthrough at upstream status", async () => {
+    const { result, written } = await executeWithSurface("openai", "openai_chat");
+    expect(result.statusCode).toBe(400);
+    expect(written).toContain('"webSearchEnabled is false"');
+    expect(written).toContain("data:");
+    expect(written).not.toContain("Cross-protocol conversion does not support streaming");
+  });
+
+  it("anthropic client receives Anthropic SSE error + message_stop at upstream status", async () => {
+    const { result, written } = await executeWithSurface("anthropic", "openai_chat");
+    expect(result.statusCode).toBe(400);
+    expect(written).toContain("event: error");
+    expect(written).toContain("event: message_stop");
+    expect(written).toContain("webSearchEnabled is false");
+    expect(written).not.toContain("Cross-protocol conversion does not support streaming");
+  });
+});

--- a/tests/unit/server/proxy/sseClientCloseAfterCompletion.test.ts
+++ b/tests/unit/server/proxy/sseClientCloseAfterCompletion.test.ts
@@ -1,0 +1,223 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import * as http from "http";
+import type { AddressInfo } from "net";
+import { PassThrough } from "stream";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ProxyExecutor } from "@/server/proxy/executor";
+import { ResponseLogger } from "@/server/responseLogger";
+import type { LogDatabase } from "@/database";
+import type { Provider, RequestTask } from "@/types";
+
+const RESPONSES_API_SSE_NO_DONE = [
+  'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_1","status":"in_progress"},"sequence_number":0}\n\n',
+  'event: response.in_progress\ndata: {"type":"response.in_progress","response":{"id":"resp_1","status":"in_progress"},"sequence_number":1}\n\n',
+  'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_1","status":"completed","usage":{"input_tokens":10,"output_tokens":5}},"sequence_number":2}\n\n',
+];
+
+function makeMockClientRes(): {
+  res: http.ServerResponse & { written: string };
+  emitClose: () => void;
+  setWritableEnded: (v: boolean) => void;
+} {
+  const pt = new PassThrough();
+  const chunks: string[] = [];
+  pt.on("data", (c: Buffer) => {
+    chunks.push(c.toString());
+  });
+
+  const mock = pt as unknown as http.ServerResponse & { written: string };
+  Object.defineProperty(mock, "written", {
+    get: () => chunks.join(""),
+    configurable: true,
+  });
+  let writableEndedFlag = false;
+  Object.defineProperty(mock, "writableEnded", {
+    get: () => writableEndedFlag,
+    configurable: true,
+  });
+  Object.defineProperty(mock, "writableFinished", {
+    get: () => writableEndedFlag,
+    configurable: true,
+  });
+  mock.writeHead = () => mock;
+
+  return {
+    res: mock,
+    emitClose: () => pt.emit("close"),
+    setWritableEnded: (v: boolean) => {
+      writableEndedFlag = v;
+    },
+  };
+}
+
+describe("ProxyExecutor SSE passthrough — false 499 regression", () => {
+  let mockUpstream: http.Server;
+  let upstreamBaseUrl: string;
+  let targetUrl: string;
+
+  beforeEach(async () => {
+    mockUpstream = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      for (const chunk of RESPONSES_API_SSE_NO_DONE) {
+        res.write(chunk);
+      }
+      res.end();
+    });
+    await new Promise<void>(resolve => mockUpstream.listen(0, "127.0.0.1", () => resolve()));
+    const addr = mockUpstream.address() as AddressInfo;
+    upstreamBaseUrl = `http://127.0.0.1:${addr.port}`;
+    targetUrl = `${upstreamBaseUrl}/v1/responses`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) => {
+      mockUpstream.close(err => (err ? reject(err) : resolve()));
+    });
+  });
+
+  function buildTask(clientRes: http.ServerResponse): RequestTask {
+    const provider: Provider = {
+      id: "azure-responses",
+      name: "Azure",
+      baseUrl: upstreamBaseUrl,
+      mode: "passthrough",
+      providerType: "openai",
+      headers: {},
+    };
+    return {
+      id: "false-499",
+      clientId: "false-499",
+      method: "POST",
+      targetUrl,
+      headers: { "content-type": "application/json" },
+      body: Buffer.from(JSON.stringify({ model: "gpt-5.4", input: "hi", stream: true })),
+      provider,
+      inboundPath: "/responses",
+      requestPath: "/v1/responses",
+      isOpenAIProvider: true,
+      clientSurface: "openai_responses",
+      originalModel: "gpt-5.4",
+      res: clientRes,
+      createdAt: Date.now(),
+    };
+  }
+
+  it("client close after writableEnded (pipe finished) is ignored — recorded as 200", async () => {
+    const { res: clientRes, emitClose, setWritableEnded } = makeMockClientRes();
+    const task = buildTask(clientRes);
+
+    // Simulate the production race deterministically: pipe has already flushed (writableEnded=true)
+    // by the time the underlying socket reports `'close'`. The disconnect listener should
+    // short-circuit and leave the request as a normal 200.
+    setTimeout(() => {
+      setWritableEnded(true);
+      emitClose();
+    }, 80);
+
+    const db = { enabled: false } as unknown as LogDatabase;
+    const executor = new ProxyExecutor(new ResponseLogger(db));
+    const result = await executor.execute(task);
+
+    expect(result.statusCode).toBe(200);
+    expect(result.errorMessage).toBeUndefined();
+    expect(result.streamCompleted).toBe(true);
+    expect(clientRes.written).toContain("response.completed");
+  });
+
+  it("normal completion (no client close) records as 200 with full response body", async () => {
+    const { res: clientRes } = makeMockClientRes();
+    const task = buildTask(clientRes);
+
+    const db = { enabled: false } as unknown as LogDatabase;
+    const executor = new ProxyExecutor(new ResponseLogger(db));
+    const result = await executor.execute(task);
+
+    expect(result.statusCode).toBe(200);
+    expect(result.errorMessage).toBeUndefined();
+    expect(result.streamCompleted).toBe(true);
+    expect(clientRes.written).toContain("response.completed");
+  });
+});
+
+describe("ProxyExecutor SSE passthrough — terminal-then-abort recovery", () => {
+  // Upstream sends `response.completed` then deliberately holds the FIN. The client closes
+  // before upstream finishes its TCP teardown; without the terminal-marker check the abort
+  // branch in setupErrorHandlers would mislabel the request as 499.
+  let mockUpstream: http.Server;
+  let upstreamBaseUrl: string;
+  let targetUrl: string;
+  let releaseUpstream: () => void = () => {};
+
+  beforeEach(async () => {
+    mockUpstream = http.createServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      for (const chunk of RESPONSES_API_SSE_NO_DONE) {
+        res.write(chunk);
+      }
+      // Hold the FIN until the test signals — this simulates Azure briefly delaying its
+      // TCP teardown after the last SSE event.
+      releaseUpstream = () => {
+        try {
+          res.end();
+        } catch {
+          /* socket may already be torn down */
+        }
+      };
+    });
+    await new Promise<void>(resolve => mockUpstream.listen(0, "127.0.0.1", () => resolve()));
+    const addr = mockUpstream.address() as AddressInfo;
+    upstreamBaseUrl = `http://127.0.0.1:${addr.port}`;
+    targetUrl = `${upstreamBaseUrl}/v1/responses`;
+  });
+
+  afterEach(async () => {
+    releaseUpstream();
+    await new Promise<void>((resolve, reject) => {
+      mockUpstream.close(err => (err ? reject(err) : resolve()));
+    });
+  });
+
+  it("client aborting after response.completed records as 200 (not 499)", async () => {
+    const { res: clientRes, emitClose } = makeMockClientRes();
+    const provider: Provider = {
+      id: "azure-responses",
+      name: "Azure",
+      baseUrl: upstreamBaseUrl,
+      mode: "passthrough",
+      providerType: "openai",
+      headers: {},
+    };
+
+    const task: RequestTask = {
+      id: "abort-after-terminal",
+      clientId: "abort-after-terminal",
+      method: "POST",
+      targetUrl,
+      headers: { "content-type": "application/json" },
+      body: Buffer.from(JSON.stringify({ model: "gpt-5.4", input: "hi", stream: true })),
+      provider,
+      inboundPath: "/responses",
+      requestPath: "/v1/responses",
+      isOpenAIProvider: true,
+      clientSurface: "openai_responses",
+      originalModel: "gpt-5.4",
+      res: clientRes,
+      createdAt: Date.now(),
+    };
+
+    // Wait long enough for all upstream chunks (incl. response.completed) to be received and
+    // marked, then trigger client close. Upstream is still holding the FIN.
+    setTimeout(() => emitClose(), 80);
+
+    const db = { enabled: false } as unknown as LogDatabase;
+    const executor = new ProxyExecutor(new ResponseLogger(db));
+    const result = await executor.execute(task);
+
+    // Allow upstream to release its FIN so its socket cleans up.
+    releaseUpstream();
+
+    expect(result.statusCode).toBe(200);
+    expect(result.errorMessage).toBeUndefined();
+    expect(result.streamCompleted).toBe(true);
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,15 @@
 import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Activity, Server, Database, Settings as SettingsIcon, Puzzle } from "lucide-react";
+import {
+  Activity,
+  Server,
+  Database,
+  Settings as SettingsIcon,
+  Puzzle,
+  Terminal,
+} from "lucide-react";
 import { api } from "./api/client";
+import ClientConfig from "./features/client-config/ClientConfig";
 import Dashboard from "./features/dashboard/Dashboard";
 import Providers from "./features/providers/Providers";
 import Logs from "./features/logs/Logs";
@@ -12,9 +20,16 @@ import { LanguageModal } from "./components/LanguageModal";
 // CCRelay icon as data URI (works in VSCode webview)
 const iconSvg = `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Cdefs%3E%3ClinearGradient id='purpleGradient' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' style='stop-color:%239B59B6;stop-opacity:1' /%3E%3Cstop offset='100%25' style='stop-color:%238E44AD;stop-opacity:1' /%3E%3C/linearGradient%3E%3ClinearGradient id='grayGradient' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' style='stop-color:%2395A5A6;stop-opacity:1' /%3E%3Cstop offset='100%25' style='stop-color:%237F8C8D;stop-opacity:1' /%3E%3C/linearGradient%3E%3C/defs%3E%3Ccircle cx='64' cy='64' r='56' fill='%232C3E50' opacity='0.1'/%3E%3Cpath d='M 32 75 Q 32 45 50 45 L 64 45' stroke='url(%23purpleGradient)' stroke-width='10' stroke-linecap='round' fill='none'/%3E%3Cpath d='M 52 35 L 66 45 L 52 55' fill='url(%23purpleGradient)' stroke='url(%23purpleGradient)' stroke-width='3' stroke-linejoin='round'/%3E%3Cpath d='M 96 53 Q 96 83 78 83 L 64 83' stroke='url(%23grayGradient)' stroke-width='10' stroke-linecap='round' fill='none'/%3E%3Cpath d='M 76 93 L 62 83 L 76 73' fill='url(%23grayGradient)' stroke='url(%23grayGradient)' stroke-width='3' stroke-linejoin='round'/%3E%3Ccircle cx='64' cy='64' r='8' fill='url(%23purpleGradient)'/%3E%3Ccircle cx='64' cy='64' r='4' fill='%23FFFFFF'/%3E%3Cline x1='22' y1='64' x2='32' y2='64' stroke='%237F8C8D' stroke-width='4' stroke-linecap='round'/%3E%3Cline x1='96' y1='64' x2='106' y2='64' stroke='%237F8C8D' stroke-width='4' stroke-linecap='round'/%3E%3Ccircle cx='18' cy='64' r='4' fill='%2395A5A6'/%3E%3Ccircle cx='110' cy='64' r='4' fill='%2395A5A6'/%3E%3C/svg%3E`;
 
-type Tab = "dashboard" | "providers" | "capabilities" | "logs" | "settings";
+type Tab = "clientConfig" | "dashboard" | "providers" | "capabilities" | "logs" | "settings";
 
-const VALID_TABS: Tab[] = ["dashboard", "providers", "capabilities", "logs", "settings"];
+const VALID_TABS: Tab[] = [
+  "clientConfig",
+  "dashboard",
+  "providers",
+  "capabilities",
+  "logs",
+  "settings",
+];
 
 function useHashTab(defaultTab: Tab): [Tab, (tab: Tab) => void] {
   const getHashTab = useCallback((): Tab => {
@@ -46,7 +61,7 @@ function useHashTab(defaultTab: Tab): [Tab, (tab: Tab) => void] {
 
 function App() {
   const { t, i18n } = useTranslation();
-  const [activeTab, setActiveTab] = useHashTab("dashboard");
+  const [activeTab, setActiveTab] = useHashTab("clientConfig");
   const [version, setVersion] = useState<string | null>(null);
   const [showLangModal, setShowLangModal] = useState(false);
   const [loggingEnabled, setLoggingEnabled] = useState(true);
@@ -84,7 +99,7 @@ function App() {
   // Redirect away from logs tab if logging is disabled
   useEffect(() => {
     if (!loggingEnabled && activeTab === "logs") {
-      setActiveTab("dashboard");
+      setActiveTab("clientConfig");
     }
   }, [loggingEnabled, activeTab, setActiveTab]);
 
@@ -100,6 +115,17 @@ function App() {
             </div>
             <nav className="flex items-center w-full sm:w-auto">
               <div className="flex w-full sm:w-auto bg-muted/50 sm:bg-transparent rounded-lg sm:rounded-none p-1 sm:p-0 gap-1 sm:gap-0">
+                <button
+                  className={`flex-1 sm:flex-none h-8 sm:h-10 px-2 sm:px-4 text-[11px] sm:text-xs sm:min-w-[80px] flex items-center justify-center gap-1.5 rounded-md sm:rounded-none transition-all duration-200 ${
+                    activeTab === "clientConfig"
+                      ? "bg-background sm:bg-primary text-foreground sm:text-primary-foreground shadow-sm sm:shadow-none"
+                      : "text-muted-foreground sm:text-foreground hover:text-foreground sm:hover:bg-primary/15"
+                  }`}
+                  onClick={() => setActiveTab("clientConfig")}
+                >
+                  <Terminal className="h-3.5 w-3.5" />
+                  <span className="hidden sm:inline">{t("nav.clientConfig")}</span>
+                </button>
                 <button
                   className={`flex-1 sm:flex-none h-8 sm:h-10 px-2 sm:px-4 text-[11px] sm:text-xs sm:min-w-[80px] flex items-center justify-center gap-1.5 rounded-md sm:rounded-none transition-all duration-200 ${
                     activeTab === "dashboard"
@@ -165,6 +191,7 @@ function App() {
 
       {/* Main content */}
       <main className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-y-contain px-2 sm:px-4 py-3 text-xs">
+        {activeTab === "clientConfig" && <ClientConfig />}
         {activeTab === "dashboard" && <Dashboard />}
         {activeTab === "providers" && <Providers />}
         {activeTab === "capabilities" && <Capabilities />}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -19,6 +19,7 @@ import type {
   SettingsConfig,
   PatchConfigResponse,
   StatsRange,
+  QueueOverviewResponse,
   WizardProbeModelsRequest,
   WizardProbeModelsResponse,
   WizardEndpointTestRequest,
@@ -173,6 +174,8 @@ export const api = {
     const params = range && range !== "all" ? `?range=${range}` : "";
     return fetchAPI<LogStats>(`/stats${params}`);
   },
+
+  getQueueStats: (): Promise<QueueOverviewResponse> => fetchAPI<QueueOverviewResponse>("/queue"),
 
   // Version
   getVersion: (): Promise<VersionResponse> => fetchAPI<VersionResponse>("/version"),

--- a/web/src/features/client-config/ClientConfig.tsx
+++ b/web/src/features/client-config/ClientConfig.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useQueryClient } from "@tanstack/react-query";
+import { Loader2, RotateCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import ClientConfigStatus from "./ClientConfigStatus";
+
+export default function ClientConfig() {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const [refreshing, setRefreshing] = useState(false);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await queryClient.refetchQueries({ queryKey: ["clientConfig"] });
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h2 className="text-base font-semibold tracking-tight">{t("clientConfig.title")}</h2>
+          <p className="text-xs text-muted-foreground">{t("clientConfig.pageSubtitle")}</p>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-7 text-xs gap-1 shrink-0"
+          onClick={handleRefresh}
+          disabled={refreshing}
+          title={t("common.refresh")}
+        >
+          {refreshing ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <RotateCw className="h-3 w-3" />
+          )}
+          <span className="hidden sm:inline">{t("common.refresh")}</span>
+        </Button>
+      </div>
+
+      <ClientConfigStatus />
+    </div>
+  );
+}

--- a/web/src/features/client-config/ClientConfigStatus.tsx
+++ b/web/src/features/client-config/ClientConfigStatus.tsx
@@ -1,15 +1,7 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  FileCode2,
-  Loader2,
-  Monitor,
-  RotateCcw,
-  SlidersHorizontal,
-  Terminal,
-  X,
-} from "lucide-react";
+import { FileCode2, Loader2, Monitor, RotateCcw, SlidersHorizontal, X } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -28,6 +20,7 @@ import { Label } from "@/components/ui/label";
 import { api } from "@/api/client";
 import { CLAUDE_CODE_DEFAULT_MODELS, CODEX_DEFAULT_MODEL } from "@/constants/claudeCodeDefaults";
 import type { ClientConfigItem, ClientConfigItemStatus } from "@/types/api";
+import ConfigFieldList from "@/features/client-config/ConfigFieldList";
 
 function statusBadge(status: ClientConfigItemStatus, t: (key: string) => string) {
   switch (status) {
@@ -62,6 +55,57 @@ function statusBadge(status: ClientConfigItemStatus, t: (key: string) => string)
 
 function needsOverwriteBeforeApply(item: ClientConfigItem): boolean {
   return item.status === "wrong_target" || item.status === "invalid";
+}
+
+/** Only true when API reports full CCRelay template applied (no missing fields). */
+function isClientConfigUpToDate(item: ClientConfigItem | null | undefined): boolean {
+  return item?.status === "ok";
+}
+
+function ClientConfigSection({
+  icon,
+  title,
+  status,
+  filePath,
+  invalidMessage,
+  actions,
+  children,
+}: {
+  icon: ReactNode;
+  title: string;
+  status?: ClientConfigItemStatus;
+  filePath: string;
+  invalidMessage?: string;
+  actions: ReactNode;
+  children?: ReactNode;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="rounded-md border border-border/60 p-2.5">
+      <div className="flex gap-2">
+        <div className="shrink-0 mt-0.5 text-muted-foreground">{icon}</div>
+        <div className="flex-1 min-w-0 w-0">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-center gap-2 flex-wrap min-w-0">
+              <span className="text-xs font-medium">{title}</span>
+              {status !== undefined && statusBadge(status, t)}
+            </div>
+            <div className="flex shrink-0 gap-1">{actions}</div>
+          </div>
+          <div className="mt-1 min-w-0 space-y-0">
+            <p className="text-[10px] text-muted-foreground font-mono truncate">{filePath}</p>
+            {invalidMessage && (
+              <p className="text-[10px] text-amber-600 dark:text-amber-500 mt-0.5">
+                {invalidMessage}
+              </p>
+            )}
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default function ClientConfigStatus() {
@@ -164,7 +208,7 @@ export default function ClientConfigStatus() {
     if (!item) {
       return;
     }
-    if (item.status === "ok") {
+    if (isClientConfigUpToDate(item)) {
       return;
     }
     if (target === "codex") {
@@ -201,11 +245,7 @@ export default function ClientConfigStatus() {
     <>
       <Card className="p-0">
         <CardHeader className="p-3 pb-2">
-          <CardTitle className="text-xs font-medium flex items-center gap-2">
-            <Terminal className="h-3.5 w-3.5 text-muted-foreground" />
-            {t("clientConfig.title")}
-          </CardTitle>
-          <p className="text-[10px] text-muted-foreground font-normal pt-0.5">
+          <p className="text-[10px] text-muted-foreground font-normal">
             {t("clientConfig.description", {
               port: data?.port ?? "—",
               claudePath: "~/.claude/settings.json",
@@ -219,304 +259,257 @@ export default function ClientConfigStatus() {
           ) : (
             <>
               {data?.claudeDesktop && (
-                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 rounded-md border border-border/60 p-2.5">
-                  <div className="flex items-start gap-2 min-w-0">
-                    <Monitor className="h-3.5 w-3.5 text-muted-foreground shrink-0 mt-0.5" />
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <span className="text-xs font-medium">
-                          {t("clientConfig.claudeDesktop.name")}
-                        </span>
-                        {statusBadge(data.claudeDesktop.status, t)}
-                      </div>
-                      <p className="text-[10px] text-muted-foreground font-mono truncate mt-0.5">
-                        {data.claudeDesktop.filePath}
-                      </p>
-                      {data.claudeDesktop.currentValue && (
-                        <p className="text-[10px] text-muted-foreground truncate">
-                          inferenceGatewayBaseUrl: {data.claudeDesktop.currentValue}
-                        </p>
+                <ClientConfigSection
+                  icon={<Monitor className="h-3.5 w-3.5" />}
+                  title={t("clientConfig.claudeDesktop.name")}
+                  status={data.claudeDesktop.status}
+                  filePath={data.claudeDesktop.filePath}
+                  invalidMessage={
+                    data.claudeDesktop.status === "invalid" ? data.claudeDesktop.message : undefined
+                  }
+                  actions={
+                    <>
+                      {isClientConfigUpToDate(data.claudeDesktop) && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-7 text-xs gap-1 text-muted-foreground hover:text-destructive"
+                          disabled={restoreMutation.isPending}
+                          onClick={() => {
+                            setRestoreTarget("claudeDesktop");
+                            setRestoreConfirmOpen(true);
+                          }}
+                        >
+                          {restoreMutation.isPending && applyingTo === "claudeDesktop" ? (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          ) : (
+                            <RotateCcw className="h-3 w-3" />
+                          )}
+                          <span className="hidden sm:inline">
+                            {t("clientConfig.claudeDesktop.restore")}
+                          </span>
+                        </Button>
                       )}
-                      {data.claudeDesktop.message && data.claudeDesktop.status !== "ok" && (
-                        <p className="text-[10px] text-amber-600 dark:text-amber-500 mt-0.5">
-                          {data.claudeDesktop.message}
-                        </p>
-                      )}
-                      <p className="text-[10px] text-muted-foreground mt-0.5">
-                        {t("clientConfig.claudeDesktop.expected")}{" "}
-                        <span className="font-mono">{data?.expectedAnthropicBase ?? "—"}</span>
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex shrink-0 sm:pl-2 gap-1">
-                    {data.claudeDesktop.status === "ok" && (
                       <Button
                         size="sm"
-                        variant="ghost"
-                        className="h-7 text-xs gap-1 text-muted-foreground hover:text-destructive"
-                        disabled={restoreMutation.isPending}
-                        onClick={() => {
-                          setRestoreTarget("claudeDesktop");
-                          setRestoreConfirmOpen(true);
-                        }}
+                        variant={isClientConfigUpToDate(data.claudeDesktop) ? "outline" : "default"}
+                        className="h-7 text-xs min-w-[7rem]"
+                        disabled={
+                          isClientConfigUpToDate(data.claudeDesktop) || applyMutation.isPending
+                        }
+                        onClick={() => onConfigureClick("claudeDesktop")}
                       >
-                        {restoreMutation.isPending && applyingTo === "claudeDesktop" ? (
+                        {applyMutation.isPending && applyingTo === "claudeDesktop" ? (
                           <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : isClientConfigUpToDate(data.claudeDesktop) ? (
+                          t("clientConfig.claudeDesktop.upToDate")
                         ) : (
-                          <RotateCcw className="h-3 w-3" />
+                          t("clientConfig.claudeDesktop.apply")
                         )}
-                        <span className="hidden sm:inline">
-                          {t("clientConfig.claudeDesktop.restore")}
-                        </span>
                       </Button>
-                    )}
-                    <Button
-                      size="sm"
-                      variant={data.claudeDesktop.status === "ok" ? "outline" : "default"}
-                      className="h-7 text-xs"
-                      disabled={data.claudeDesktop.status === "ok" || applyMutation.isPending}
-                      onClick={() => onConfigureClick("claudeDesktop")}
-                    >
-                      {applyMutation.isPending && applyingTo === "claudeDesktop" ? (
-                        <Loader2 className="h-3 w-3 animate-spin" />
-                      ) : data.claudeDesktop.status === "ok" ? (
-                        t("clientConfig.claudeDesktop.upToDate")
-                      ) : (
-                        t("clientConfig.claudeDesktop.apply")
-                      )}
-                    </Button>
-                  </div>
-                </div>
+                    </>
+                  }
+                >
+                  <ConfigFieldList fields={data.claudeDesktop.fields ?? []} />
+                </ClientConfigSection>
               )}
 
-              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 rounded-md border border-border/60 p-2.5">
-                <div className="flex items-start gap-2 min-w-0">
-                  <FileCode2 className="h-3.5 w-3.5 text-muted-foreground shrink-0 mt-0.5" />
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="text-xs font-medium">
-                        {t("clientConfig.claudeCode.name")}
-                      </span>
-                      {data?.claudeCode && statusBadge(data.claudeCode.status, t)}
-                    </div>
-                    <p className="text-[10px] text-muted-foreground font-mono truncate mt-0.5">
-                      {data?.claudeCode.filePath}
-                    </p>
-                    {data?.claudeCode.currentValue && (
-                      <p className="text-[10px] text-muted-foreground truncate">
-                        {t("clientConfig.claudeCode.envVarLabel")}: {data.claudeCode.currentValue}
-                      </p>
-                    )}
-                    {data?.claudeCode.message && data.claudeCode.status !== "ok" && (
-                      <p className="text-[10px] text-amber-600 dark:text-amber-500 mt-0.5">
-                        {data.claudeCode.message}
-                      </p>
-                    )}
-                    <p className="text-[10px] text-muted-foreground mt-0.5">
-                      {t("clientConfig.claudeCode.expected")}{" "}
-                      <span className="font-mono">{data?.expectedAnthropicBase ?? "—"}</span>
-                    </p>
-                    <div className="mt-2 pt-2 border-t border-border/50 space-y-1.5">
-                      <p className="text-[10px] text-muted-foreground">
-                        <span className="font-medium text-foreground/90">
-                          {t("clientConfig.claudeCode.optionalModels.title")}
-                        </span>{" "}
-                        {t("clientConfig.claudeCode.optionalModels.description")}
-                      </p>
-                      {data?.claudeDefaultModels &&
-                      (data.claudeDefaultModels.opus ||
-                        data.claudeDefaultModels.sonnet ||
-                        data.claudeDefaultModels.haiku) ? (
-                        <p className="text-[10px] font-mono break-all text-foreground/80">
-                          Opus: {data.claudeDefaultModels.opus || "—"} · Sonnet:{" "}
-                          {data.claudeDefaultModels.sonnet || "—"} · Haiku:{" "}
-                          {data.claudeDefaultModels.haiku || "—"}
-                        </p>
-                      ) : (
-                        <p className="text-[10px] text-muted-foreground">
-                          <span className="italic">
-                            {t("clientConfig.claudeCode.optionalModels.notSet")}
-                          </span>{" "}
-                          {t("clientConfig.claudeCode.optionalModels.suggested")}{" "}
-                          <span className="font-mono text-foreground/80">
-                            {CLAUDE_CODE_DEFAULT_MODELS.opus} · {CLAUDE_CODE_DEFAULT_MODELS.sonnet}{" "}
-                            · {CLAUDE_CODE_DEFAULT_MODELS.haiku}
-                          </span>
-                        </p>
-                      )}
-                      <div>
+              {data?.claudeCode && (
+                <ClientConfigSection
+                  icon={<FileCode2 className="h-3.5 w-3.5" />}
+                  title={t("clientConfig.claudeCode.name")}
+                  status={data.claudeCode.status}
+                  filePath={data.claudeCode.filePath}
+                  invalidMessage={
+                    data.claudeCode.status === "invalid" ? data.claudeCode.message : undefined
+                  }
+                  actions={
+                    <>
+                      {isClientConfigUpToDate(data.claudeCode) && (
                         <Button
-                          type="button"
                           size="sm"
-                          variant="secondary"
-                          className="h-7 text-xs gap-1"
-                          disabled={applyMutation.isPending || modelsMutation.isPending}
+                          variant="ghost"
+                          className="h-7 text-xs gap-1 text-muted-foreground hover:text-destructive"
+                          disabled={restoreMutation.isPending}
                           onClick={() => {
-                            const m = data?.claudeDefaultModels;
-                            setOpus(m?.opus ?? CLAUDE_CODE_DEFAULT_MODELS.opus);
-                            setSonnet(m?.sonnet ?? CLAUDE_CODE_DEFAULT_MODELS.sonnet);
-                            setHaiku(m?.haiku ?? CLAUDE_CODE_DEFAULT_MODELS.haiku);
-                            setModelModalOpen(true);
+                            setRestoreTarget("claudeCode");
+                            setRestoreConfirmOpen(true);
                           }}
                         >
-                          <SlidersHorizontal className="h-3 w-3" />
-                          {t("clientConfig.claudeCode.configureModels")}
+                          {restoreMutation.isPending && applyingTo === "claudeCode" ? (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          ) : (
+                            <RotateCcw className="h-3 w-3" />
+                          )}
+                          <span className="hidden sm:inline">
+                            {t("clientConfig.claudeCode.restore")}
+                          </span>
                         </Button>
-                      </div>
+                      )}
+                      <Button
+                        size="sm"
+                        variant={isClientConfigUpToDate(data.claudeCode) ? "outline" : "default"}
+                        className="h-7 text-xs min-w-[7rem]"
+                        disabled={
+                          isClientConfigUpToDate(data.claudeCode) ||
+                          applyMutation.isPending ||
+                          modelsMutation.isPending
+                        }
+                        onClick={() => onConfigureClick("claudeCode")}
+                      >
+                        {applyMutation.isPending && applyingTo === "claudeCode" ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : isClientConfigUpToDate(data.claudeCode) ? (
+                          t("clientConfig.claudeCode.upToDate")
+                        ) : (
+                          t("clientConfig.claudeCode.apply")
+                        )}
+                      </Button>
+                    </>
+                  }
+                >
+                  <div className="mt-2 pt-2 border-t border-border/50 space-y-1.5 w-full">
+                    <p className="text-[10px] text-muted-foreground">
+                      <span className="font-medium text-foreground/90">
+                        {t("clientConfig.claudeCode.optionalModels.title")}
+                      </span>{" "}
+                      {t("clientConfig.claudeCode.optionalModels.description")}
+                    </p>
+                    {data.claudeDefaultModels &&
+                    (data.claudeDefaultModels.opus ||
+                      data.claudeDefaultModels.sonnet ||
+                      data.claudeDefaultModels.haiku) ? (
+                      <p className="text-[10px] font-mono break-all text-foreground/80">
+                        Opus: {data.claudeDefaultModels.opus || "—"} · Sonnet:{" "}
+                        {data.claudeDefaultModels.sonnet || "—"} · Haiku:{" "}
+                        {data.claudeDefaultModels.haiku || "—"}
+                      </p>
+                    ) : (
+                      <p className="text-[10px] text-muted-foreground">
+                        <span className="italic">
+                          {t("clientConfig.claudeCode.optionalModels.notSet")}
+                        </span>{" "}
+                        {t("clientConfig.claudeCode.optionalModels.suggested")}{" "}
+                        <span className="font-mono text-foreground/80">
+                          {CLAUDE_CODE_DEFAULT_MODELS.opus} · {CLAUDE_CODE_DEFAULT_MODELS.sonnet} ·{" "}
+                          {CLAUDE_CODE_DEFAULT_MODELS.haiku}
+                        </span>
+                      </p>
+                    )}
+                    <div>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="secondary"
+                        className="h-7 text-xs gap-1"
+                        disabled={applyMutation.isPending || modelsMutation.isPending}
+                        onClick={() => {
+                          const m = data.claudeDefaultModels;
+                          setOpus(m?.opus ?? CLAUDE_CODE_DEFAULT_MODELS.opus);
+                          setSonnet(m?.sonnet ?? CLAUDE_CODE_DEFAULT_MODELS.sonnet);
+                          setHaiku(m?.haiku ?? CLAUDE_CODE_DEFAULT_MODELS.haiku);
+                          setModelModalOpen(true);
+                        }}
+                      >
+                        <SlidersHorizontal className="h-3 w-3" />
+                        {t("clientConfig.claudeCode.configureModels")}
+                      </Button>
                     </div>
                   </div>
-                </div>
-                <div className="flex shrink-0 sm:pl-2 gap-1">
-                  {data?.claudeCode.status === "ok" && (
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="h-7 text-xs gap-1 text-muted-foreground hover:text-destructive"
-                      disabled={restoreMutation.isPending}
-                      onClick={() => {
-                        setRestoreTarget("claudeCode");
-                        setRestoreConfirmOpen(true);
-                      }}
-                    >
-                      {restoreMutation.isPending && applyingTo === "claudeCode" ? (
-                        <Loader2 className="h-3 w-3 animate-spin" />
-                      ) : (
-                        <RotateCcw className="h-3 w-3" />
-                      )}
-                      <span className="hidden sm:inline">
-                        {t("clientConfig.claudeCode.restore")}
-                      </span>
-                    </Button>
-                  )}
-                  <Button
-                    size="sm"
-                    variant={data?.claudeCode.status === "ok" ? "outline" : "default"}
-                    className="h-7 text-xs"
-                    disabled={
-                      data?.claudeCode.status === "ok" ||
-                      applyMutation.isPending ||
-                      modelsMutation.isPending
-                    }
-                    onClick={() => onConfigureClick("claudeCode")}
-                  >
-                    {applyMutation.isPending && applyingTo === "claudeCode" ? (
-                      <Loader2 className="h-3 w-3 animate-spin" />
-                    ) : data?.claudeCode.status === "ok" ? (
-                      t("clientConfig.claudeCode.upToDate")
-                    ) : (
-                      t("clientConfig.claudeCode.apply")
-                    )}
-                  </Button>
-                </div>
-              </div>
+                  <ConfigFieldList fields={data.claudeCode.fields ?? []} />
+                </ClientConfigSection>
+              )}
 
-              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 rounded-md border border-border/60 p-2.5">
-                <div className="flex items-start gap-2 min-w-0">
-                  <FileCode2 className="h-3.5 w-3.5 text-muted-foreground shrink-0 mt-0.5" />
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="text-xs font-medium">{t("clientConfig.codex.name")}</span>
-                      {data?.codex && statusBadge(data.codex.status, t)}
-                    </div>
-                    <p className="text-[10px] text-muted-foreground font-mono truncate mt-0.5">
-                      {data?.codex.filePath}
-                    </p>
-                    {data?.codex.currentValue && (
-                      <p className="text-[10px] text-muted-foreground truncate">
-                        base_url ({data.codex.modelProvider ?? "?"}): {data.codex.currentValue}
-                      </p>
-                    )}
-                    {data?.codex.message && data.codex.status !== "ok" && (
-                      <p className="text-[10px] text-amber-600 dark:text-amber-500 mt-0.5">
-                        {data.codex.message}
-                      </p>
-                    )}
-                    <p className="text-[10px] text-muted-foreground mt-0.5">
-                      {t("clientConfig.codex.expected")}{" "}
-                      <span className="font-mono">{data?.expectedCodexBaseUrl ?? "—"}</span>
-                    </p>
-                    <div className="mt-2 pt-2 border-t border-border/50 space-y-1.5">
-                      <p className="text-[10px] text-muted-foreground">
-                        <span className="font-medium text-foreground/90">
-                          {t("clientConfig.codex.model.label")}
-                        </span>{" "}
-                        {t("clientConfig.codex.model.description")}
-                      </p>
-                      {data?.codex?.model ? (
-                        <p className="text-[10px] font-mono text-foreground/80">
-                          {data.codex.model}
-                        </p>
-                      ) : (
-                        <p className="text-[10px] text-muted-foreground">
-                          <span className="italic">{t("clientConfig.codex.model.notSet")}</span>{" "}
-                          {t("clientConfig.codex.model.default")}{" "}
-                          <span className="font-mono text-foreground/80">
-                            {CODEX_DEFAULT_MODEL}
-                          </span>
-                        </p>
-                      )}
-                      <div>
+              {data?.codex && (
+                <ClientConfigSection
+                  icon={<FileCode2 className="h-3.5 w-3.5" />}
+                  title={t("clientConfig.codex.name")}
+                  status={data.codex.status}
+                  filePath={data.codex.filePath}
+                  invalidMessage={data.codex.status === "invalid" ? data.codex.message : undefined}
+                  actions={
+                    <>
+                      {isClientConfigUpToDate(data.codex) && (
                         <Button
-                          type="button"
                           size="sm"
-                          variant="secondary"
-                          className="h-7 text-xs gap-1"
-                          disabled={applyMutation.isPending || codexModelPatchMutation.isPending}
+                          variant="ghost"
+                          className="h-7 text-xs gap-1 text-muted-foreground hover:text-destructive"
+                          disabled={restoreMutation.isPending}
                           onClick={() => {
-                            setCodexModalMode("configure");
-                            setCodexModel(data?.codex?.model ?? "");
-                            setCodexModelModalOpen(true);
+                            setRestoreTarget("codex");
+                            setRestoreConfirmOpen(true);
                           }}
                         >
-                          <SlidersHorizontal className="h-3 w-3" />
-                          {t("clientConfig.codex.configureModel")}
+                          {restoreMutation.isPending && applyingTo === "codex" ? (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          ) : (
+                            <RotateCcw className="h-3 w-3" />
+                          )}
+                          <span className="hidden sm:inline">
+                            {t("clientConfig.codex.restore")}
+                          </span>
                         </Button>
-                      </div>
+                      )}
+                      <Button
+                        size="sm"
+                        variant={isClientConfigUpToDate(data.codex) ? "outline" : "default"}
+                        className="h-7 text-xs min-w-[7rem]"
+                        disabled={
+                          isClientConfigUpToDate(data.codex) ||
+                          applyMutation.isPending ||
+                          modelsMutation.isPending ||
+                          codexModelPatchMutation.isPending
+                        }
+                        onClick={() => onConfigureClick("codex")}
+                      >
+                        {applyMutation.isPending && applyingTo === "codex" ? (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        ) : isClientConfigUpToDate(data.codex) ? (
+                          t("clientConfig.codex.upToDate")
+                        ) : (
+                          t("clientConfig.codex.apply")
+                        )}
+                      </Button>
+                    </>
+                  }
+                >
+                  <div className="mt-2 pt-2 border-t border-border/50 space-y-1.5 w-full">
+                    <p className="text-[10px] text-muted-foreground">
+                      <span className="font-medium text-foreground/90">
+                        {t("clientConfig.codex.model.label")}
+                      </span>{" "}
+                      {t("clientConfig.codex.model.description")}
+                    </p>
+                    {data.codex.model ? (
+                      <p className="text-[10px] font-mono text-foreground/80">{data.codex.model}</p>
+                    ) : (
+                      <p className="text-[10px] text-muted-foreground">
+                        <span className="italic">{t("clientConfig.codex.model.notSet")}</span>{" "}
+                        {t("clientConfig.codex.model.default")}{" "}
+                        <span className="font-mono text-foreground/80">{CODEX_DEFAULT_MODEL}</span>
+                      </p>
+                    )}
+                    <div>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="secondary"
+                        className="h-7 text-xs gap-1"
+                        disabled={applyMutation.isPending || codexModelPatchMutation.isPending}
+                        onClick={() => {
+                          setCodexModalMode("configure");
+                          setCodexModel(data.codex?.model ?? "");
+                          setCodexModelModalOpen(true);
+                        }}
+                      >
+                        <SlidersHorizontal className="h-3 w-3" />
+                        {t("clientConfig.codex.configureModel")}
+                      </Button>
                     </div>
                   </div>
-                </div>
-                <div className="flex shrink-0 sm:pl-2 gap-1">
-                  {data?.codex.status === "ok" && (
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="h-7 text-xs gap-1 text-muted-foreground hover:text-destructive"
-                      disabled={restoreMutation.isPending}
-                      onClick={() => {
-                        setRestoreTarget("codex");
-                        setRestoreConfirmOpen(true);
-                      }}
-                    >
-                      {restoreMutation.isPending && applyingTo === "codex" ? (
-                        <Loader2 className="h-3 w-3 animate-spin" />
-                      ) : (
-                        <RotateCcw className="h-3 w-3" />
-                      )}
-                      <span className="hidden sm:inline">{t("clientConfig.codex.restore")}</span>
-                    </Button>
-                  )}
-                  <Button
-                    size="sm"
-                    variant={data?.codex.status === "ok" ? "outline" : "default"}
-                    className="h-7 text-xs"
-                    disabled={
-                      data?.codex.status === "ok" ||
-                      applyMutation.isPending ||
-                      modelsMutation.isPending ||
-                      codexModelPatchMutation.isPending
-                    }
-                    onClick={() => onConfigureClick("codex")}
-                  >
-                    {applyMutation.isPending && applyingTo === "codex" ? (
-                      <Loader2 className="h-3 w-3 animate-spin" />
-                    ) : data?.codex.status === "ok" ? (
-                      t("clientConfig.codex.upToDate")
-                    ) : (
-                      t("clientConfig.codex.apply")
-                    )}
-                  </Button>
-                </div>
-              </div>
+                  <ConfigFieldList fields={data.codex.fields ?? []} />
+                </ClientConfigSection>
+              )}
 
               {applyMutation.isError && (
                 <p className="text-[10px] text-destructive">

--- a/web/src/features/client-config/ConfigFieldList.tsx
+++ b/web/src/features/client-config/ConfigFieldList.tsx
@@ -1,0 +1,169 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { ClientConfigField } from "@/types/api";
+
+const EXPECTED_RULE_SLUGS: Record<string, string> = {
+  "(non-empty)": "nonEmpty",
+  "(positive number)": "positiveNumber",
+  "(truthy)": "truthy",
+  "(absent)": "absent",
+  "(any non-empty)": "anyNonEmpty",
+  '(non-empty array including "*")': "nonEmptyArrayIncludingStar",
+  "x-ccrelay-model-alias: (non-empty, key case-insensitive)": "aliasHeaderNonEmpty",
+};
+
+function fieldLabel(key: string, t: (k: string) => string): string {
+  const translated = t(`clientConfig.fields.${key}`);
+  return translated === `clientConfig.fields.${key}` ? key : translated;
+}
+
+function expectedHint(
+  expected: string,
+  t: (k: string, options?: Record<string, unknown>) => string
+): string {
+  const slug = EXPECTED_RULE_SLUGS[expected];
+  if (!slug) {
+    return expected;
+  }
+  const translated = t(`clientConfig.rules.${slug}`);
+  return translated === `clientConfig.rules.${slug}` ? expected : translated;
+}
+
+function FieldRow({
+  field,
+  variant,
+  t,
+}: {
+  field: ClientConfigField;
+  variant: "gap" | "ok";
+  t: (k: string, options?: Record<string, unknown>) => string;
+}) {
+  const label = fieldLabel(field.key, t);
+
+  if (variant === "ok") {
+    return (
+      <div className="flex items-start gap-1.5 py-0.5">
+        <Check className="h-3 w-3 text-green-600 dark:text-green-500 shrink-0 mt-0.5" />
+        <div className="min-w-0">
+          <span className="text-[10px] text-muted-foreground">{label}</span>
+          {field.current && (
+            <p className="text-[10px] font-mono text-muted-foreground break-all">{field.current}</p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded border border-amber-500/40 px-2 py-1.5 space-y-0.5">
+      <p className="text-[10px] font-medium text-amber-700 dark:text-amber-400">{label}</p>
+      <p className="text-[10px] text-muted-foreground">
+        <span className="text-amber-600 dark:text-amber-500">
+          {t("clientConfig.diff.expectedLabel")}
+        </span>{" "}
+        <span className="font-mono break-all">{expectedHint(field.expected, t)}</span>
+      </p>
+      <p className="text-[10px] text-muted-foreground">
+        <span className="text-amber-600 dark:text-amber-500">
+          {t("clientConfig.diff.currentLabel")}
+        </span>{" "}
+        <span className="font-mono break-all">
+          {field.current ?? t("clientConfig.diff.notSetCurrent")}
+        </span>
+      </p>
+    </div>
+  );
+}
+
+export default function ConfigFieldList({ fields }: { fields: ClientConfigField[] }) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+
+  if (fields.length === 0) {
+    return null;
+  }
+
+  const gaps = fields.filter(f => !f.ok);
+  const okFields = fields.filter(f => f.ok);
+  const allOk = gaps.length === 0;
+
+  if (allOk) {
+    return (
+      <div className="mt-2 pt-2 border-t border-border/50 space-y-1 w-full">
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-[10px] text-muted-foreground">
+            {t("clientConfig.diff.allConfigured")}
+          </p>
+          {okFields.length > 0 && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-6 px-1.5 text-[10px] gap-0.5"
+              onClick={() => setExpanded(v => !v)}
+            >
+              {expanded ? (
+                <>
+                  <ChevronUp className="h-3 w-3" />
+                  {t("clientConfig.diff.collapse")}
+                </>
+              ) : (
+                <>
+                  <ChevronDown className="h-3 w-3" />
+                  {t("clientConfig.diff.expandAll")}
+                </>
+              )}
+            </Button>
+          )}
+        </div>
+        {expanded && (
+          <div className="space-y-0.5">
+            {okFields.map(field => (
+              <FieldRow key={field.key} field={field} variant="ok" t={t} />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-2 pt-2 border-t border-border/50 space-y-1.5 w-full">
+      {gaps.map(field => (
+        <FieldRow key={field.key} field={field} variant="gap" t={t} />
+      ))}
+      {okFields.length > 0 && (
+        <>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-6 px-1.5 text-[10px] gap-0.5"
+            onClick={() => setExpanded(v => !v)}
+          >
+            {expanded ? (
+              <>
+                <ChevronUp className="h-3 w-3" />
+                {t("clientConfig.diff.collapseOk")}
+              </>
+            ) : (
+              <>
+                <ChevronDown className="h-3 w-3" />
+                {t("clientConfig.diff.expandOk")}
+              </>
+            )}
+          </Button>
+          {expanded && (
+            <div className="space-y-0.5">
+              {okFields.map(field => (
+                <FieldRow key={field.key} field={field} variant="ok" t={t} />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/features/dashboard/Dashboard.tsx
+++ b/web/src/features/dashboard/Dashboard.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { api } from "@/api/client";
 import type { StatsRange } from "@/types/api";
-import ClientConfigStatus from "./ClientConfigStatus";
+import QueueStatus from "./QueueStatus";
 
 function formatTokenCount(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
@@ -47,7 +47,7 @@ export default function Dashboard() {
       await Promise.all([
         queryClient.refetchQueries({ queryKey: ["status"] }),
         queryClient.refetchQueries({ queryKey: ["stats", range] }),
-        queryClient.refetchQueries({ queryKey: ["clientConfig"] }),
+        queryClient.refetchQueries({ queryKey: ["queue"] }),
       ]);
     } finally {
       setRefreshing(false);
@@ -359,7 +359,7 @@ export default function Dashboard() {
         </Card>
       )}
 
-      <ClientConfigStatus />
+      <QueueStatus />
     </div>
   );
 }

--- a/web/src/features/dashboard/QueueStatus.tsx
+++ b/web/src/features/dashboard/QueueStatus.tsx
@@ -1,0 +1,179 @@
+import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
+import { Layers, Loader2 } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { api } from "@/api/client";
+import type { QueueDetailStats } from "@/types/api";
+
+function formatDuration(ms: number): string {
+  if (ms >= 60_000) return `${(ms / 60_000).toFixed(1)}m`;
+  if (ms >= 1_000) return `${(ms / 1_000).toFixed(1)}s`;
+  return `${ms}ms`;
+}
+
+function shortenTaskId(id: string): string {
+  if (id.length <= 20) return id;
+  return `${id.slice(0, 12)}…${id.slice(-6)}`;
+}
+
+function QueueSection({
+  name,
+  stats,
+  t,
+}: {
+  name: string;
+  stats: QueueDetailStats;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}) {
+  const hasTasks = stats.processingTasks.length > 0 || stats.queuedTasks.length > 0;
+  const utilization =
+    stats.maxWorkers > 0 ? Math.round((stats.activeWorkers / stats.maxWorkers) * 100) : 0;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5 min-w-0">
+          <span className="text-xs font-medium truncate">{name}</span>
+          {stats.activeWorkers >= stats.maxWorkers && stats.queueLength > 0 && (
+            <Badge variant="secondary" className="text-[10px] px-1.5 py-0 shrink-0">
+              {t("dashboard.queue.saturated")}
+            </Badge>
+          )}
+        </div>
+        <span className="text-[10px] text-muted-foreground shrink-0">
+          {t("dashboard.queue.workers", {
+            active: stats.activeWorkers,
+            max: stats.maxWorkers,
+          })}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        <div className="rounded border border-border px-2 py-1.5">
+          <div className="text-[10px] text-muted-foreground">{t("dashboard.queue.processing")}</div>
+          <div className="text-xs font-medium font-mono">
+            {stats.activeWorkers}/{stats.maxWorkers}
+            <span className="text-[10px] text-muted-foreground font-sans ml-1">
+              ({utilization}%)
+            </span>
+          </div>
+        </div>
+        <div className="rounded border border-border px-2 py-1.5">
+          <div className="text-[10px] text-muted-foreground">{t("dashboard.queue.waiting")}</div>
+          <div className="text-xs font-medium font-mono">
+            {stats.queueLength}/{stats.maxQueueSize}
+          </div>
+        </div>
+        <div className="rounded border border-border px-2 py-1.5">
+          <div className="text-[10px] text-muted-foreground">{t("dashboard.queue.avgWait")}</div>
+          <div className="text-xs font-medium">{formatDuration(stats.avgWaitTime)}</div>
+        </div>
+        <div className="rounded border border-border px-2 py-1.5">
+          <div className="text-[10px] text-muted-foreground">{t("dashboard.queue.avgProcess")}</div>
+          <div className="text-xs font-medium">{formatDuration(stats.avgProcessTime)}</div>
+        </div>
+      </div>
+
+      {hasTasks ? (
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="text-left py-1 pr-2 text-muted-foreground font-medium">
+                  {t("dashboard.queue.taskId")}
+                </th>
+                <th className="text-left py-1 px-2 text-muted-foreground font-medium">
+                  {t("dashboard.queue.taskState")}
+                </th>
+                <th className="text-right py-1 pl-2 text-muted-foreground font-medium">
+                  {t("dashboard.queue.elapsed")}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {stats.processingTasks.map(task => (
+                <tr key={`p-${task.id}`} className="border-b border-border last:border-0">
+                  <td className="py-1 pr-2 font-mono text-[10px]" title={task.id}>
+                    {shortenTaskId(task.id)}
+                  </td>
+                  <td className="py-1 px-2">
+                    <Badge variant="success" className="text-[10px] px-1.5 py-0">
+                      {t("dashboard.queue.stateProcessing")}
+                    </Badge>
+                  </td>
+                  <td className="py-1 pl-2 text-right font-mono">{formatDuration(task.elapsed)}</td>
+                </tr>
+              ))}
+              {stats.queuedTasks.map(task => (
+                <tr key={`q-${task.id}`} className="border-b border-border last:border-0">
+                  <td className="py-1 pr-2 font-mono text-[10px]" title={task.id}>
+                    {shortenTaskId(task.id)}
+                  </td>
+                  <td className="py-1 px-2">
+                    <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                      {t("dashboard.queue.stateQueued")}
+                    </Badge>
+                  </td>
+                  <td className="py-1 pl-2 text-right font-mono">{formatDuration(task.elapsed)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="text-[10px] text-muted-foreground">{t("dashboard.queue.noActiveTasks")}</p>
+      )}
+    </div>
+  );
+}
+
+export default function QueueStatus() {
+  const { t } = useTranslation();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["queue"],
+    queryFn: () => api.getQueueStats(),
+    refetchInterval: 3000,
+  });
+
+  const sections: Array<{ name: string; stats: QueueDetailStats }> = [];
+  if (data?.default) {
+    sections.push({ name: t("dashboard.queue.defaultQueue"), stats: data.default });
+  }
+  if (data?.routes) {
+    for (const [name, stats] of Object.entries(data.routes)) {
+      sections.push({ name, stats });
+    }
+  }
+
+  return (
+    <Card className="p-0">
+      <CardHeader className="flex flex-row items-center justify-between p-3 pb-2">
+        <CardTitle className="text-xs font-medium">{t("dashboard.queue.title")}</CardTitle>
+        <Layers className="h-3.5 w-3.5 text-muted-foreground" />
+      </CardHeader>
+      <CardContent className="p-3 pt-0 space-y-3">
+        {isLoading ? (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            {t("dashboard.queue.loading")}
+          </div>
+        ) : !data?.enabled ? (
+          <p className="text-xs text-muted-foreground">
+            {data?.message ?? t("dashboard.queue.disabled")}
+          </p>
+        ) : sections.length === 0 ? (
+          <p className="text-xs text-muted-foreground">{t("dashboard.queue.noQueues")}</p>
+        ) : (
+          sections.map((section, index) => (
+            <div key={section.name}>
+              {index > 0 && <div className="border-t border-border mb-3" />}
+              <QueueSection name={section.name} stats={section.stats} t={t} />
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -9,6 +9,7 @@
     "delete": "Delete"
   },
   "nav": {
+    "clientConfig": "Client Config",
     "dashboard": "Dashboard",
     "providers": "Providers",
     "capabilities": "Capabilities",
@@ -72,16 +73,73 @@
       "provider": "Provider",
       "requests": "Requests",
       "tokens": "Tokens"
+    },
+    "queue": {
+      "title": "Concurrency Queue",
+      "loading": "Loading queue status…",
+      "disabled": "Concurrency queue is disabled",
+      "noQueues": "No queues configured",
+      "defaultQueue": "Default",
+      "saturated": "Saturated",
+      "workers": "{{active}} / {{max}} workers",
+      "processing": "Processing",
+      "waiting": "Waiting",
+      "avgWait": "Avg wait",
+      "avgProcess": "Avg process",
+      "taskId": "Task",
+      "taskState": "State",
+      "elapsed": "Elapsed",
+      "stateProcessing": "Processing",
+      "stateQueued": "Queued",
+      "noActiveTasks": "No active or queued tasks"
     }
   },
   "clientConfig": {
     "title": "Client configuration",
+    "pageSubtitle": "Point Claude Desktop, Claude Code, and Codex at this CCRelay instance",
     "description": "Check Claude Desktop, Claude Code ({{claudePath}}), and Codex ({{codexPath}}) configs point to this CCRelay instance (port {{port}}).",
     "status": {
       "ok": "OK",
       "notSet": "Not set",
       "otherHost": "Other host",
       "invalidFile": "Invalid file"
+    },
+    "diff": {
+      "allConfigured": "All fields configured",
+      "expandAll": "Show all fields",
+      "expandOk": "Show OK fields",
+      "collapse": "Collapse",
+      "collapseOk": "Hide OK fields",
+      "expectedLabel": "Expected:",
+      "currentLabel": "Current:",
+      "notSetCurrent": "(not set)"
+    },
+    "rules": {
+      "nonEmpty": "Any non-empty value",
+      "positiveNumber": "Any positive number",
+      "truthy": "Truthy (1, \"1\", or true)",
+      "absent": "Must be absent",
+      "anyNonEmpty": "Any non-empty value",
+      "nonEmptyArrayIncludingStar": "Non-empty array including \"*\"",
+      "aliasHeaderNonEmpty": "x-ccrelay-model-alias header with non-empty value (key case-insensitive)"
+    },
+    "fields": {
+      "ANTHROPIC_BASE_URL": "Anthropic base URL",
+      "ANTHROPIC_AUTH_TOKEN": "Anthropic auth token",
+      "API_TIMEOUT_MS": "API timeout (ms)",
+      "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "Disable nonessential traffic",
+      "model_provider": "Model provider",
+      "model_providers.ccrelay.base_url": "CCRelay base URL",
+      "model": "Model",
+      "inferenceGatewayBaseUrl": "Gateway base URL",
+      "inferenceProvider": "Inference provider",
+      "inferenceGatewayApiKey": "Gateway API key",
+      "coworkEgressAllowedHosts": "Cowork egress allowed hosts",
+      "inferenceCustomHeaders": "Gateway custom headers",
+      "inferenceGatewayHeaders": "Gateway headers (legacy)",
+      "disableEssentialTelemetry": "Disable essential telemetry",
+      "disableNonessentialTelemetry": "Disable nonessential telemetry",
+      "deploymentMode": "Deployment mode"
     },
     "claudeCode": {
       "name": "Claude Code",
@@ -100,7 +158,6 @@
     },
     "claudeDesktop": {
       "name": "Claude Desktop",
-      "expected": "Expected:",
       "restore": "Restore",
       "upToDate": "Up to date",
       "apply": "Apply CCRelay settings"

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -9,6 +9,7 @@
     "delete": "删除"
   },
   "nav": {
+    "clientConfig": "客户端配置",
     "dashboard": "仪表盘",
     "providers": "提供商",
     "capabilities": "能力",
@@ -72,16 +73,73 @@
       "provider": "提供商",
       "requests": "请求数",
       "tokens": "Token"
+    },
+    "queue": {
+      "title": "并发队列",
+      "loading": "加载队列状态…",
+      "disabled": "并发队列未启用",
+      "noQueues": "未配置队列",
+      "defaultQueue": "默认队列",
+      "saturated": "已满",
+      "workers": "{{active}} / {{max}} 并发",
+      "processing": "执行中",
+      "waiting": "排队中",
+      "avgWait": "平均等待",
+      "avgProcess": "平均执行",
+      "taskId": "任务",
+      "taskState": "状态",
+      "elapsed": "耗时",
+      "stateProcessing": "执行中",
+      "stateQueued": "排队中",
+      "noActiveTasks": "当前无执行中或排队任务"
     }
   },
   "clientConfig": {
     "title": "客户端配置",
+    "pageSubtitle": "将 Claude Desktop、Claude Code 和 Codex 指向此 CCRelay 实例",
     "description": "检查 Claude Desktop、Claude Code（{{claudePath}}）和 Codex（{{codexPath}}）配置是否指向此 CCRelay 实例（端口 {{port}}）。",
     "status": {
       "ok": "正常",
       "notSet": "未设置",
       "otherHost": "其他地址",
       "invalidFile": "文件无效"
+    },
+    "diff": {
+      "allConfigured": "全部已配置",
+      "expandAll": "展开查看全部字段",
+      "expandOk": "展开 OK 字段",
+      "collapse": "收起",
+      "collapseOk": "收起 OK 字段",
+      "expectedLabel": "期望:",
+      "currentLabel": "当前:",
+      "notSetCurrent": "（未设置）"
+    },
+    "rules": {
+      "nonEmpty": "任意非空值",
+      "positiveNumber": "任意正数",
+      "truthy": "Truthy（1、\"1\" 或 true）",
+      "absent": "必须不存在",
+      "anyNonEmpty": "任意非空值",
+      "nonEmptyArrayIncludingStar": "非空数组且包含 \"*\"",
+      "aliasHeaderNonEmpty": "x-ccrelay-model-alias 请求头非空（key 大小写不敏感）"
+    },
+    "fields": {
+      "ANTHROPIC_BASE_URL": "Anthropic 基础 URL",
+      "ANTHROPIC_AUTH_TOKEN": "Anthropic 认证令牌",
+      "API_TIMEOUT_MS": "API 超时（毫秒）",
+      "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "禁用非必要流量",
+      "model_provider": "模型提供商",
+      "model_providers.ccrelay.base_url": "CCRelay 基础 URL",
+      "model": "模型",
+      "inferenceGatewayBaseUrl": "网关基础 URL",
+      "inferenceProvider": "推理提供商",
+      "inferenceGatewayApiKey": "网关 API 密钥",
+      "coworkEgressAllowedHosts": "Cowork 出站允许主机",
+      "inferenceCustomHeaders": "网关自定义请求头",
+      "inferenceGatewayHeaders": "网关请求头（旧版）",
+      "disableEssentialTelemetry": "禁用必要遥测",
+      "disableNonessentialTelemetry": "禁用非必要遥测",
+      "deploymentMode": "部署模式"
     },
     "claudeCode": {
       "name": "Claude Code",
@@ -100,7 +158,6 @@
     },
     "claudeDesktop": {
       "name": "Claude Desktop",
-      "expected": "期望值:",
       "restore": "还原",
       "upToDate": "已是最新",
       "apply": "应用 CCRelay 设置"

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -187,6 +187,31 @@ export interface LogStats {
 
 export type StatsRange = "1d" | "7d" | "30d" | "all";
 
+export interface QueueTaskSnapshot {
+  id: string;
+  elapsed: number;
+}
+
+export interface QueueDetailStats {
+  queueLength: number;
+  activeWorkers: number;
+  maxWorkers: number;
+  maxQueueSize: number;
+  totalProcessed: number;
+  totalFailed: number;
+  avgWaitTime: number;
+  avgProcessTime: number;
+  processingTasks: QueueTaskSnapshot[];
+  queuedTasks: QueueTaskSnapshot[];
+}
+
+export interface QueueOverviewResponse {
+  enabled: boolean;
+  message?: string;
+  default?: QueueDetailStats | null;
+  routes: Record<string, QueueDetailStats>;
+}
+
 export interface BlockPattern {
   path: string;
   response: string;
@@ -227,10 +252,20 @@ export interface VersionResponse {
 
 export type ClientConfigItemStatus = "ok" | "missing" | "wrong_target" | "invalid";
 
+export interface ClientConfigField {
+  key: string;
+  expected: string;
+  current?: string;
+  ok: boolean;
+}
+
 export interface ClientConfigItem {
   status: ClientConfigItemStatus;
   filePath: string;
+  fields: ClientConfigField[];
   currentValue?: string;
+  customHeaders?: Record<string, string>;
+  expectedCustomHeaders?: Record<string, string>;
   modelProvider?: string;
   model?: string;
   message?: string;


### PR DESCRIPTION
## Summary
- Add a dedicated **Client Config** tab (default landing) with unified `fields[]` diff UI for Claude Desktop, Claude Code, and Codex; detection uses semantic rules (non-empty tokens, local proxy URLs, case-insensitive alias headers, etc.) instead of exact template matching.
- Add **Concurrency Queue** status on the Dashboard with live worker/queued task snapshots from extended `GET /ccrelay/api/queue`.
- Fix cross-protocol proxy streaming: native SSE errors per client surface, correct log completion when clients disconnect after terminal events, strict Chat tool sanitization (hosted tools / apply_patch), and richer stream body logging.

## Test plan
- [ ] Open Web UI → **Client Config** tab: verify all three clients show field gaps/OK state; Apply/Restore still work; expand/collapse field lists layout correctly
- [ ] Client Config: Claude Code with only custom auth token / timeout / localhost base URL shows OK where rules allow
- [ ] Client Config: Claude Desktop with `X-CCRelay-Model-Alias` header (mixed case) shows custom headers OK
- [ ] Dashboard → **Concurrency Queue**: workers, waiting count, and task list update while requests are in flight
- [ ] Cross-protocol streaming: Anthropic client against OpenAI upstream errors render as SSE (not 502); completed streams log success even if client disconnects before upstream FIN
- [ ] `npm test` and `npm run lint` pass locally


Made with [Cursor](https://cursor.com)