### PR TITLE
feat: dashboard UX, offline gate, and multi-instance leadership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **UI**
 
+- When the proxy is stopped or unreachable, the dashboard shows a **Server not running** screen and polls until the server is back.
 - **Smart Routing** tab between Dashboard and Providers: aggregates all provider model lists, exposes unified `/v1/models` with `<providerId>:<modelId>` ids, and routes requests by model without switching the active provider.
 - **Providers** page: Smart Routing card and provider cards are mutually exclusive routing modes — enable Smart Routing from the Providers tab; selecting a fallback provider disables Smart Routing. Aggregated catalog shows provider fetch errors when upstream model lists fail.
 - **Client configuration** page shows installed Claude Desktop claude-code bundles (scanned from the Claude-3p directory) and the Claude Code CLI version (via `claude --version`). CLI version detection can be disabled on the page.
@@ -20,13 +21,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `smartRouting` section in `config.yaml` (`enabled`, include/exclude filters, alias prefix, upstream models cache TTL). Optional alias-drift migration when enabling smart routing updates legacy custom model aliases that collide across providers.
 - `clientVersionDetection` section in `config.yaml` (`enabled`, default true) controls whether the dashboard runs `claude --version` for Client configuration.
 
+**Desktop**
+
+- Electron desktop app serves the dashboard from bundled UI assets, so the window can open even when the HTTP proxy is not running.
+
 ### Changed
 
 **UI**
 
+- Dashboard **Overview** combines server status, current provider, and total requests in one card, aligned with Performance and Token Usage.
 - Provider wizard and Cowork quick-fill generate canonical alias hashes (`claude-{8 hex}` from `providerId:protocol:upstreamModelId`); the same upstream model on different providers or protocols gets a different alias.
 
 ### Fixed
+
+**UI**
+
+- Dashboard and VS Code status bar show **Smart Routing** as the current provider when smart routing is enabled; the status bar **Switch Provider** menu can enable or disable Smart Routing.
+- Electron desktop dashboard no longer fails to load scripts and styles when opened while the proxy is stopped.
+
+**Multi-instance**
+
+- Leader election across VS Code extension and desktop instances now follows the active HTTP proxy port: only the serving instance holds the leader role, stale instances release coordination after reload or shutdown, and followers recover within a short polling window when the leader stops.
 
 **Config**
 

--- a/packages/core/src/api/providers.ts
+++ b/packages/core/src/api/providers.ts
@@ -9,6 +9,10 @@
 import * as http from "http";
 import type { ProxyServer } from "../server/handler";
 import type { Provider, ProvidersResponse, ProviderConfigInput, ModelMapEntry } from "../types";
+import {
+  isSmartRoutingEnabled,
+  SMART_ROUTING_PROVIDER_ID,
+} from "../server/smartRouting/virtualProvider";
 import { sendJson, parseJsonBody } from "./index";
 
 let serverInstance: ProxyServer | null = null;
@@ -48,7 +52,8 @@ export function handleListProviders(
 
   const router = serverInstance.getRouter();
   const config = serverInstance.getConfig();
-  const currentId = router.getCurrentProviderId();
+  const srEnabled = isSmartRoutingEnabled(config);
+  const currentId = srEnabled ? SMART_ROUTING_PROVIDER_ID : router.getCurrentProviderId();
 
   // Return all providers (including disabled ones)
   const webSearchProviders = config.webSearchConfig?.providers ?? [];
@@ -60,7 +65,7 @@ export function handleListProviders(
     mode: p.mode,
     providerType: p.providerType,
     baseUrl: p.baseUrl,
-    active: p.id === currentId,
+    active: !srEnabled && p.id === router.getCurrentProviderId(),
     enabled: p.enabled !== false,
     apiKey: maskApiKey(p.apiKey),
     modelMap: p.modelMap,

--- a/packages/core/src/api/stats.ts
+++ b/packages/core/src/api/stats.ts
@@ -7,6 +7,11 @@ import * as http from "http";
 import { getDatabase } from "../database";
 import { sendJson } from "./index";
 import { rejectLogStorageApiIfNotLeader } from "./serverRef";
+import { SMART_ROUTING_PROVIDER_ID } from "../server/smartRouting/virtualProvider";
+
+function omitVirtualProviderFromBreakdown<T extends { providerId: string }>(rows: T[]): T[] {
+  return rows.filter(row => row.providerId !== SMART_ROUTING_PROVIDER_ID);
+}
 
 export async function handleStats(
   req: http.IncomingMessage,
@@ -54,5 +59,8 @@ export async function handleStats(
   }
 
   const stats = await db.getStats(since ? { since } : undefined);
-  sendJson(res, 200, stats);
+  sendJson(res, 200, {
+    ...stats,
+    providerBreakdown: omitVirtualProviderFromBreakdown(stats.providerBreakdown),
+  });
 }

--- a/packages/core/src/api/status.ts
+++ b/packages/core/src/api/status.ts
@@ -6,6 +6,7 @@
 import * as http from "http";
 import type { ProxyServer } from "../server/handler";
 import type { RouterStatus } from "../types";
+import { resolveEffectiveRoutingStatus } from "../server/smartRouting/virtualProvider";
 import { sendJson } from "./index";
 
 let serverInstance: ProxyServer | null = null;
@@ -31,15 +32,16 @@ export function handleStatus(
   }
 
   const router = serverInstance.getRouter();
-  const provider = router.getCurrentProvider();
   const config = serverInstance.getConfig();
+  const routing = resolveEffectiveRoutingStatus(config, router);
 
   const status: RouterStatus = {
     status: serverInstance.running ? "running" : "stopped",
-    currentProvider: router.getCurrentProviderId(),
-    providerName: provider?.name,
-    providerMode: provider?.mode,
+    currentProvider: routing.currentProvider,
+    providerName: routing.providerName,
+    providerMode: routing.providerMode,
     port: config.port,
+    host: config.host,
   };
 
   sendJson(res, 200, status);

--- a/packages/core/src/database/drivers/postgres/driver.ts
+++ b/packages/core/src/database/drivers/postgres/driver.ts
@@ -558,13 +558,17 @@ export class PostgresDriver implements DatabaseDriver {
       const pid = String(row.provider_id);
       const count = num(row.count);
       byProvider[pid] = count;
+      const inputTokens = num(row.totalInputTokens);
+      const cacheTokens = num(row.totalCacheTokens);
+      const denom = inputTokens + cacheTokens;
       providerBreakdown.push({
         providerId: pid,
         providerName: String(row.provider_name ?? pid),
         count,
-        totalInputTokens: num(row.totalInputTokens),
+        totalInputTokens: inputTokens,
         totalOutputTokens: num(row.totalOutputTokens),
-        totalCacheTokens: num(row.totalCacheTokens),
+        totalCacheTokens: cacheTokens,
+        cacheHitRate: denom > 0 ? Math.round((cacheTokens / denom) * 100) : 0,
       });
     }
 

--- a/packages/core/src/database/drivers/sqlite/cli.ts
+++ b/packages/core/src/database/drivers/sqlite/cli.ts
@@ -1403,13 +1403,17 @@ export class SqliteCliDriver implements DatabaseDriver {
     const providerBreakdown: ProviderStatRow[] = [];
     for (const r of providerRows) {
       byProvider[r.provider_id as string] = r.count as number;
+      const inputTokens = (r.totalInputTokens as number) ?? 0;
+      const cacheTokens = (r.totalCacheTokens as number) ?? 0;
+      const denom = inputTokens + cacheTokens;
       providerBreakdown.push({
         providerId: r.provider_id as string,
         providerName: (r.provider_name as string) || (r.provider_id as string),
         count: r.count as number,
-        totalInputTokens: (r.totalInputTokens as number) ?? 0,
+        totalInputTokens: inputTokens,
         totalOutputTokens: (r.totalOutputTokens as number) ?? 0,
-        totalCacheTokens: (r.totalCacheTokens as number) ?? 0,
+        totalCacheTokens: cacheTokens,
+        cacheHitRate: denom > 0 ? Math.round((cacheTokens / denom) * 100) : 0,
       });
     }
 

--- a/packages/core/src/database/drivers/sqlite/native.ts
+++ b/packages/core/src/database/drivers/sqlite/native.ts
@@ -422,13 +422,17 @@ export class SqliteNativeDriver implements DatabaseDriver {
     const providerBreakdown: ProviderStatRow[] = [];
     for (const r of providerRows) {
       byProvider[r.provider_id as string] = r.count as number;
+      const inputTokens = (r.totalInputTokens as number) ?? 0;
+      const cacheTokens = (r.totalCacheTokens as number) ?? 0;
+      const denom = inputTokens + cacheTokens;
       providerBreakdown.push({
         providerId: r.provider_id as string,
         providerName: (r.provider_name as string) || (r.provider_id as string),
         count: r.count as number,
-        totalInputTokens: (r.totalInputTokens as number) ?? 0,
+        totalInputTokens: inputTokens,
         totalOutputTokens: (r.totalOutputTokens as number) ?? 0,
-        totalCacheTokens: (r.totalCacheTokens as number) ?? 0,
+        totalCacheTokens: cacheTokens,
+        cacheHitRate: denom > 0 ? Math.round((cacheTokens / denom) * 100) : 0,
       });
     }
 

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -85,6 +85,7 @@ export interface ProviderStatRow {
   totalInputTokens: number;
   totalOutputTokens: number;
   totalCacheTokens: number;
+  cacheHitRate: number;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,13 @@ export { setWebDistPath } from "./server/static";
 export { getUiAccessToken } from "./server/httpAccessGate";
 export { CCRELAY_UI_HEADER_NAME, CCRELAY_UI_HEADER_VALUE } from "./server/internalUiHeaders";
 
+export {
+  isSmartRoutingEnabled,
+  resolveEffectiveRoutingStatus,
+  SMART_ROUTING_PROVIDER_ID,
+  SMART_ROUTING_VIRTUAL_PROVIDER,
+} from "./server/smartRouting/virtualProvider";
+
 export { Logger, ScopedLogger, LogLevel, getLogDir } from "./utils/logger";
 
 export * as Api from "./api/index";

--- a/packages/core/src/server/handler.ts
+++ b/packages/core/src/server/handler.ts
@@ -131,6 +131,71 @@ export class ProxyServer {
   }
 
   /**
+   * Handle HTTP server start failure after winning leadership election.
+   */
+  private async handleLeaderServerStartFailure(err: unknown): Promise<void> {
+    this.serverStartInProgress = false;
+    this.log.error(
+      `[Server:${this.instanceId}] Failed to start server as leader, releasing leadership`,
+      err
+    );
+
+    await this.database.close();
+
+    if (!this.leaderElection) {
+      return;
+    }
+
+    const isPortInUse =
+      err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "EADDRINUSE";
+
+    if (isPortInUse) {
+      const portConflict = await this.leaderElection.handlePortConflict();
+      if (portConflict.becameFollower && portConflict.leaderUrl) {
+        this.role = "follower";
+        this.leaderUrl = portConflict.leaderUrl;
+        await this.ensureFollowerNoLogStorage();
+        this.connectToLeader(portConflict.leaderUrl);
+        this.log.info(
+          `[Server:${this.instanceId}] Demoted to follower of port holder at ${portConflict.leaderUrl}`
+        );
+        return;
+      }
+    }
+
+    this.leaderElection.recordLeadershipFailure();
+    await this.leaderElection.releaseLeadership();
+    this.role = "follower";
+    this.leaderUrl = null;
+
+    if (!this.leaderElection.hasExternalPortConflict()) {
+      this.leaderElection.startMonitoringAsFollower();
+    }
+
+    await this.ensureFollowerNoLogStorage();
+  }
+
+  /**
+   * Force-stop coordination (lock/IPC/heartbeat) without waiting for HTTP shutdown.
+   */
+  async forceStopCoordination(): Promise<void> {
+    if (this.leaderElection) {
+      await this.leaderElection.forceStop();
+    }
+
+    this.stopWsServer();
+    this.disconnectFromLeader();
+
+    void this.stopServerOnly().catch(stopErr => {
+      this.log.error("[Server] Error force-stopping HTTP server", stopErr);
+    });
+
+    void this.database.close().catch(closeErr => {
+      this.log.error("[Server] Error force-closing database", closeErr);
+    });
+  }
+
+  /**
    * Open persisted logs only on the leader (before HTTP accepts proxy traffic).
    */
   private async ensureLeaderLogStorage(): Promise<void> {
@@ -194,38 +259,31 @@ export class ProxyServer {
             this.leaderElection.notifyServerStarted();
           }
         } catch (err) {
-          this.serverStartInProgress = false;
-          this.log.error("[Server] Failed to start server after becoming leader", err);
-          await this.database.close();
-          if (this.leaderElection) {
-            this.leaderElection.recordLeadershipFailure();
-            await this.leaderElection.releaseLeadership();
-            this.role = "follower";
-            this.leaderUrl = null;
-
-            if (!this.leaderElection.hasExternalPortConflict()) {
-              this.leaderElection.startMonitoringAsFollower();
-            }
-            this.log.info("[Server] Released leadership after server start failure");
-          }
+          await this.handleLeaderServerStartFailure(err);
         }
       })();
     }
 
-    // If we became a follower and server is running, stop it
-    if (info.role === "follower" && this.isRunning) {
-      this.log.info("[Server] Became follower, stopping HTTP server and log storage");
-      this.stopServerOnly()
-        .then(async () => {
-          await this.database.close();
-          this.stopWsServer();
-          if (this.leaderElection) {
-            this.leaderElection.notifyServerStopped();
+    // If we became a follower, release coordination and stop HTTP if still running
+    if (info.role === "follower" && (this.isRunning || oldRole === "leader")) {
+      this.log.info("[Server] Became follower, stopping HTTP server and releasing coordination");
+      void (async () => {
+        try {
+          if (this.isRunning) {
+            await this.stopServerOnly();
+            await this.database.close();
+            this.stopWsServer();
+            if (this.leaderElection) {
+              this.leaderElection.notifyServerStopped();
+            }
           }
-        })
-        .catch(err => {
-          this.log.error("[Server] Failed to stop server after becoming follower", err);
-        });
+          if (this.leaderElection) {
+            await this.leaderElection.releaseCoordinationOnDemotion();
+          }
+        } catch (stopErr) {
+          this.log.error("[Server] Failed to stop server after becoming follower", stopErr);
+        }
+      })();
     }
 
     // Notify status bar to update
@@ -463,28 +521,7 @@ export class ProxyServer {
           // Notify election that server started successfully
           this.leaderElection.notifyServerStarted();
         } catch (err) {
-          this.serverStartInProgress = false;
-          // Server failed to start (port in use by external process)
-          this.log.error(
-            `[Server:${this.instanceId}] Failed to start server as leader, releasing leadership`,
-            err
-          );
-
-          await this.database.close();
-
-          // Record failure and release leadership
-          this.leaderElection.recordLeadershipFailure();
-          await this.leaderElection.releaseLeadership();
-          this.role = "follower";
-          this.leaderUrl = null;
-
-          // Continue monitoring unless we've hit max failures
-          if (!this.leaderElection.hasExternalPortConflict()) {
-            this.leaderElection.startMonitoringAsFollower();
-          }
-
-          await this.ensureFollowerNoLogStorage();
-
+          await this.handleLeaderServerStartFailure(err);
           return { role: this.role, leaderUrl: this.leaderUrl ?? undefined };
         }
       } else {

--- a/packages/core/src/server/httpLeaderProbe.ts
+++ b/packages/core/src/server/httpLeaderProbe.ts
@@ -1,0 +1,49 @@
+/**
+ * Lightweight HTTP probe: is a CCRelay leader serving /ccrelay/api/status?
+ */
+
+import * as http from "http";
+import { CCRELAY_UI_HEADER_NAME, CCRELAY_UI_HEADER_VALUE } from "./internalUiHeaders";
+
+const DEFAULT_PROBE_TIMEOUT_MS = 500;
+
+let getBearerToken: (() => string) | null = null;
+
+export function setLeaderHttpProbeBearer(getter: () => string): void {
+  getBearerToken = getter;
+}
+
+export function probeCcrelayHttp(
+  host: string,
+  port: number,
+  timeoutMs: number = DEFAULT_PROBE_TIMEOUT_MS
+): Promise<boolean> {
+  return new Promise(resolve => {
+    const bearer = getBearerToken?.() ?? "";
+    const req = http.request(
+      {
+        hostname: host,
+        port,
+        path: "/ccrelay/api/status",
+        method: "GET",
+        timeout: timeoutMs,
+        headers: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP request header casing
+          Authorization: `Bearer ${bearer}`,
+          [CCRELAY_UI_HEADER_NAME]: CCRELAY_UI_HEADER_VALUE,
+        },
+      },
+      res => {
+        resolve(res.statusCode === 200);
+        res.resume();
+      }
+    );
+
+    req.on("error", () => resolve(false));
+    req.on("timeout", () => {
+      req.destroy();
+      resolve(false);
+    });
+    req.end();
+  });
+}

--- a/packages/core/src/server/leaderElection.ts
+++ b/packages/core/src/server/leaderElection.ts
@@ -11,9 +11,8 @@
  * - waiting: Waiting for a new leader to appear
  */
 
-import * as http from "http";
-import { CCRELAY_UI_HEADER_NAME, CCRELAY_UI_HEADER_VALUE } from "./internalUiHeaders";
 import { ServerLock, getServerLock } from "./serverLock";
+import { probeCcrelayHttp, setLeaderHttpProbeBearer } from "./httpLeaderProbe";
 import { ScopedLogger } from "../utils/logger";
 import {
   ElectionResult,
@@ -88,6 +87,7 @@ export class LeaderElection {
     this.host = host;
     this.getApiBearerToken = getApiBearerToken;
     this.serverLock = getServerLock();
+    setLeaderHttpProbeBearer(getApiBearerToken);
   }
 
   /**
@@ -113,58 +113,46 @@ export class LeaderElection {
    */
   private async probeExistingServer(): Promise<boolean> {
     const probeStart = Date.now();
-    return new Promise(resolve => {
-      const bearer = this.getApiBearerToken();
-      const req = http.request(
-        {
-          hostname: this.host,
-          port: this.port,
-          path: "/ccrelay/api/status",
-          method: "GET",
-          timeout: PROBE_TIMEOUT_MS,
-          headers: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP request header casing
-            Authorization: `Bearer ${bearer}`,
-            [CCRELAY_UI_HEADER_NAME]: CCRELAY_UI_HEADER_VALUE,
-          },
-        },
-        res => {
-          const duration = Date.now() - probeStart;
-          // Any response from /ccrelay/api/status means CCRelay is running
-          if (res.statusCode === 200) {
-            this.log.info(
-              `[LeaderElection] Found existing CCRelay server at ${this.host}:${this.port} in ${duration}ms`
-            );
-            resolve(true);
-          } else {
-            this.log.debug(
-              `[LeaderElection] Server responded with status ${res.statusCode} in ${duration}ms`
-            );
-            resolve(false);
-          }
-          // Consume the response to free up resources
-          res.resume();
-        }
+    const ok = await probeCcrelayHttp(this.host, this.port, PROBE_TIMEOUT_MS);
+    const duration = Date.now() - probeStart;
+    if (ok) {
+      this.log.info(
+        `[LeaderElection] Found existing CCRelay server at ${this.host}:${this.port} in ${duration}ms`
       );
+    } else if (duration > 100) {
+      this.log.debug(`[LeaderElection] Probe failed in ${duration}ms`);
+    }
+    return ok;
+  }
 
-      req.on("error", () => {
-        const duration = Date.now() - probeStart;
-        // Connection refused or other error means no server running
-        if (duration > 100) {
-          this.log.debug(`[LeaderElection] Probe failed in ${duration}ms`);
-        }
-        resolve(false);
-      });
+  private async isLeaderHttpServing(leader: ServerLockInfo): Promise<boolean> {
+    return probeCcrelayHttp(leader.host, leader.port, PROBE_TIMEOUT_MS);
+  }
 
-      req.on("timeout", () => {
-        const duration = Date.now() - probeStart;
-        this.log.debug(`[LeaderElection] Probe timed out after ${duration}ms`);
-        req.destroy();
-        resolve(false);
-      });
+  /**
+   * Become follower for a lock-recorded leader only when its HTTP server responds.
+   */
+  private async tryBecomeFollowerForLeader(leader: ServerLockInfo): Promise<ElectionResult | null> {
+    const leaderHttpUp = await this.isLeaderHttpServing(leader);
+    if (!leaderHttpUp) {
+      this.log.warn(
+        `[LeaderElection] Leader ${leader.instanceId} is registered in the lock but HTTP is not serving`
+      );
+      return null;
+    }
 
-      req.end();
-    });
+    this.log.info(
+      `[LeaderElection] Existing leader found: ${leader.instanceId} at ${leader.host}:${leader.port}`
+    );
+    this.role = "follower";
+    this.setState("follower");
+    this.leaderUrl = `http://${leader.host}:${leader.port}`;
+    this.resetProbeInterval();
+    return {
+      isLeader: false,
+      leaderUrl: this.leaderUrl,
+      existingLeader: leader,
+    };
   }
 
   /**
@@ -327,19 +315,11 @@ export class LeaderElection {
       const currentLeader = await this.serverLock.getCurrentLeader();
 
       if (currentLeader) {
-        // There's already a valid leader
-        this.log.info(
-          `[LeaderElection] Existing leader found: ${currentLeader.instanceId} at ${currentLeader.host}:${currentLeader.port}`
-        );
-        this.role = "follower";
-        this.setState("follower");
-        this.leaderUrl = `http://${currentLeader.host}:${currentLeader.port}`;
-        this.resetProbeInterval();
-        return {
-          isLeader: false,
-          leaderUrl: this.leaderUrl,
-          existingLeader: currentLeader,
-        };
+        const followerResult = await this.tryBecomeFollowerForLeader(currentLeader);
+        if (followerResult) {
+          return followerResult;
+        }
+        await this.serverLock.cleanupStaleLocks();
       }
 
       // No valid leader, try to become the leader
@@ -352,6 +332,8 @@ export class LeaderElection {
           this.log.warn(
             `[LeaderElection] Acquired leadership lock but failed to bind IPC coordination socket`
           );
+        } else {
+          await this.serverLock.invalidateInheritedLeaderIfHttpDown(this.instanceId);
         }
         this.log.info(`[LeaderElection] Instance ${this.instanceId} became leader`);
         this.role = "leader";
@@ -368,15 +350,10 @@ export class LeaderElection {
       const newLeader = await this.serverLock.getCurrentLeader();
 
       if (newLeader) {
-        this.role = "follower";
-        this.setState("follower");
-        this.leaderUrl = `http://${newLeader.host}:${newLeader.port}`;
-        this.resetProbeInterval();
-        return {
-          isLeader: false,
-          leaderUrl: this.leaderUrl,
-          existingLeader: newLeader,
-        };
+        const followerResult = await this.tryBecomeFollowerForLeader(newLeader);
+        if (followerResult) {
+          return followerResult;
+        }
       }
 
       // Shouldn't reach here, but handle gracefully - assume follower
@@ -407,9 +384,7 @@ export class LeaderElection {
     this.isRunning = true;
     this.log.info(`[LeaderElection] Started election for instance ${this.instanceId}`);
 
-    if (this.role === "leader") {
-      this.startHeartbeat();
-    } else if (this.role === "follower") {
+    if (this.role === "follower") {
       this.startMonitoring();
     }
   }
@@ -423,17 +398,14 @@ export class LeaderElection {
     this.isRunning = false;
 
     // Stop timers
-    if (this.heartbeatTimer) {
-      clearInterval(this.heartbeatTimer);
-      this.heartbeatTimer = null;
-    }
+    this.stopHeartbeat();
     if (this.electionTimer) {
       clearTimeout(this.electionTimer);
       this.electionTimer = null;
     }
 
     // Release lock if we're the leader
-    if (this.role === "leader") {
+    if (this.role === "leader" || this.state === "leader" || this.state === "leader_active") {
       await this.serverLock.release(this.instanceId);
       this.log.info(`[LeaderElection] Released leadership lock`);
     }
@@ -469,18 +441,125 @@ export class LeaderElection {
   }
 
   /**
-   * Start heartbeat as leader
+   * Start heartbeat as leader (only while HTTP is actively serving)
    */
   private startHeartbeat(): void {
-    this.log.info(`[LeaderElection] Starting heartbeat as leader`);
+    this.stopHeartbeat();
+    this.log.info(`[LeaderElection] Starting heartbeat as leader_active`);
     this.heartbeatTimer = setInterval(
       // eslint-disable-next-line @typescript-eslint/no-misused-promises -- setInterval doesn't await callbacks
       async () => {
+        if (this.state !== "leader_active") {
+          this.stopHeartbeat();
+          return;
+        }
+
+        const selfHttpUp = await probeCcrelayHttp(this.host, this.port, PROBE_TIMEOUT_MS);
+        if (!selfHttpUp) {
+          this.log.warn(
+            `[LeaderElection] Self HTTP not serving while leader_active, self-evicting instance ${this.instanceId}`
+          );
+          await this.selfEvict();
+          return;
+        }
+
         await this.serverLock.updateHeartbeat(this.instanceId, this.port, this.host);
-        // this.log.debug(`[LeaderElection] Heartbeat sent for instance ${this.instanceId}`);
       },
       LEADER_HEARTBEAT_INTERVAL_MS
     );
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  /**
+   * Leader detected it no longer serves HTTP — release coordination and become follower.
+   */
+  private async selfEvict(): Promise<void> {
+    this.stopHeartbeat();
+    await this.serverLock.release(this.instanceId);
+    await this.serverLock.close();
+
+    this.role = "follower";
+    this.setState("waiting");
+    this.leaderUrl = null;
+
+    if (this.isRunning) {
+      this.startMonitoringAsFollower();
+    }
+    this.notifyRoleChange();
+  }
+
+  /**
+   * Port bind failed (EADDRINUSE). If another instance serves HTTP, demote to its follower.
+   */
+  async handlePortConflict(): Promise<{ becameFollower: boolean; leaderUrl?: string }> {
+    const serverUp = await this.probeExistingServer();
+    if (serverUp) {
+      this.log.info(
+        `[LeaderElection] Port ${this.port} held by active server, demoting to follower`
+      );
+      this.stopHeartbeat();
+      await this.serverLock.release(this.instanceId);
+      await this.serverLock.close();
+
+      this.role = "follower";
+      this.setState("follower");
+      this.leaderUrl = `http://${this.host}:${this.port}`;
+      this.failedLeadershipAttempts = 0;
+      this.resetProbeInterval();
+
+      if (this.isRunning) {
+        this.stopMonitoring();
+        this.startMonitoring();
+      }
+
+      this.notifyRoleChange();
+      return { becameFollower: true, leaderUrl: this.leaderUrl };
+    }
+
+    this.log.info(
+      `[LeaderElection] Port conflict but no server responding, cleaning stale coordination state`
+    );
+    await this.serverLock.cleanupStaleLocks();
+    await this.serverLock.invalidateInheritedLeaderIfHttpDown(this.instanceId);
+    return { becameFollower: false };
+  }
+
+  /**
+   * Release lock and IPC socket when demoting to follower (keep election monitoring).
+   */
+  async releaseCoordinationOnDemotion(): Promise<void> {
+    this.stopHeartbeat();
+    if (this.role === "leader" || this.state === "leader" || this.state === "leader_active") {
+      await this.serverLock.release(this.instanceId);
+    }
+    await this.serverLock.close();
+  }
+
+  /**
+   * Force-stop coordination without waiting for HTTP shutdown (deactivate timeout path).
+   */
+  async forceStop(): Promise<void> {
+    this.isRunning = false;
+    this.stopHeartbeat();
+    if (this.electionTimer) {
+      clearTimeout(this.electionTimer);
+      this.electionTimer = null;
+    }
+
+    if (this.role === "leader" || this.state === "leader" || this.state === "leader_active") {
+      await this.serverLock.release(this.instanceId);
+    }
+    await this.serverLock.close();
+
+    this.role = "follower";
+    this.setState("idle");
+    this.leaderUrl = null;
   }
 
   /**
@@ -540,7 +619,6 @@ export class LeaderElection {
           // We became the leader - notify server to start HTTP server
           this.log.info(`[LeaderElection] Re-elected as leader`);
           this.stopMonitoring();
-          this.startHeartbeat();
           this.notifyRoleChange(); // Notify server to start HTTP server
         } else if (result.leaderUrl) {
           // Another instance became leader, wait for it to be ready
@@ -579,8 +657,37 @@ export class LeaderElection {
       }
       this.notifyRoleChange();
     } else {
-      // Leader is still valid, reset probe interval on success
-      this.resetProbeInterval();
+      const leaderHttpUp = await this.isLeaderHttpServing(leader);
+      if (!leaderHttpUp) {
+        this.log.info(
+          `[LeaderElection] Leader ${leader.instanceId} lock is fresh but HTTP is down, starting re-election`
+        );
+        this.increaseProbeInterval();
+        try {
+          const result = await this.electLeaderWithTimeout();
+          if (result.isLeader) {
+            this.log.info(`[LeaderElection] Re-elected as leader after HTTP-down leader`);
+            this.stopMonitoring();
+            this.notifyRoleChange();
+          } else if (result.leaderUrl) {
+            this.leaderUrl = result.leaderUrl;
+            const leaderReady = await this.waitForLeaderReady(result.leaderUrl);
+            if (leaderReady) {
+              this.resetProbeInterval();
+            } else {
+              this.increaseProbeInterval();
+            }
+            this.notifyRoleChange();
+          }
+        } catch (err) {
+          this.log.error(`[LeaderElection] Re-election after HTTP-down leader failed`, err);
+          this.setState("waiting");
+          this.increaseProbeInterval();
+          this.notifyRoleChange(err instanceof Error ? err : new Error(String(err)));
+        }
+      } else {
+        this.resetProbeInterval();
+      }
     }
   }
 
@@ -668,10 +775,7 @@ export class LeaderElection {
     this.log.info(`[LeaderElection] Releasing leadership for instance ${this.instanceId}`);
 
     // Stop heartbeat timer
-    if (this.heartbeatTimer) {
-      clearInterval(this.heartbeatTimer);
-      this.heartbeatTimer = null;
-    }
+    this.stopHeartbeat();
 
     // Release the lock
     await this.serverLock.release(this.instanceId);
@@ -717,6 +821,7 @@ export class LeaderElection {
       this.setState("leader_active");
       this.resetProbeInterval();
       this.log.info(`[LeaderElection] Server started, state is now leader_active`);
+      this.startHeartbeat();
       // Notify listeners (StatusBarManager) to update UI
       this.notifyRoleChange();
     }
@@ -728,6 +833,7 @@ export class LeaderElection {
   notifyServerStopped(): void {
     if (this.state === "leader_active") {
       this.setState("leader");
+      this.stopHeartbeat();
       this.log.info(`[LeaderElection] Server stopped, state is now leader`);
       // Notify listeners (StatusBarManager) to update UI
       this.notifyRoleChange();
@@ -749,10 +855,7 @@ export class LeaderElection {
     this.setState("waiting"); // Use waiting state since we just failed leadership
 
     // Stop any existing timers
-    if (this.heartbeatTimer) {
-      clearInterval(this.heartbeatTimer);
-      this.heartbeatTimer = null;
-    }
+    this.stopHeartbeat();
 
     // Reset probe interval and start monitoring
     this.resetProbeInterval();
@@ -773,10 +876,7 @@ export class LeaderElection {
     this.log.info(`[LeaderElection] Force re-election triggered`);
 
     // Stop current timers
-    if (this.heartbeatTimer) {
-      clearInterval(this.heartbeatTimer);
-      this.heartbeatTimer = null;
-    }
+    this.stopHeartbeat();
     if (this.electionTimer) {
       clearTimeout(this.electionTimer);
       this.electionTimer = null;
@@ -793,7 +893,9 @@ export class LeaderElection {
     // Restart timers based on new role
     if (this.isRunning) {
       if (result.isLeader) {
-        this.startHeartbeat();
+        if (this.state === "leader_active") {
+          this.startHeartbeat();
+        }
       } else {
         this.startMonitoring();
       }

--- a/packages/core/src/server/serverLock.ts
+++ b/packages/core/src/server/serverLock.ts
@@ -15,6 +15,7 @@ import * as os from "os";
 import * as path from "path";
 import * as fs from "fs";
 import { Logger } from "../utils/logger";
+import { probeCcrelayHttp } from "./httpLeaderProbe";
 import type { ServerLockInfo } from "../types";
 
 // Heartbeat timeout in milliseconds - leader must heartbeat within this window
@@ -32,6 +33,9 @@ const IPC_CONNECT_TIMEOUT_MS = 500;
 
 /** Min interval between IPC takeover attempts (heartbeat / probes) */
 const IPC_TAKEOVER_COOLDOWN_MS = 5_000;
+
+/** Grace period after lock acquire before HTTP-down preempt is allowed */
+const LEADER_HTTP_PREEMPT_GRACE_MS = 5_000;
 
 // Message types for IPC communication
 type MessageType = "query" | "acquire" | "heartbeat" | "release" | "response" | "error";
@@ -280,6 +284,55 @@ export class ServerLock {
   }
 
   /**
+   * When this process becomes IPC server, drop a cached leader whose HTTP is not serving.
+   * Skips selfInstanceId so a leader mid-startup is not cleared before HTTP binds.
+   */
+  async invalidateInheritedLeaderIfHttpDown(selfInstanceId: string): Promise<void> {
+    if (!this.isIpcServer || !this.currentLeader) {
+      return;
+    }
+    if (this.currentLeader.instanceId === selfInstanceId) {
+      return;
+    }
+
+    const httpUp = await probeCcrelayHttp(this.currentLeader.host, this.currentLeader.port);
+    if (!httpUp) {
+      this.log.info(
+        `[ServerLock:${this.instanceId}] Clearing inherited leader ${this.currentLeader.instanceId} (HTTP not serving)`
+      );
+      this.currentLeader = null;
+    }
+  }
+
+  /**
+   * True when a fresh-heartbeat leader should be preempted (HTTP not serving, not self).
+   */
+  private async shouldPreemptFreshLeader(
+    leader: ServerLockInfo,
+    requesterId: string
+  ): Promise<boolean> {
+    if (leader.instanceId === requesterId) {
+      return false;
+    }
+
+    const httpUp = await probeCcrelayHttp(leader.host, leader.port);
+    if (httpUp) {
+      return false;
+    }
+
+    const now = Date.now();
+    const heartbeatFresh = now - leader.lastHeartbeat <= HEARTBEAT_TIMEOUT_MS;
+    const inStartupGrace = now - leader.startTime <= LEADER_HTTP_PREEMPT_GRACE_MS;
+
+    // Allow brief startup window for HTTP bind before treating HTTP-down as preemptible.
+    if (inStartupGrace && heartbeatFresh) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
    * Probe the existing socket to check if a real IPC server is listening.
    * Returns true if a server responds, false if connection is refused (stale socket).
    */
@@ -374,59 +427,73 @@ export class ServerLock {
    */
   private handleAcquireMessage(socket: net.Socket, message: IpcMessage): void {
     if (!this.currentLeader) {
-      // No leader yet, grant lock
-      if (message.instanceId && message.port && message.host) {
-        this.currentLeader = {
-          instanceId: message.instanceId,
-          pid: message.pid ?? process.pid,
-          port: message.port,
-          host: message.host,
-          startTime: message.startTime ?? Date.now(),
-          lastHeartbeat: message.lastHeartbeat ?? Date.now(),
-        };
-        this.log.info(
-          `[ServerLock] Lock acquired by ${this.currentLeader.instanceId} at ${this.currentLeader.host}:${this.currentLeader.port}`
-        );
-        this.sendToClient(socket, {
-          type: "response",
-          leader: this.currentLeader,
-        });
-      }
-    } else {
-      // Check if current leader is still valid
-      const now = Date.now();
-      if (now - this.currentLeader.lastHeartbeat > HEARTBEAT_TIMEOUT_MS) {
-        // Current leader is dead (heartbeat timeout), release and grant to new requester
-        this.log.info(
-          `[ServerLock] Previous leader ${this.currentLeader.instanceId} heartbeat timed out, releasing lock`
-        );
-        this.currentLeader = null;
-
-        if (message.instanceId && message.port && message.host) {
-          this.currentLeader = {
-            instanceId: message.instanceId,
-            pid: message.pid ?? process.pid,
-            port: message.port,
-            host: message.host,
-            startTime: message.startTime ?? Date.now(),
-            lastHeartbeat: message.lastHeartbeat ?? Date.now(),
-          };
-          this.log.info(
-            `[ServerLock] Lock acquired by ${this.currentLeader.instanceId} at ${this.currentLeader.host}:${this.currentLeader.port}`
-          );
-        }
-        this.sendToClient(socket, {
-          type: "response",
-          leader: this.currentLeader,
-        });
-      } else {
-        // Current leader is valid, deny request
-        this.sendToClient(socket, {
-          type: "response",
-          leader: this.currentLeader,
-        });
-      }
+      this.grantAcquireToRequester(socket, message);
+      return;
     }
+
+    const now = Date.now();
+    if (now - this.currentLeader.lastHeartbeat > HEARTBEAT_TIMEOUT_MS) {
+      this.log.info(
+        `[ServerLock] Previous leader ${this.currentLeader.instanceId} heartbeat timed out, releasing lock`
+      );
+      this.currentLeader = null;
+      this.grantAcquireToRequester(socket, message);
+      return;
+    }
+
+    void this.maybePreemptLeaderWithoutHttp(socket, message);
+  }
+
+  private grantAcquireToRequester(socket: net.Socket, message: IpcMessage): void {
+    if (!message.instanceId || !message.port || !message.host) {
+      this.sendToClient(socket, {
+        type: "error",
+        error: "Missing acquire fields",
+      });
+      return;
+    }
+
+    this.currentLeader = {
+      instanceId: message.instanceId,
+      pid: message.pid ?? process.pid,
+      port: message.port,
+      host: message.host,
+      startTime: message.startTime ?? Date.now(),
+      lastHeartbeat: message.lastHeartbeat ?? Date.now(),
+    };
+    this.log.info(
+      `[ServerLock] Lock acquired by ${this.currentLeader.instanceId} at ${this.currentLeader.host}:${this.currentLeader.port}`
+    );
+    this.sendToClient(socket, {
+      type: "response",
+      leader: this.currentLeader,
+    });
+  }
+
+  private async maybePreemptLeaderWithoutHttp(
+    socket: net.Socket,
+    message: IpcMessage
+  ): Promise<void> {
+    const leader = this.currentLeader;
+    if (!leader) {
+      this.grantAcquireToRequester(socket, message);
+      return;
+    }
+
+    const requesterId = message.instanceId ?? "";
+    if (!(await this.shouldPreemptFreshLeader(leader, requesterId))) {
+      this.sendToClient(socket, {
+        type: "response",
+        leader,
+      });
+      return;
+    }
+
+    this.log.info(
+      `[ServerLock] Preempting leader ${leader.instanceId}: heartbeat fresh but HTTP is not serving`
+    );
+    this.currentLeader = null;
+    this.grantAcquireToRequester(socket, message);
   }
 
   /**
@@ -574,6 +641,20 @@ export class ServerLock {
           // Check if current leader is dead
           if (now - this.currentLeader.lastHeartbeat > HEARTBEAT_TIMEOUT_MS) {
             this.log.info(`[ServerLock:${this.instanceId}] Current leader is dead, taking over`);
+            this.currentLeader = {
+              instanceId,
+              pid: process.pid,
+              port,
+              host,
+              startTime: now,
+              lastHeartbeat: now,
+            };
+            return true;
+          }
+          if (await this.shouldPreemptFreshLeader(this.currentLeader, instanceId)) {
+            this.log.info(
+              `[ServerLock:${this.instanceId}] Preempting leader ${this.currentLeader.instanceId}: heartbeat fresh but HTTP is not serving`
+            );
             this.currentLeader = {
               instanceId,
               pid: process.pid,

--- a/packages/core/src/server/smartRouting/virtualProvider.ts
+++ b/packages/core/src/server/smartRouting/virtualProvider.ts
@@ -11,3 +11,32 @@ export const SMART_ROUTING_VIRTUAL_PROVIDER: Provider = {
   providerType: "anthropic",
   enabled: true,
 };
+
+export function isSmartRoutingEnabled(config: {
+  smartRoutingConfig?: { enabled?: boolean };
+}): boolean {
+  return config.smartRoutingConfig?.enabled === true;
+}
+
+export function resolveEffectiveRoutingStatus(
+  config: { smartRoutingConfig?: { enabled?: boolean } },
+  router: { getCurrentProviderId(): string; getCurrentProvider(): Provider | undefined }
+): {
+  currentProvider: string;
+  providerName?: string;
+  providerMode?: Provider["mode"];
+} {
+  if (isSmartRoutingEnabled(config)) {
+    return {
+      currentProvider: SMART_ROUTING_PROVIDER_ID,
+      providerName: SMART_ROUTING_VIRTUAL_PROVIDER.name,
+      providerMode: SMART_ROUTING_VIRTUAL_PROVIDER.mode,
+    };
+  }
+  const provider = router.getCurrentProvider();
+  return {
+    currentProvider: router.getCurrentProviderId(),
+    providerName: provider?.name,
+    providerMode: provider?.mode,
+  };
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -472,6 +472,7 @@ export interface RouterStatus {
   providerName?: string;
   providerMode?: ProviderMode;
   port?: number;
+  host?: string;
 }
 
 export interface ProvidersResponse {

--- a/packages/desktop/src/dashboardProtocol.ts
+++ b/packages/desktop/src/dashboardProtocol.ts
@@ -6,7 +6,6 @@
 import { protocol } from "electron";
 import * as fs from "fs";
 import * as path from "path";
-import { pathToFileURL } from "url";
 
 export const DASHBOARD_PROTOCOL = "ccrelay-dashboard";
 
@@ -16,11 +15,32 @@ export type DashboardInjectConfig = {
   locale?: string;
 };
 
-let webDistDir = "";
-let injectConfig: DashboardInjectConfig = {
-  apiOrigin: "http://127.0.0.1:7575",
-  apiBearer: "",
+/* eslint-disable @typescript-eslint/naming-convention -- file extension keys */
+const MIME_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".ico": "image/x-icon",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
 };
+/* eslint-enable @typescript-eslint/naming-convention */
+
+let webDistDir = "";
+let injectConfig: DashboardInjectConfig | null = null;
+
+function getMimeType(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  return MIME_TYPES[ext] ?? "application/octet-stream";
+}
 
 export function registerDashboardProtocolSchemes(): void {
   protocol.registerSchemesAsPrivileged([
@@ -61,6 +81,16 @@ function resolveAssetPath(urlPathname: string): string | null {
   return normalizedFile;
 }
 
+async function readFileResponse(filePath: string, cacheable: boolean): Promise<Response> {
+  const data = await fs.promises.readFile(filePath);
+  return new Response(data, {
+    headers: {
+      "Content-Type": getMimeType(filePath), // eslint-disable-line @typescript-eslint/naming-convention -- HTTP header
+      ...(cacheable ? { "Cache-Control": "public, max-age=3600" } : {}), // eslint-disable-line @typescript-eslint/naming-convention -- HTTP header
+    },
+  });
+}
+
 export function registerDashboardProtocolHandler(webDist: string): void {
   webDistDir = webDist;
 
@@ -75,7 +105,9 @@ export function registerDashboardProtocolHandler(webDist: string): void {
         return new Response("Web UI not built. Run npm run build:web.", { status: 503 });
       }
       let html = fs.readFileSync(filePath, "utf-8");
-      html = html.replace("<head>", `<head>${buildInjectScript(injectConfig)}`);
+      if (injectConfig) {
+        html = html.replace("<head>", `<head>${buildInjectScript(injectConfig)}`);
+      }
       return new Response(html, {
         headers: { "Content-Type": "text/html; charset=utf-8" }, // eslint-disable-line @typescript-eslint/naming-convention -- HTTP header
       });
@@ -85,7 +117,7 @@ export function registerDashboardProtocolHandler(webDist: string): void {
       return new Response("Not found", { status: 404 });
     }
 
-    return fetch(pathToFileURL(filePath).href);
+    return readFileResponse(filePath, true);
   });
 }
 

--- a/packages/desktop/src/dashboardProtocol.ts
+++ b/packages/desktop/src/dashboardProtocol.ts
@@ -1,0 +1,98 @@
+/**
+ * Serve the bundled Web UI from a custom protocol so the dashboard stays available
+ * when the proxy HTTP server on :7575 is stopped.
+ */
+
+import { protocol } from "electron";
+import * as fs from "fs";
+import * as path from "path";
+import { pathToFileURL } from "url";
+
+export const DASHBOARD_PROTOCOL = "ccrelay-dashboard";
+
+export type DashboardInjectConfig = {
+  apiOrigin: string;
+  apiBearer: string;
+  locale?: string;
+};
+
+let webDistDir = "";
+let injectConfig: DashboardInjectConfig = {
+  apiOrigin: "http://127.0.0.1:7575",
+  apiBearer: "",
+};
+
+export function registerDashboardProtocolSchemes(): void {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: DASHBOARD_PROTOCOL,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        corsEnabled: true,
+        stream: true,
+      },
+    },
+  ]);
+}
+
+function buildInjectScript(config: DashboardInjectConfig): string {
+  return `<script>window.CCRELAY_API_URL=${JSON.stringify(config.apiOrigin)};window.CCRELAY_API_BEARER=${JSON.stringify(config.apiBearer)};window.CCRELAY_LOCALE=${JSON.stringify(config.locale ?? "")};</script>`;
+}
+
+function resolveAssetPath(urlPathname: string): string | null {
+  let relative = decodeURIComponent(urlPathname);
+  if (relative.startsWith("/ccrelay/")) {
+    relative = relative.slice("/ccrelay/".length);
+  } else if (relative.startsWith("/")) {
+    relative = relative.slice(1);
+  }
+  if (relative === "" || relative === "/") {
+    relative = "index.html";
+  }
+
+  const filePath = path.join(webDistDir, relative);
+  const normalizedRoot = path.normalize(webDistDir + path.sep);
+  const normalizedFile = path.normalize(filePath);
+  if (!normalizedFile.startsWith(normalizedRoot)) {
+    return null;
+  }
+  return normalizedFile;
+}
+
+export function registerDashboardProtocolHandler(webDist: string): void {
+  webDistDir = webDist;
+
+  protocol.handle(DASHBOARD_PROTOCOL, async request => {
+    const filePath = resolveAssetPath(new URL(request.url).pathname);
+    if (!filePath) {
+      return new Response("Forbidden", { status: 403 });
+    }
+
+    if (path.basename(filePath) === "index.html") {
+      if (!fs.existsSync(filePath)) {
+        return new Response("Web UI not built. Run npm run build:web.", { status: 503 });
+      }
+      let html = fs.readFileSync(filePath, "utf-8");
+      html = html.replace("<head>", `<head>${buildInjectScript(injectConfig)}`);
+      return new Response(html, {
+        headers: { "Content-Type": "text/html; charset=utf-8" }, // eslint-disable-line @typescript-eslint/naming-convention -- HTTP header
+      });
+    }
+
+    if (!fs.existsSync(filePath)) {
+      return new Response("Not found", { status: 404 });
+    }
+
+    return fetch(pathToFileURL(filePath).href);
+  });
+}
+
+export function setDashboardInjectConfig(config: DashboardInjectConfig): void {
+  injectConfig = config;
+}
+
+export function dashboardLocalUrl(): string {
+  return `${DASHBOARD_PROTOCOL}://app/ccrelay/`;
+}

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -17,7 +17,13 @@ import {
   setWebDistPath,
 } from "@ccrelay/core";
 import { createTray } from "./tray";
-import { showDashboardWindow, dashboardWebUrl } from "./window";
+import { showDashboardWindow } from "./window";
+import {
+  registerDashboardProtocolHandler,
+  registerDashboardProtocolSchemes,
+} from "./dashboardProtocol";
+
+registerDashboardProtocolSchemes();
 
 function registerLocalCcrelayRequestHeaders(configManager: ConfigManager): void {
   const port = configManager.port;
@@ -72,6 +78,7 @@ void app.whenReady().then(async () => {
   }
 
   setWebDistPath(resolveWebDist());
+  registerDashboardProtocolHandler(resolveWebDist());
 
   const configManager = new ConfigManager();
   setLogDatabaseDriverConfigResolver(() => {
@@ -95,7 +102,7 @@ void app.whenReady().then(async () => {
     } catch {
       console.log("[Desktop] Second instance attempted launch");
     }
-    showDashboardWindow(dashboardWebUrl(server, configManager));
+    showDashboardWindow(server, configManager);
   });
 
   Api.setServer(server);
@@ -109,5 +116,5 @@ void app.whenReady().then(async () => {
   }
 
   createTray(server, configManager);
-  showDashboardWindow(dashboardWebUrl(server, configManager));
+  showDashboardWindow(server, configManager);
 });

--- a/packages/desktop/src/tray.ts
+++ b/packages/desktop/src/tray.ts
@@ -6,7 +6,7 @@ import { Tray, Menu, shell, nativeImage, app } from "electron";
 import * as path from "path";
 import { getLogDir, type ConfigManager, type ProxyServer } from "@ccrelay/core";
 import { setOpenAtLogin, getOpenAtLogin } from "./autoLaunch";
-import { dashboardWebUrl, showDashboardWindow } from "./window";
+import { showDashboardWindow } from "./window";
 
 /** macOS tray uses template (monochrome); Windows/Linux use the full-color asset. */
 function trayIconFile(): string {
@@ -90,7 +90,7 @@ export function createTray(server: ProxyServer, config: ConfigManager): Tray {
       {
         label: "Open Dashboard",
         click: (): void => {
-          showDashboardWindow(dashboardWebUrl(server, config));
+          showDashboardWindow(server, config);
         },
       },
       { type: "separator" },
@@ -154,7 +154,7 @@ export function createTray(server: ProxyServer, config: ConfigManager): Tray {
   tray.setToolTip("CCRelay");
 
   tray.on("double-click", () => {
-    showDashboardWindow(dashboardWebUrl(server, config));
+    showDashboardWindow(server, config);
   });
 
   updateMenu();

--- a/packages/desktop/src/window.ts
+++ b/packages/desktop/src/window.ts
@@ -1,19 +1,35 @@
 /**
- * Electron BrowserWindow loads the dashboard over HTTP served by ProxyServer.
+ * Electron BrowserWindow loads the dashboard from bundled web assets (custom protocol).
+ * API calls still target the proxy server on the configured host/port.
  */
 
 import { BrowserWindow, app } from "electron";
 import type { ProxyServer, ConfigManager } from "@ccrelay/core";
+import {
+  dashboardLocalUrl,
+  setDashboardInjectConfig,
+  type DashboardInjectConfig,
+} from "./dashboardProtocol";
 
 let dashboardWin: BrowserWindow | null = null;
 
-export function dashboardWebUrl(server: ProxyServer, config: ConfigManager): string {
+function resolveApiOrigin(server: ProxyServer, config: ConfigManager): string {
   const base = server.getLeaderUrl() ?? `http://${config.host}:${config.port}`;
-  const normalized = base.endsWith("/") ? base.slice(0, -1) : base;
-  return `${normalized}/ccrelay/`;
+  return base.endsWith("/") ? base.slice(0, -1) : base;
 }
 
-export function showDashboardWindow(url: string): void {
+function buildInjectConfig(server: ProxyServer, config: ConfigManager): DashboardInjectConfig {
+  return {
+    apiOrigin: resolveApiOrigin(server, config),
+    apiBearer: config.getApiBearerToken(),
+    locale: config.locale,
+  };
+}
+
+export function showDashboardWindow(server: ProxyServer, config: ConfigManager): void {
+  setDashboardInjectConfig(buildInjectConfig(server, config));
+  const url = dashboardLocalUrl();
+
   if (dashboardWin) {
     if (dashboardWin.webContents.getURL() !== url) {
       void dashboardWin.loadURL(url).catch(() => {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -287,13 +287,23 @@ export async function deactivate(): Promise<void> {
       const role = server.getRole();
       logger?.info(`[Extension] Deactivating with role: ${role}`);
 
-      const stopPromise = server.stop();
-      const timeoutPromise = timeout(5000).then(() => {
-        logger?.warn("[Extension] Server stop timed out after 5s, forcing cleanup");
+      let stopTimedOut = false;
+      const stopPromise = server.stop().catch(err => {
+        logger?.error("[Extension] Error during server.stop()", err);
       });
 
-      await Promise.race([stopPromise, timeoutPromise]);
-      await Promise.race([stopPromise, timeout(1000)]);
+      await Promise.race([
+        stopPromise,
+        timeout(5000).then(async () => {
+          stopTimedOut = true;
+          logger?.warn("[Extension] Server stop timed out after 5s, forcing coordination cleanup");
+          await server!.forceStopCoordination();
+        }),
+      ]);
+
+      if (!stopTimedOut) {
+        await stopPromise;
+      }
 
       logger?.info("[Extension] Server stopped successfully");
     }

--- a/packages/vscode/src/vscode/statusBar.ts
+++ b/packages/vscode/src/vscode/statusBar.ts
@@ -4,7 +4,12 @@
 
 import * as vscode from "vscode";
 import type { ConfigManager, ProxyServer } from "@ccrelay/core";
-import type { Provider, InstanceRole, RoleChangeInfo, ElectionState } from "@ccrelay/core";
+import {
+  resolveEffectiveRoutingStatus,
+  isSmartRoutingEnabled,
+  SMART_ROUTING_PROVIDER_ID,
+} from "@ccrelay/core";
+import type { InstanceRole, RoleChangeInfo, ElectionState } from "@ccrelay/core";
 
 export class StatusBarManager implements vscode.Disposable {
   private statusBarItem: vscode.StatusBarItem;
@@ -51,6 +56,14 @@ export class StatusBarManager implements vscode.Disposable {
   private handleConfigChange = (): void => {
     this.update();
   };
+
+  private getRoutingDisplay() {
+    return resolveEffectiveRoutingStatus(this.config, this.server.getRouter());
+  }
+
+  private getDisplayProviderName(): string | undefined {
+    return this.getRoutingDisplay().providerName;
+  }
 
   private createStatusBarItem(): vscode.StatusBarItem {
     const priority = 100;
@@ -109,12 +122,27 @@ export class StatusBarManager implements vscode.Disposable {
     }
 
     const router = this.server.getRouter();
-    const currentProviderId = router.getCurrentProviderId();
-    const provider = this.config.getProvider(currentProviderId);
+    const routing = this.getRoutingDisplay();
+    const displayName = routing.providerName;
+    const provider = router.getCurrentProvider();
+    const isSmartRouting = routing.currentProvider === SMART_ROUTING_PROVIDER_ID;
 
-    if (provider) {
-      this.statusBarItem.text = `${statusIcon} ${provider.name}${statusSuffix}`;
-      this.statusBarItem.tooltip = this.buildTooltip(provider, role, electionState, leaderUrl);
+    if (displayName) {
+      this.statusBarItem.text = `${statusIcon} ${displayName}${statusSuffix}`;
+      this.statusBarItem.tooltip = this.buildTooltip(
+        isSmartRouting
+          ? { id: SMART_ROUTING_PROVIDER_ID, name: displayName }
+          : {
+              id: provider?.id ?? routing.currentProvider,
+              name: displayName,
+              mode: provider?.mode,
+              baseUrl: provider?.baseUrl,
+            },
+        role,
+        electionState,
+        leaderUrl,
+        isSmartRouting
+      );
       this.statusBarItem.backgroundColor = backgroundColor;
     } else {
       this.statusBarItem.text = `$(warning) CCRelay${statusSuffix}`;
@@ -124,23 +152,29 @@ export class StatusBarManager implements vscode.Disposable {
   }
 
   private buildTooltip(
-    provider: Provider,
+    display: { name: string; id: string; mode?: string; baseUrl?: string },
     role: InstanceRole,
     electionState: ElectionState,
-    leaderUrl: string | null
+    leaderUrl: string | null,
+    isSmartRouting: boolean
   ): string {
-    const lines = [
-      "CCRelay",
-      "",
-      `Current: ${provider.name}`,
-      `ID: ${provider.id}`,
-      `Mode: ${provider.mode}`,
-      `Base URL: ${provider.baseUrl}`,
+    const lines = ["CCRelay", "", `Current: ${display.name}`, `ID: ${display.id}`];
+
+    if (!isSmartRouting) {
+      if (display.mode) {
+        lines.push(`Mode: ${display.mode}`);
+      }
+      if (display.baseUrl) {
+        lines.push(`Base URL: ${display.baseUrl}`);
+      }
+    }
+
+    lines.push(
       `Port: ${this.config.port}`,
       "",
       `Role: ${this.getRoleDisplayName(role)}`,
-      `State: ${this.getStateDisplayName(electionState)}`,
-    ];
+      `State: ${this.getStateDisplayName(electionState)}`
+    );
 
     // Add leader URL for follower
     if (role === "follower" && leaderUrl) {
@@ -193,9 +227,7 @@ export class StatusBarManager implements vscode.Disposable {
    */
   async showMenu(): Promise<void> {
     const isRunning = this.server.running;
-    const router = this.server.getRouter();
-    const currentProviderId = router.getCurrentProviderId();
-    const currentProvider = this.config.getProvider(currentProviderId);
+    const displayName = this.getDisplayProviderName();
     const role = this.server.getRole();
 
     const menuItems: vscode.QuickPickItem[] = [
@@ -237,7 +269,7 @@ export class StatusBarManager implements vscode.Disposable {
     const roleLabel =
       role === "leader" ? "Leader" : role === "follower" ? "Follower" : "Standalone";
     const selected = await vscode.window.showQuickPick(menuItems, {
-      placeHolder: `CCRelay [${roleLabel}]${isRunning ? ` (${currentProvider?.name || "Unknown"})` : "(Stopped)"}`,
+      placeHolder: `CCRelay [${roleLabel}]${isRunning ? ` (${displayName || "Unknown"})` : "(Stopped)"}`,
       title: "CCRelay",
     });
 
@@ -293,36 +325,79 @@ export class StatusBarManager implements vscode.Disposable {
     const providers = this.config.enabledProviders;
     const router = this.server.getRouter();
     const currentId = router.getCurrentProviderId();
+    const srEnabled = isSmartRoutingEnabled(this.config);
+    const displayName = this.getDisplayProviderName();
 
-    if (providers.length === 0) {
+    if (providers.length === 0 && !srEnabled) {
       vscode.window.showWarningMessage("No enabled providers found.");
       return;
     }
 
-    const items: vscode.QuickPickItem[] = providers.map(provider => ({
-      label: provider.name,
-      description: provider.id,
-      detail: `Mode: ${provider.mode} | URL: ${provider.baseUrl}`,
-      picked: provider.id === currentId,
-    }));
+    const items: vscode.QuickPickItem[] = [
+      {
+        label: "Smart Routing",
+        description: SMART_ROUTING_PROVIDER_ID,
+        detail: "Route requests by model alias across providers",
+        picked: srEnabled,
+      },
+      { label: "", kind: vscode.QuickPickItemKind.Separator },
+      ...providers.map(provider => ({
+        label: provider.name,
+        description: provider.id,
+        detail: `Mode: ${provider.mode} | URL: ${provider.baseUrl}`,
+        picked: !srEnabled && provider.id === currentId,
+      })),
+    ];
 
     const selected = await vscode.window.showQuickPick(items, {
-      placeHolder: `Select a provider (current: ${this.config.getProvider(currentId)?.name || "Unknown"})`,
+      placeHolder: `Select routing (current: ${displayName || "Unknown"})`,
       title: "CCRelay - Switch Provider",
     });
 
-    if (selected) {
-      const provider = providers.find(p => p.id === selected.description);
-      if (provider) {
-        const result = await this.server.switchProvider(provider.id);
-        if (result.success) {
-          vscode.window.showInformationMessage(`Switched to ${provider.name}`);
-        } else {
-          vscode.window.showErrorMessage(
-            `Failed to switch to ${provider.name}: ${result.error || "Unknown error"}`
-          );
-        }
+    if (!selected?.description) {
+      return;
+    }
+
+    if (selected.description === SMART_ROUTING_PROVIDER_ID) {
+      if (srEnabled) {
+        return;
       }
+      const result = this.config.updateConfigSection("smartRouting", { enabled: true });
+      if (!result.ok) {
+        vscode.window.showErrorMessage(
+          `Failed to enable Smart Routing: ${result.error || "Unknown error"}`
+        );
+        return;
+      }
+      void this.server.getModelCatalog().refreshAll();
+      this.update();
+      vscode.window.showInformationMessage("Smart Routing enabled");
+      return;
+    }
+
+    const provider = providers.find(p => p.id === selected.description);
+    if (!provider) {
+      return;
+    }
+
+    if (srEnabled) {
+      const disableResult = this.config.updateConfigSection("smartRouting", { enabled: false });
+      if (!disableResult.ok) {
+        vscode.window.showErrorMessage(
+          `Failed to disable Smart Routing: ${disableResult.error || "Unknown error"}`
+        );
+        return;
+      }
+    }
+
+    const switchResult = await this.server.switchProvider(provider.id);
+    if (switchResult.success) {
+      this.update();
+      vscode.window.showInformationMessage(`Switched to ${provider.name}`);
+    } else {
+      vscode.window.showErrorMessage(
+        `Failed to switch to ${provider.name}: ${switchResult.error || "Unknown error"}`
+      );
     }
   }
 

--- a/tests/unit/api/status.test.ts
+++ b/tests/unit/api/status.test.ts
@@ -115,6 +115,7 @@ class MockRouter {
 class MockConfigManager {
   port: number = 7575;
   host: string = "127.0.0.1";
+  smartRoutingConfig?: { enabled?: boolean };
 
   getPort(): number {
     return this.port;
@@ -238,12 +239,37 @@ describe("api/status: handleStatus", () => {
         providerName: string;
         providerMode: string;
         port: number;
+        host: string;
       };
       expect(body.status).toBe("running");
       expect(body.currentProvider).toBe("test-provider");
       expect(body.providerName).toBe("Test Provider");
       expect(body.providerMode).toBe("passthrough");
       expect(body.port).toBe(7575);
+      expect(body.host).toBe("127.0.0.1");
+    });
+
+    it("should report Smart Routing as current provider when smart routing is enabled", () => {
+      const req = new MockIncomingMessage(
+        "/ccrelay/api/status",
+        "GET"
+      ) as unknown as MockIncomingMessage & IncomingMessage;
+      const res = new MockServerResponse() as unknown as MockServerResponse & ServerResponse;
+
+      mockConfig.smartRoutingConfig = { enabled: true };
+      (mockServer as unknown as MockProxyServer).setRunning(true);
+      setServer(mockServer);
+
+      handleStatus(req, res, {});
+
+      const body = JSON.parse(res.body) as {
+        currentProvider: string;
+        providerName: string;
+        providerMode: string;
+      };
+      expect(body.currentProvider).toBe("smart-routing");
+      expect(body.providerName).toBe("Smart Routing");
+      expect(body.providerMode).toBe("passthrough");
     });
 
     it("should include all provider details when server is running", () => {

--- a/tests/unit/web/server-reachability.test.ts
+++ b/tests/unit/web/server-reachability.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  fetchServerStatus,
+  isServerUnreachableHttpStatus,
+  probeServerReachable,
+  STOPPED_SERVER_STATUS,
+} from "../../../web/src/api/serverReachability";
+
+describe("serverReachability", () => {
+  beforeEach(() => {
+    /* eslint-disable @typescript-eslint/naming-convention -- mirrors window injection keys */
+    vi.stubGlobal("window", {
+      CCRELAY_API_URL: undefined,
+      CCRELAY_API_BEARER: "",
+    });
+    /* eslint-enable @typescript-eslint/naming-convention */
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("isServerUnreachableHttpStatus treats 503 and 5xx gateway errors as unreachable", () => {
+    expect(isServerUnreachableHttpStatus(503)).toBe(true);
+    expect(isServerUnreachableHttpStatus(502)).toBe(true);
+    expect(isServerUnreachableHttpStatus(504)).toBe(true);
+    expect(isServerUnreachableHttpStatus(401)).toBe(false);
+    expect(isServerUnreachableHttpStatus(200)).toBe(false);
+  });
+
+  it("probeServerReachable returns true when status endpoint responds ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: "running" }),
+      })
+    );
+
+    await expect(probeServerReachable()).resolves.toBe(true);
+  });
+
+  it("probeServerReachable returns false on network error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+
+    await expect(probeServerReachable()).resolves.toBe(false);
+  });
+
+  it("fetchServerStatus returns stopped snapshot when API is unreachable", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+
+    await expect(fetchServerStatus()).resolves.toEqual(STOPPED_SERVER_STATUS);
+  });
+
+  it("fetchServerStatus returns stopped snapshot for 503", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: () => Promise.resolve({ error: "not ready" }),
+      })
+    );
+
+    await expect(fetchServerStatus()).resolves.toEqual(STOPPED_SERVER_STATUS);
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -27,6 +27,7 @@ import type {
   SmartRoutingCatalogResponse,
   AliasDriftResponse,
 } from "../types/api";
+import { fetchServerStatus } from "./serverReachability";
 
 // Re-export types for convenience
 export type { LogEntry, LogsQuery };
@@ -98,7 +99,7 @@ async function fetchWizardPostJson<T>(
 
 export const api = {
   // Status
-  getStatus: (): Promise<ServerStatus> => fetchAPI<ServerStatus>("/status"),
+  getStatus: (): Promise<ServerStatus> => fetchServerStatus(),
 
   // Providers
   getProviders: (): Promise<ProvidersResponse> => fetchAPI<ProvidersResponse>("/providers"),

--- a/web/src/api/serverReachability.ts
+++ b/web/src/api/serverReachability.ts
@@ -1,0 +1,93 @@
+import type { ServerStatus } from "../types/api";
+
+type CcrelayRuntime = {
+  CCRELAY_API_URL?: string;
+  CCRELAY_API_BEARER?: string;
+  location?: { host: string; origin: string };
+};
+
+function readRuntime(): CcrelayRuntime {
+  if (typeof globalThis === "undefined") {
+    return {};
+  }
+  return globalThis as CcrelayRuntime;
+}
+
+function buildDefaultHeaders(includeJsonBody: boolean): Record<string, string> {
+  const h: Record<string, string> = {};
+  if (includeJsonBody) {
+    h["Content-Type"] = "application/json";
+  }
+  const runtime = readRuntime();
+  const bearer =
+    typeof runtime.CCRELAY_API_BEARER === "string" ? runtime.CCRELAY_API_BEARER.trim() : "";
+  if (bearer.length > 0) {
+    h.Authorization = `Bearer ${bearer}`;
+  }
+  return h;
+}
+
+export function getApiBase(): string {
+  const runtime = readRuntime();
+  return runtime.CCRELAY_API_URL ? `${runtime.CCRELAY_API_URL}/ccrelay/api` : "/ccrelay/api";
+}
+
+/** Human-readable API origin for the stopped-server screen. */
+export function getApiOriginLabel(): string {
+  const runtime = readRuntime();
+  if (runtime.CCRELAY_API_URL) {
+    try {
+      return new URL(runtime.CCRELAY_API_URL).host;
+    } catch {
+      return runtime.CCRELAY_API_URL;
+    }
+  }
+  return runtime.location?.host || "127.0.0.1:7575";
+}
+
+export const STOPPED_SERVER_STATUS: ServerStatus = {
+  status: "stopped",
+  currentProvider: "",
+  providerName: null,
+  providerMode: null,
+  port: 0,
+  host: "",
+};
+
+export function isServerUnreachableHttpStatus(status: number): boolean {
+  return status === 503 || status >= 502;
+}
+
+export async function probeServerReachable(): Promise<boolean> {
+  try {
+    const response = await fetch(`${getApiBase()}/status`, {
+      headers: buildDefaultHeaders(false),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function fetchServerStatus(): Promise<ServerStatus> {
+  try {
+    const response = await fetch(`${getApiBase()}/status`, {
+      headers: buildDefaultHeaders(false),
+    });
+    if (response.ok) {
+      return response.json() as Promise<ServerStatus>;
+    }
+    if (isServerUnreachableHttpStatus(response.status)) {
+      return STOPPED_SERVER_STATUS;
+    }
+    const errorBody = (await response.json().catch(() => ({ message: "Unknown error" }))) as {
+      message?: string;
+    };
+    throw new Error(errorBody.message || `HTTP ${response.status}`);
+  } catch (err) {
+    if (err instanceof TypeError) {
+      return STOPPED_SERVER_STATUS;
+    }
+    throw err;
+  }
+}

--- a/web/src/components/ServerAvailabilityGate.tsx
+++ b/web/src/components/ServerAvailabilityGate.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+import ServerStoppedScreen from "./ServerStoppedScreen";
+import { useServerAvailability } from "@/hooks/useServerAvailability";
+
+type ServerAvailabilityGateProps = {
+  children: ReactNode;
+};
+
+export default function ServerAvailabilityGate({ children }: ServerAvailabilityGateProps) {
+  const available = useServerAvailability();
+
+  if (available === false) {
+    return <ServerStoppedScreen checking />;
+  }
+
+  return children;
+}

--- a/web/src/components/ServerStoppedScreen.tsx
+++ b/web/src/components/ServerStoppedScreen.tsx
@@ -1,0 +1,36 @@
+import { useTranslation } from "react-i18next";
+import { Loader2, ServerOff } from "lucide-react";
+import { getApiOriginLabel } from "@/api/serverReachability";
+
+type ServerStoppedScreenProps = {
+  checking: boolean;
+};
+
+export default function ServerStoppedScreen({ checking }: ServerStoppedScreenProps) {
+  const { t } = useTranslation();
+  const endpoint = getApiOriginLabel();
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-6 py-12 text-center">
+      <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-muted">
+        <ServerOff className="h-7 w-7 text-muted-foreground" aria-hidden />
+      </div>
+      <h1 className="text-base font-semibold">{t("serverOffline.title")}</h1>
+      <p className="mt-2 max-w-md text-xs text-muted-foreground">
+        {t("serverOffline.description")}
+      </p>
+      <p className="mt-3 font-mono text-[11px] text-muted-foreground">{endpoint}</p>
+      <div className="mt-6 flex items-center gap-2 text-xs text-muted-foreground">
+        {checking ? (
+          <>
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+            <span>{t("serverOffline.checking")}</span>
+          </>
+        ) : (
+          <span>{t("serverOffline.waiting")}</span>
+        )}
+      </div>
+      <p className="mt-4 max-w-sm text-[10px] text-muted-foreground">{t("serverOffline.hint")}</p>
+    </div>
+  );
+}

--- a/web/src/features/dashboard/Dashboard.tsx
+++ b/web/src/features/dashboard/Dashboard.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Activity, Loader2, RotateCw, Server, Zap } from "lucide-react";
+import { Loader2, RotateCw } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { api } from "@/api/client";
-import type { StatsRange } from "@/types/api";
+import type { StatsRange, ServerStatus } from "@/types/api";
+import { cn } from "@/lib/utils";
 import QueueStatus from "./QueueStatus";
 
 function formatTokenCount(n: number): string {
@@ -19,6 +19,38 @@ function formatDuration(ms: number): string {
   if (ms >= 60_000) return `${(ms / 60_000).toFixed(1)}m`;
   if (ms >= 1_000) return `${(ms / 1_000).toFixed(1)}s`;
   return `${ms}ms`;
+}
+
+function formatListenAddress(host: string | undefined, port: number | undefined): string {
+  if (!port) return "";
+  const normalizedHost = host?.trim() || "127.0.0.1";
+  return `${normalizedHost}:${port}`;
+}
+
+function getProviderDisplay(
+  status: ServerStatus | undefined,
+  t: (key: string) => string
+): { label: string; hint: string | null } {
+  if (!status) {
+    return { label: t("common.na"), hint: null };
+  }
+  if (status.currentProvider === "smart-routing") {
+    return { label: t("nav.smartRouting"), hint: null };
+  }
+
+  const label =
+    status.providerName || status.currentProvider || t("dashboard.currentProvider.none");
+  const hints: string[] = [];
+  if (status.providerMode) hints.push(status.providerMode);
+  if (
+    status.currentProvider &&
+    status.providerName &&
+    status.currentProvider !== status.providerName
+  ) {
+    hints.push(status.currentProvider);
+  }
+
+  return { label, hint: hints.length > 0 ? hints.join(" · ") : null };
 }
 
 const RANGES: StatsRange[] = ["1d", "7d", "30d", "all"];
@@ -53,6 +85,12 @@ export default function Dashboard() {
       setRefreshing(false);
     }
   };
+
+  const provider = getProviderDisplay(status, t);
+  const totalLogs = stats?.totalLogs ?? 0;
+  const successCount = stats?.successCount ?? 0;
+  const errorCount = stats?.errorCount ?? 0;
+  const successRate = totalLogs > 0 ? Math.round((successCount / totalLogs) * 100) : 0;
 
   return (
     <div className="space-y-3">
@@ -97,210 +135,203 @@ export default function Dashboard() {
         </div>
       </div>
 
-      {/* Status Cards */}
-      <div className="grid gap-2 grid-cols-1 sm:grid-cols-3">
+      {/* Overview + Performance / Token */}
+      <div className="grid gap-2 grid-cols-1 lg:grid-cols-2">
         <Card className="p-0">
-          <CardHeader className="flex flex-row items-center justify-between p-3 pb-1">
-            <CardTitle className="text-xs font-medium">
-              {t("dashboard.serverStatus.title")}
-            </CardTitle>
-            <Server className="h-3.5 w-3.5 text-muted-foreground" />
-          </CardHeader>
-          <CardContent className="p-3 pt-0">
-            {statusLoading ? (
-              <div className="h-6 animate-pulse bg-muted rounded" />
+          <CardContent className="p-3 space-y-3">
+            {statusLoading || statsLoading ? (
+              <div className="h-[4.5rem] animate-pulse bg-muted rounded" />
             ) : (
               <>
-                <div className="text-lg font-bold">
-                  {status?.status === "running"
-                    ? t("dashboard.serverStatus.running")
-                    : t("dashboard.serverStatus.stopped")}
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span
+                      className={cn(
+                        "h-2 w-2 shrink-0 rounded-full",
+                        status?.status === "running" ? "bg-green-500" : "bg-muted-foreground"
+                      )}
+                      aria-hidden
+                    />
+                    <span className="text-sm font-semibold">
+                      {status?.status === "running"
+                        ? t("dashboard.serverStatus.running")
+                        : t("dashboard.serverStatus.stopped")}
+                    </span>
+                  </div>
+                  {status?.status === "running" && status.port ? (
+                    <code className="text-[10px] text-muted-foreground font-mono shrink-0">
+                      {formatListenAddress(status.host, status.port)}
+                    </code>
+                  ) : null}
                 </div>
-                <div className="flex items-center gap-1.5 mt-1">
-                  <Badge
-                    variant={status?.status === "running" ? "success" : "destructive"}
-                    className="text-[10px] px-1.5 py-0"
-                  >
-                    {status?.port || t("common.na")}
-                  </Badge>
-                  <span className="text-[10px] text-muted-foreground">
-                    {status?.host || t("common.na")}
-                  </span>
+
+                <div className="border-t border-border pt-3 grid grid-cols-2 gap-4">
+                  <div className="min-w-0">
+                    <p className="text-[10px] text-muted-foreground mb-1">
+                      {t("dashboard.currentProvider.title")}
+                    </p>
+                    <p className="text-base font-semibold truncate">{provider.label}</p>
+                    {provider.hint ? (
+                      <p className="text-[10px] text-muted-foreground truncate mt-0.5">
+                        {provider.hint}
+                      </p>
+                    ) : null}
+                  </div>
+
+                  <div>
+                    <p className="text-[10px] text-muted-foreground mb-1">
+                      {t("dashboard.totalRequests.title")}
+                    </p>
+                    <p className="text-base font-semibold">{totalLogs}</p>
+                    {totalLogs > 0 ? (
+                      <>
+                        <p className="text-[10px] mt-0.5">
+                          <span className="text-green-600 dark:text-green-500">
+                            {successCount} {t("dashboard.totalRequests.success")}
+                          </span>
+                          {errorCount > 0 ? (
+                            <>
+                              <span className="text-muted-foreground mx-1">·</span>
+                              <span className="text-destructive">
+                                {errorCount} {t("dashboard.totalRequests.errors")}
+                              </span>
+                            </>
+                          ) : null}
+                        </p>
+                        <div
+                          className="mt-1.5 h-1 rounded-full bg-muted overflow-hidden"
+                          role="presentation"
+                        >
+                          <div
+                            className="h-full bg-green-500 transition-[width]"
+                            style={{ width: `${successRate}%` }}
+                          />
+                        </div>
+                      </>
+                    ) : null}
+                  </div>
                 </div>
               </>
             )}
           </CardContent>
         </Card>
 
-        <Card className="p-0">
-          <CardHeader className="flex flex-row items-center justify-between p-3 pb-1">
-            <CardTitle className="text-xs font-medium">
-              {t("dashboard.currentProvider.title")}
-            </CardTitle>
-            <Activity className="h-3.5 w-3.5 text-muted-foreground" />
-          </CardHeader>
-          <CardContent className="p-3 pt-0">
-            {statusLoading ? (
-              <div className="h-6 animate-pulse bg-muted rounded" />
-            ) : (
-              <>
-                <div className="text-lg font-bold truncate">
-                  {status?.providerName || t("dashboard.currentProvider.none")}
+        <div className="grid gap-2 grid-cols-1 sm:grid-cols-2">
+          <Card className="p-0">
+            <CardHeader className="p-3 pb-2">
+              <CardTitle className="text-xs font-medium">
+                {t("dashboard.performance.title")}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-3 pt-0">
+              {statsLoading ? (
+                <div className="h-20 animate-pulse bg-muted rounded" />
+              ) : (
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-muted-foreground">
+                      {t("dashboard.performance.avgResponseTime")}
+                    </span>
+                    <span className="text-xs font-medium">
+                      {formatDuration(stats?.avgDuration || 0)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-muted-foreground">
+                      {t("dashboard.performance.p50Latency")}
+                    </span>
+                    <span className="text-xs font-medium">
+                      {formatDuration(stats?.p50Duration || 0)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-muted-foreground">
+                      {t("dashboard.performance.p90Latency")}
+                    </span>
+                    <span className="text-xs font-medium">
+                      {formatDuration(stats?.p90Duration || 0)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-muted-foreground">
+                      {t("dashboard.performance.avgTtfb")}
+                    </span>
+                    <span className="text-xs font-medium">
+                      {formatDuration(stats?.avgTtfb || 0)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-muted-foreground">
+                      {t("dashboard.performance.successRate")}
+                    </span>
+                    <span className="text-xs font-medium">
+                      {stats?.totalLogs
+                        ? `${Math.round((stats.successCount / stats.totalLogs) * 100)}%`
+                        : t("common.na")}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span
+                      className="text-xs text-muted-foreground"
+                      title={t("dashboard.performance.outputTpsTooltip")}
+                    >
+                      {t("dashboard.performance.outputTps")}
+                    </span>
+                    <span className="text-xs font-medium">
+                      {stats?.outputTps ? `${stats.outputTps.toFixed(1)} t/s` : "-"}
+                    </span>
+                  </div>
                 </div>
-                <div className="flex items-center gap-1.5 mt-1">
-                  <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
-                    {status?.providerMode || t("common.na")}
-                  </Badge>
-                  <span className="text-[10px] text-muted-foreground truncate">
-                    {status?.currentProvider || t("common.na")}
-                  </span>
-                </div>
-              </>
-            )}
-          </CardContent>
-        </Card>
+              )}
+            </CardContent>
+          </Card>
 
-        <Card className="p-0">
-          <CardHeader className="flex flex-row items-center justify-between p-3 pb-1">
-            <CardTitle className="text-xs font-medium">
-              {t("dashboard.totalRequests.title")}
-            </CardTitle>
-            <Zap className="h-3.5 w-3.5 text-muted-foreground" />
-          </CardHeader>
-          <CardContent className="p-3 pt-0">
-            {statsLoading ? (
-              <div className="h-6 animate-pulse bg-muted rounded" />
-            ) : (
-              <>
-                <div className="text-lg font-bold">{stats?.totalLogs || 0}</div>
-                <div className="flex items-center gap-1.5 mt-1">
-                  <span className="text-[10px] text-green-500">
-                    {`${stats?.successCount || 0} ${t("dashboard.totalRequests.success")}`}
-                  </span>
-                  <span className="text-[10px] text-red-500">
-                    {`${stats?.errorCount || 0} ${t("dashboard.totalRequests.errors")}`}
-                  </span>
+          <Card className="p-0">
+            <CardHeader className="p-3 pb-2">
+              <CardTitle className="text-xs font-medium">{t("dashboard.tokens.title")}</CardTitle>
+            </CardHeader>
+            <CardContent className="p-3 pt-0">
+              {statsLoading ? (
+                <div className="h-20 animate-pulse bg-muted rounded" />
+              ) : (
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-muted-foreground">
+                      {t("dashboard.tokens.input")}
+                    </span>
+                    <span className="text-xs font-medium">
+                      {formatTokenCount(stats?.totalInputTokens || 0)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-muted-foreground">
+                      {t("dashboard.tokens.output")}
+                    </span>
+                    <span className="text-xs font-medium">
+                      {formatTokenCount(stats?.totalOutputTokens || 0)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-muted-foreground">
+                      {t("dashboard.tokens.cache")}
+                    </span>
+                    <span className="text-xs font-medium">
+                      {formatTokenCount(stats?.totalCacheTokens || 0)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-muted-foreground">
+                      {t("dashboard.tokens.cacheHitRate")}
+                    </span>
+                    <span className="text-xs font-medium">
+                      {stats?.cacheHitRate != null ? `${stats.cacheHitRate}%` : "-"}
+                    </span>
+                  </div>
                 </div>
-              </>
-            )}
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Performance + Token Usage */}
-      <div className="grid gap-2 grid-cols-1 sm:grid-cols-2">
-        <Card className="p-0">
-          <CardHeader className="p-3 pb-2">
-            <CardTitle className="text-xs font-medium">
-              {t("dashboard.performance.title")}
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="p-3 pt-0">
-            {statsLoading ? (
-              <div className="h-20 animate-pulse bg-muted rounded" />
-            ) : (
-              <div className="space-y-1.5">
-                <div className="flex items-center justify-between">
-                  <span className="text-xs text-muted-foreground">
-                    {t("dashboard.performance.avgResponseTime")}
-                  </span>
-                  <span className="text-xs font-medium">
-                    {formatDuration(stats?.avgDuration || 0)}
-                  </span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-xs text-muted-foreground">
-                    {t("dashboard.performance.p50Latency")}
-                  </span>
-                  <span className="text-xs font-medium">
-                    {formatDuration(stats?.p50Duration || 0)}
-                  </span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-xs text-muted-foreground">
-                    {t("dashboard.performance.p90Latency")}
-                  </span>
-                  <span className="text-xs font-medium">
-                    {formatDuration(stats?.p90Duration || 0)}
-                  </span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-xs text-muted-foreground">
-                    {t("dashboard.performance.avgTtfb")}
-                  </span>
-                  <span className="text-xs font-medium">{formatDuration(stats?.avgTtfb || 0)}</span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-xs text-muted-foreground">
-                    {t("dashboard.performance.successRate")}
-                  </span>
-                  <span className="text-xs font-medium">
-                    {stats?.totalLogs
-                      ? `${Math.round((stats.successCount / stats.totalLogs) * 100)}%`
-                      : t("common.na")}
-                  </span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span
-                    className="text-xs text-muted-foreground"
-                    title={t("dashboard.performance.outputTpsTooltip")}
-                  >
-                    {t("dashboard.performance.outputTps")}
-                  </span>
-                  <span className="text-xs font-medium">
-                    {stats?.outputTps ? `${stats.outputTps.toFixed(1)} t/s` : "-"}
-                  </span>
-                </div>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card className="p-0">
-          <CardHeader className="p-3 pb-2">
-            <CardTitle className="text-xs font-medium">{t("dashboard.tokens.title")}</CardTitle>
-          </CardHeader>
-          <CardContent className="p-3 pt-0">
-            {statsLoading ? (
-              <div className="h-20 animate-pulse bg-muted rounded" />
-            ) : (
-              <div className="space-y-1.5">
-                <div className="flex items-center justify-between">
-                  <span className="text-xs text-muted-foreground">
-                    {t("dashboard.tokens.input")}
-                  </span>
-                  <span className="text-xs font-medium">
-                    {formatTokenCount(stats?.totalInputTokens || 0)}
-                  </span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-xs text-muted-foreground">
-                    {t("dashboard.tokens.output")}
-                  </span>
-                  <span className="text-xs font-medium">
-                    {formatTokenCount(stats?.totalOutputTokens || 0)}
-                  </span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-xs text-muted-foreground">
-                    {t("dashboard.tokens.cache")}
-                  </span>
-                  <span className="text-xs font-medium">
-                    {formatTokenCount(stats?.totalCacheTokens || 0)}
-                  </span>
-                </div>
-                <div className="flex items-center justify-between">
-                  <span className="text-xs text-muted-foreground">
-                    {t("dashboard.tokens.cacheHitRate")}
-                  </span>
-                  <span className="text-xs font-medium">
-                    {stats?.cacheHitRate != null ? `${stats.cacheHitRate}%` : "-"}
-                  </span>
-                </div>
-              </div>
-            )}
-          </CardContent>
-        </Card>
+              )}
+            </CardContent>
+          </Card>
+        </div>
       </div>
 
       {/* Provider Breakdown */}

--- a/web/src/features/dashboard/Dashboard.tsx
+++ b/web/src/features/dashboard/Dashboard.tsx
@@ -362,6 +362,9 @@ export default function Dashboard() {
                     <th className="text-right py-1.5 pl-2 text-muted-foreground font-medium">
                       {t("dashboard.tokens.cache")}
                     </th>
+                    <th className="text-right py-1.5 pl-2 text-muted-foreground font-medium">
+                      {t("dashboard.providerBreakdown.cacheHitRate")}
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
@@ -380,6 +383,9 @@ export default function Dashboard() {
                       </td>
                       <td className="text-right py-1.5 pl-2 font-mono text-muted-foreground">
                         {formatTokenCount(p.totalCacheTokens)}
+                      </td>
+                      <td className="text-right py-1.5 pl-2 font-mono">
+                        {p.cacheHitRate != null ? `${p.cacheHitRate}%` : "-"}
                       </td>
                     </tr>
                   ))}

--- a/web/src/hooks/useServerAvailability.ts
+++ b/web/src/hooks/useServerAvailability.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { probeServerReachable } from "@/api/serverReachability";
+
+const HEARTBEAT_MS = 3000;
+
+/** null = first probe not finished yet (render main UI optimistically). */
+export type ServerAvailability = boolean | null;
+
+export function useServerAvailability(): ServerAvailability {
+  const queryClient = useQueryClient();
+  const [available, setAvailable] = useState<ServerAvailability>(null);
+  const prevAvailable = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const tick = async () => {
+      const ok = await probeServerReachable();
+      if (cancelled) {
+        return;
+      }
+
+      if (prevAvailable.current === false && ok) {
+        void queryClient.invalidateQueries();
+      }
+      prevAvailable.current = ok;
+      setAvailable(ok);
+
+      timer = setTimeout(() => {
+        void tick();
+      }, HEARTBEAT_MS);
+    };
+
+    void tick();
+
+    return () => {
+      cancelled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
+  }, [queryClient]);
+
+  return available;
+}

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -8,6 +8,13 @@
     "apply": "Apply",
     "delete": "Delete"
   },
+  "serverOffline": {
+    "title": "Server not running",
+    "description": "No CCRelay instance is available. Start the server from the desktop tray or extension menu.",
+    "checking": "Checking for server…",
+    "waiting": "Waiting for server to come back…",
+    "hint": "The dashboard will reopen automatically when the server is reachable again."
+  },
   "nav": {
     "clientConfig": "Client Config",
     "dashboard": "Dashboard",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -80,7 +80,8 @@
       "title": "Provider Breakdown",
       "provider": "Provider",
       "requests": "Requests",
-      "tokens": "Tokens"
+      "tokens": "Tokens",
+      "cacheHitRate": "Cache Hit Rate"
     },
     "queue": {
       "title": "Concurrency Queue",

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -8,6 +8,13 @@
     "apply": "应用",
     "delete": "删除"
   },
+  "serverOffline": {
+    "title": "服务器未运行",
+    "description": "当前没有可用的 CCRelay 实例。请从桌面托盘或扩展菜单启动服务器。",
+    "checking": "正在检测服务器…",
+    "waiting": "等待服务器恢复…",
+    "hint": "服务器恢复后将自动返回管理界面。"
+  },
   "nav": {
     "clientConfig": "客户端配置",
     "dashboard": "仪表盘",

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -80,7 +80,8 @@
       "title": "提供商分布",
       "provider": "提供商",
       "requests": "请求数",
-      "tokens": "Token"
+      "tokens": "Token",
+      "cacheHitRate": "缓存命中率"
     },
     "queue": {
       "title": "并发队列",

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "./i18n";
 import App from "./App";
 import "./styles/globals.css";
+import ServerAvailabilityGate from "./components/ServerAvailabilityGate";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -18,7 +19,9 @@ const queryClient = new QueryClient({
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <ServerAvailabilityGate>
+        <App />
+      </ServerAvailabilityGate>
     </QueryClientProvider>
   </StrictMode>
 );

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -165,6 +165,7 @@ export interface ProviderBreakdownRow {
   totalInputTokens: number;
   totalOutputTokens: number;
   totalCacheTokens: number;
+  cacheHitRate: number;
 }
 
 export interface LogStats {


### PR DESCRIPTION
## Summary
- **Dashboard**: compact Overview card (server status, provider, request count); Smart Routing shown correctly as current provider; provider breakdown adds per-provider cache hit rate and omits virtual Smart Routing.
- **Offline UX**: dashboard shows a stopped-server screen with heartbeat polling when the API is unreachable; Electron loads bundled UI assets so the window works even when the proxy is down.
- **Multi-instance**: leadership aligned with HTTP port ownership—heartbeat gated on active serving, symmetric lock preemption, self-evict on stale leaders, and forced coordination cleanup on extension deactivate.
- **VS Code**: status bar displays and switches Smart Routing alongside upstream providers.

## Test plan
- [ ] Enable Smart Routing — Dashboard Overview and status bar show Smart Routing; provider breakdown lists upstream providers only (no smart-routing row) with cache hit rates.
- [ ] Stop server from tray/menu — dashboard shows Server not running; recovers automatically when server restarts.
- [ ] Electron desktop — open dashboard while proxy stopped; UI loads (no blank/broken scripts).
- [ ] Two VS Code windows / reload extension — only one instance serves :7575; follower connects to leader within ~30s after leader stops.
- [ ] `npm run format`, `npm run lint`, `npm test` pass locally.


Made with [Cursor](https://cursor.com)