### PR TITLE
fix(smart-routing): show excluded models in settings catalog

### DIFF
--- a/packages/core/src/api/smartRouting.ts
+++ b/packages/core/src/api/smartRouting.ts
@@ -18,8 +18,8 @@ let serverInstance: ProxyServer | null = null;
 function buildCatalogPayload(catalog: ModelCatalog) {
   return {
     enabled: catalog.isEnabled(),
-    entries: catalog.getAll(),
-    stats: catalog.getStats(),
+    entries: catalog.getManageableEntries(),
+    stats: catalog.getManageableStats(),
     providerErrors: catalog.getProviderErrors(),
   };
 }

--- a/packages/core/src/server/smartRouting/modelCatalog.ts
+++ b/packages/core/src/server/smartRouting/modelCatalog.ts
@@ -91,12 +91,39 @@ export class ModelCatalog {
     this.rebuildCatalog();
   }
 
+  /** Entries visible to clients (include/exclude filters applied). */
   getAll(): SmartRoutingCatalogEntry[] {
-    return this.applyFilters([...this.entries]);
+    return this.applyRoutingFilters([...this.entries]);
+  }
+
+  /** Full catalog for settings UI — exclude filter not applied so excluded models stay manageable. */
+  getManageableEntries(): SmartRoutingCatalogEntry[] {
+    return this.applyIncludeFilter([...this.entries]);
   }
 
   getStats(): SmartRoutingCatalogStats {
     const entries = this.getAll();
+    const providerIds = new Set(entries.map(e => e.providerId));
+    let lastRefreshedAt = 0;
+    for (const cache of this.upstreamCache.values()) {
+      if (cache.fetchedAt > lastRefreshedAt) {
+        lastRefreshedAt = cache.fetchedAt;
+      }
+    }
+    for (const entry of this.entries) {
+      if (entry.fetchedAt > lastRefreshedAt) {
+        lastRefreshedAt = entry.fetchedAt;
+      }
+    }
+    return {
+      providerCount: providerIds.size,
+      modelCount: entries.length,
+      ...(lastRefreshedAt > 0 ? { lastRefreshedAt } : {}),
+    };
+  }
+
+  getManageableStats(): SmartRoutingCatalogStats {
+    const entries = this.getManageableEntries();
     const providerIds = new Set(entries.map(e => e.providerId));
     let lastRefreshedAt = 0;
     for (const cache of this.upstreamCache.values()) {
@@ -319,18 +346,24 @@ export class ModelCatalog {
     }
   }
 
-  private applyFilters(entries: SmartRoutingCatalogEntry[]): SmartRoutingCatalogEntry[] {
+  private applyIncludeFilter(entries: SmartRoutingCatalogEntry[]): SmartRoutingCatalogEntry[] {
     const sr = this.smartRouting;
     if (sr.include?.length) {
       return entries.filter(e => sr.include!.some(p => minimatch(e.publicId, p)));
     }
-    if (sr.exclude?.length) {
-      return entries.filter(e => !sr.exclude!.some(p => minimatch(e.publicId, p)));
-    }
     return entries;
   }
 
+  private applyRoutingFilters(entries: SmartRoutingCatalogEntry[]): SmartRoutingCatalogEntry[] {
+    const filtered = this.applyIncludeFilter(entries);
+    const sr = this.smartRouting;
+    if (sr.exclude?.length) {
+      return filtered.filter(e => !sr.exclude!.some(p => minimatch(e.publicId, p)));
+    }
+    return filtered;
+  }
+
   private isEntryVisible(entry: SmartRoutingCatalogEntry): boolean {
-    return this.applyFilters([entry]).length > 0;
+    return this.applyRoutingFilters([entry]).length > 0;
   }
 }

--- a/tests/unit/server/smartRouting/modelCatalog.test.ts
+++ b/tests/unit/server/smartRouting/modelCatalog.test.ts
@@ -144,6 +144,35 @@ describe("ModelCatalog", () => {
     expect(catalog.getStats().providerCount).toBe(1);
   });
 
+  it("keeps excluded models in manageable catalog but not in routed catalog", async () => {
+    const providers = {
+      cn: {
+        id: "cn",
+        name: "CN",
+        baseUrl: "https://cn.example.com",
+        mode: "inject" as const,
+        providerType: "anthropic" as const,
+        enabled: true,
+        useCustomModelsList: true,
+        customModelsList: ["glm-5.1", "glm-5.2"],
+      },
+    };
+    const manager = mockConfig(providers);
+    manager.configValue.smartRouting = {
+      ...manager.configValue.smartRouting!,
+      exclude: ["cn:glm-5.1"],
+    };
+    const catalog = new ModelCatalog(manager);
+    await catalog.refreshAll();
+    expect(catalog.getAll().map(e => e.publicId)).toEqual(["cn:glm-5.2"]);
+    expect(
+      catalog
+        .getManageableEntries()
+        .map(e => e.publicId)
+        .sort()
+    ).toEqual(["cn:glm-5.1", "cn:glm-5.2"]);
+  });
+
   it("includes official provider when not in passthrough mode", async () => {
     const providers = {
       official: {

--- a/web/src/features/smart-routing/SmartRouting.tsx
+++ b/web/src/features/smart-routing/SmartRouting.tsx
@@ -26,6 +26,7 @@ import type {
   SmartRoutingProviderError,
   SmartRoutingSettings,
 } from "@/types/api";
+import { matchesSmartRoutingExclude } from "@/utils/glob";
 
 type DriftChoice = "update" | "keep";
 
@@ -97,15 +98,22 @@ export default function SmartRouting() {
   const stats = catalog?.stats;
   const providerErrors = catalog?.providerErrors ?? [];
 
-  const grouped = useMemo(() => {
-    const map = new Map<string, SmartRoutingCatalogEntry[]>();
-    for (const e of catalog?.entries ?? []) {
-      const list = map.get(e.providerId) ?? [];
-      list.push(e);
-      map.set(e.providerId, list);
-    }
-    return map;
-  }, [catalog?.entries]);
+  const sortedEntries = useMemo(() => {
+    const excludePatterns = smartRouting.exclude ?? [];
+    const entries = catalog?.entries ?? [];
+    return [...entries].sort((a, b) => {
+      const aExcluded = matchesSmartRoutingExclude(a.publicId, excludePatterns) ? 1 : 0;
+      const bExcluded = matchesSmartRoutingExclude(b.publicId, excludePatterns) ? 1 : 0;
+      if (aExcluded !== bExcluded) {
+        return aExcluded - bExcluded;
+      }
+      const providerCmp = a.providerId.localeCompare(b.providerId);
+      if (providerCmp !== 0) {
+        return providerCmp;
+      }
+      return a.publicId.localeCompare(b.publicId);
+    });
+  }, [catalog?.entries, smartRouting.exclude]);
 
   const totalEntries = catalog?.entries?.length ?? 0;
 
@@ -376,40 +384,41 @@ export default function SmartRouting() {
                   </tr>
                 </thead>
                 <tbody>
-                  {[...grouped.entries()].map(([providerId, rows]) =>
-                    rows.map(row => {
-                      const excluded = (smartRouting.exclude ?? []).includes(row.publicId);
-                      const displayLabels = catalogDisplayLabels(row);
-                      return (
-                        <tr key={row.publicId} className="border-b border-border last:border-0">
-                          <td className="py-1.5 pr-2 font-mono text-[10px] max-w-[180px] truncate">
-                            {row.publicId}
-                            <div className="text-muted-foreground">{providerId}</div>
-                          </td>
-                          <td className="py-1.5 px-2 font-mono text-[10px]">
-                            <div>{row.aliasHash}</div>
-                            {displayLabels.length > 0 ? (
-                              <div className="font-sans text-muted-foreground mt-0.5">
-                                {displayLabels.join(" · ")}
-                              </div>
-                            ) : null}
-                          </td>
-                          <td className="py-1.5 px-2">{row.protocol}</td>
-                          <td className="py-1.5 px-2">
-                            <Badge variant="outline" className="text-[10px]">
-                              {row.source}
-                            </Badge>
-                          </td>
-                          <td className="py-1.5 pl-2 text-center">
-                            <Checkbox
-                              checked={excluded}
-                              onCheckedChange={v => toggleExclude(row.publicId, v === true)}
-                            />
-                          </td>
-                        </tr>
-                      );
-                    })
-                  )}
+                  {sortedEntries.map(row => {
+                    const excluded = matchesSmartRoutingExclude(
+                      row.publicId,
+                      smartRouting.exclude ?? []
+                    );
+                    const displayLabels = catalogDisplayLabels(row);
+                    return (
+                      <tr key={row.publicId} className="border-b border-border last:border-0">
+                        <td className="py-1.5 pr-2 font-mono text-[10px] max-w-[180px] truncate">
+                          {row.publicId}
+                          <div className="text-muted-foreground">{row.providerId}</div>
+                        </td>
+                        <td className="py-1.5 px-2 font-mono text-[10px]">
+                          <div>{row.aliasHash}</div>
+                          {displayLabels.length > 0 ? (
+                            <div className="font-sans text-muted-foreground mt-0.5">
+                              {displayLabels.join(" · ")}
+                            </div>
+                          ) : null}
+                        </td>
+                        <td className="py-1.5 px-2">{row.protocol}</td>
+                        <td className="py-1.5 px-2">
+                          <Badge variant="outline" className="text-[10px]">
+                            {row.source}
+                          </Badge>
+                        </td>
+                        <td className="py-1.5 pl-2 text-center">
+                          <Checkbox
+                            checked={excluded}
+                            onCheckedChange={v => toggleExclude(row.publicId, v === true)}
+                          />
+                        </td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>

--- a/web/src/utils/glob.ts
+++ b/web/src/utils/glob.ts
@@ -1,0 +1,46 @@
+/** Simple glob pattern matching (aligned with core smart-routing exclude patterns). */
+export function minimatch(str: string, pattern: string): boolean {
+  let regexStr = "";
+
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i];
+    const nextChar = pattern[i + 1];
+
+    switch (char) {
+      case "*":
+        if (nextChar === "*") {
+          regexStr += ".*";
+          i++;
+        } else {
+          regexStr += "[^/]*";
+        }
+        break;
+      case "?":
+        regexStr += "[^/]";
+        break;
+      case ".":
+      case "^":
+      case "$":
+      case "+":
+      case "(":
+      case ")":
+      case "[":
+      case "]":
+      case "{":
+      case "}":
+      case "|":
+      case "\\":
+        regexStr += "\\";
+        regexStr += char;
+        break;
+      default:
+        regexStr += char;
+    }
+  }
+
+  return new RegExp(`^${regexStr}$`).test(str);
+}
+
+export function matchesSmartRoutingExclude(publicId: string, patterns: string[]): boolean {
+  return patterns.some(p => minimatch(publicId, p));
+}


### PR DESCRIPTION
## Summary

- Settings catalog API returns all manageable models without applying the `exclude` filter, so excluded models remain visible and editable in the Smart Routing tab.
- Runtime routing and `/v1/models` still use the filtered catalog via `getAll()`.
- UI lists non-excluded models first, then excluded ones; exclude checkboxes respect glob patterns (e.g. `official:*`).

## Test plan

- [ ] Open Smart Routing settings with some models excluded — excluded rows appear at the bottom with checkboxes checked
- [ ] Uncheck an excluded model, save, and confirm it reappears in client `/v1/models`
- [ ] Confirm disabled providers still do not appear in the settings catalog
- [ ] `npm test -- tests/unit/server/smartRouting/modelCatalog.test.ts`


Made with [Cursor](https://cursor.com)