### PR TITLE
feat: 0.2.5 dashboard updates, release check, and language settings UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.5] - 2026-05-28
 
-Smart Routing aggregates provider models with unified `/v1/models` routing. The dashboard adds an offline gate, client configuration, and a metrics split so statistics survive log clears. Desktop can open the bundled UI without a running proxy; multi-instance leader election follows the active proxy port.
+Smart Routing aggregates provider models with unified `/v1/models` routing. The dashboard adds an offline gate, client configuration, a metrics split so statistics survive log clears, and release update checks against GitHub. Desktop can open the bundled UI without a running proxy; multi-instance leader election follows the active proxy port.
 
 ### Added
 
@@ -19,6 +19,8 @@ Smart Routing aggregates provider models with unified `/v1/models` routing. The 
 - **Smart Routing** tab between Dashboard and Providers: aggregates all provider model lists, exposes unified `/v1/models` with `<providerId>:<modelId>` ids, and routes requests by model without switching the active provider.
 - **Providers** page: Smart Routing card and provider cards are mutually exclusive routing modes — enable Smart Routing from the Providers tab; selecting a fallback provider disables Smart Routing. Aggregated catalog shows provider fetch errors when upstream model lists fail.
 - **Client configuration** page shows installed Claude Desktop claude-code bundles (scanned from the Claude-3p directory) and the Claude Code CLI version (via `claude --version`). CLI version detection can be disabled on the page.
+- **Release update check** in the footer: compares your build to the latest formal GitHub Release (not the development version on `main`). Checks run about one minute after the proxy starts and once every 24 hours while it keeps running; you can also check immediately from the footer.
+- When a newer release is available, the dashboard opens an update dialog with release notes and a link to download on GitHub (opened in your system browser on desktop). The dialog refreshes if a later release appears on a subsequent check.
 
 **Config**
 
@@ -29,6 +31,7 @@ Smart Routing aggregates provider models with unified `/v1/models` routing. The 
 
 - Electron desktop app serves the dashboard from bundled UI assets, so the window can open even when the HTTP proxy is not running.
 - Electron and Tauri log build version at startup (version, build hash, git hash), matching the VS Code extension.
+- Dashboard external links (including the update download page on GitHub) open in the system default browser instead of inside the app window.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2026-05-28
+
+Smart Routing aggregates provider models with unified `/v1/models` routing. The dashboard adds an offline gate, client configuration, and a metrics split so statistics survive log clears. Desktop can open the bundled UI without a running proxy; multi-instance leader election follows the active proxy port.
+
 ### Added
 
 **UI**
@@ -44,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **UI**
 
 - Dashboard and VS Code status bar show **Smart Routing** as the current provider when smart routing is enabled; the status bar **Switch Provider** menu can enable or disable Smart Routing.
+- Smart Routing settings list excluded models again (non-excluded first) while runtime routing still omits them from `/v1/models`.
 - Electron desktop dashboard no longer fails to load scripts and styles when opened while the proxy is stopped.
 
 **Multi-instance**
@@ -65,10 +70,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Request logs for cross-protocol streaming (Chat SSE to Responses SSE) now update from `pending` to `completed` when the stream finishes, matching passthrough streaming behavior.
 - Cross-protocol streaming request logs now store the converted Responses SSE sent to the client and the upstream wire body, not only status and duration.
 - Xiaomi MiMo (Anthropic protocol): Claude Agent SDK requests that put system instructions in `messages` with `role: system` no longer fail upstream validation; those entries are rewritten as user messages and merged with adjacent user turns when needed.
-
-## [0.2.5] - 2026-05-26 (pre-release)
-
-Pre-release line for 0.2.5.
 
 ## [0.2.4] - 2026-05-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2504,6 +2504,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/superagent": {
       "version": "8.1.9",
       "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
@@ -10345,6 +10352,7 @@
       "dependencies": {
         "js-yaml": "^4.1.1",
         "pg": "^8.18.0",
+        "semver": "^7.7.3",
         "ws": "^8.20.1",
         "zod": "^4.3.6"
       },
@@ -10353,6 +10361,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.19.11",
         "@types/pg": "^8.16.0",
+        "@types/semver": "^7.7.1",
         "@types/ws": "^8.5.13",
         "better-sqlite3": "^12.9.0",
         "typescript": "^5.0.4"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,12 +10,14 @@
     "type-check": "tsc --noEmit -p ./tsconfig.json"
   },
   "dependencies": {
+    "semver": "^7.7.3",
     "js-yaml": "^4.1.1",
     "pg": "^8.18.0",
     "ws": "^8.20.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/semver": "^7.7.1",
     "@types/better-sqlite3": "^7.6.13",
     "better-sqlite3": "^12.9.0",
     "@types/js-yaml": "^4.0.9",

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -24,6 +24,7 @@ import { handleSwitchProvider, setServer as setSwitchServer } from "./switch";
 import { handleLogs, handleLogDetail, handleDeleteLogs, handleClearLogs } from "./logs";
 import { handleStats } from "./stats";
 import { handleVersion } from "./version";
+import { handleUpdateCheck, handleTriggerUpdateCheck } from "./updateCheck";
 import { handleQueueStats, handleClearQueue, setServer as setQueueServer } from "./queue";
 import {
   handleGetClientConfig,
@@ -79,6 +80,7 @@ const API_ROUTES: Record<string, ApiHandler> = {
   "/ccrelay/api/logs": handleLogs,
   "/ccrelay/api/stats": handleStats,
   "/ccrelay/api/version": handleVersion,
+  "/ccrelay/api/update-check": handleUpdateCheck,
   "/ccrelay/api/queue": handleQueueStats,
   "/ccrelay/api/internal/ui-token": handleUiToken,
 };
@@ -292,6 +294,16 @@ export function handleApiRequest(req: http.IncomingMessage, res: http.ServerResp
   if (reqPath === "/ccrelay/api/smart-routing/alias-drift/apply" && method === "POST") {
     handleSmartRoutingAliasDriftApply(req, res).catch(err => {
       log.error("Error handling POST /smart-routing/alias-drift/apply", err);
+      if (!res.headersSent) {
+        sendJson(res, 500, { error: "Internal server error" });
+      }
+    });
+    return true;
+  }
+
+  if (reqPath === "/ccrelay/api/update-check" && method === "POST") {
+    handleTriggerUpdateCheck(req, res).catch(err => {
+      log.error("Error handling POST /update-check", err);
       if (!res.headersSent) {
         sendJson(res, 500, { error: "Internal server error" });
       }

--- a/packages/core/src/api/settings.ts
+++ b/packages/core/src/api/settings.ts
@@ -15,6 +15,24 @@ export function setServer(server: ProxyServer): void {
   serverInstance = server;
 }
 
+function serverPatchRequiresRestart(
+  data: Record<string, unknown>,
+  configManager: { getConfigRawForApi(): Record<string, unknown> }
+): boolean {
+  const current =
+    (configManager.getConfigRawForApi().server as Record<string, unknown> | undefined) ?? {};
+  if ("port" in data && data.port !== undefined && data.port !== current.port) {
+    return true;
+  }
+  if ("host" in data && data.host !== undefined && data.host !== current.host) {
+    return true;
+  }
+  if ("autoStart" in data && data.autoStart !== undefined && data.autoStart !== current.autoStart) {
+    return true;
+  }
+  return false;
+}
+
 const ALLOWED_SECTIONS = new Set([
   "logging",
   "concurrency",
@@ -103,6 +121,10 @@ export async function handlePatchConfig(
       return;
     }
 
+    const restartRequired =
+      section === "logging" ||
+      (section === "server" && serverPatchRequiresRestart(body.data, configManager));
+
     const result = configManager.updateConfigSection(
       section as
         | "logging"
@@ -120,7 +142,6 @@ export async function handlePatchConfig(
       return;
     }
 
-    const restartRequired = section === "server" || section === "logging";
     sendJson(res, 200, { status: "ok", restartRequired });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/packages/core/src/api/stats.ts
+++ b/packages/core/src/api/stats.ts
@@ -5,6 +5,7 @@
 
 import * as http from "http";
 import { getDatabase } from "../database";
+import { filterProviderBreakdownByTokenUsage } from "../database/shared-utils";
 import { sendJson } from "./index";
 import { rejectLogStorageApiIfNotLeader } from "./serverRef";
 import { SMART_ROUTING_PROVIDER_ID } from "../server/smartRouting/virtualProvider";
@@ -61,6 +62,8 @@ export async function handleStats(
   const stats = await db.getStats(since ? { since } : undefined);
   sendJson(res, 200, {
     ...stats,
-    providerBreakdown: omitVirtualProviderFromBreakdown(stats.providerBreakdown),
+    providerBreakdown: filterProviderBreakdownByTokenUsage(
+      omitVirtualProviderFromBreakdown(stats.providerBreakdown)
+    ),
   });
 }

--- a/packages/core/src/api/updateCheck.ts
+++ b/packages/core/src/api/updateCheck.ts
@@ -1,0 +1,20 @@
+/**
+ * Update check API endpoint
+ * GET /ccrelay/api/update-check - Returns cached GitHub update check state
+ */
+
+import * as http from "http";
+import { getUpdateCheckState, requestUpdateCheck } from "../server/updateCheck";
+import { sendJson } from "./httpJson";
+
+export function handleUpdateCheck(_req: http.IncomingMessage, res: http.ServerResponse): void {
+  sendJson(res, 200, getUpdateCheckState());
+}
+
+export async function handleTriggerUpdateCheck(
+  _req: http.IncomingMessage,
+  res: http.ServerResponse
+): Promise<void> {
+  const state = await requestUpdateCheck();
+  sendJson(res, 200, state);
+}

--- a/packages/core/src/api/version.ts
+++ b/packages/core/src/api/version.ts
@@ -4,7 +4,7 @@
  */
 
 import * as http from "http";
-import { sendJson } from "./index";
+import { sendJson } from "./httpJson";
 
 /**
  * Type definition for auto-generated version info
@@ -18,10 +18,21 @@ type GeneratedVersion = {
   BUILD_HASH: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention -- Build constants use UPPER_CASE
   GIT_HASH?: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- Build constants use UPPER_CASE
+  PACKAGE_VERSION?: string;
+};
+
+export type BuildVersionInfo = {
+  version: string;
+  packageVersion: string;
+  date: string;
+  hash: string;
+  gitHash: string;
 };
 
 // Import auto-generated version info (fallback if not generated yet)
 let BUILD_VERSION = "dev";
+let PACKAGE_VERSION = "dev";
 let BUILD_DATE = "";
 let BUILD_HASH = "dev";
 let GIT_HASH = "unknown";
@@ -29,6 +40,7 @@ try {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const gen = require("./version.generated") as GeneratedVersion;
   BUILD_VERSION = gen.BUILD_VERSION;
+  PACKAGE_VERSION = gen.PACKAGE_VERSION ?? gen.BUILD_VERSION;
   BUILD_DATE = gen.BUILD_DATE;
   BUILD_HASH = gen.BUILD_HASH;
   GIT_HASH = gen.GIT_HASH ?? "unknown";
@@ -36,15 +48,27 @@ try {
   // Use defaults during development
   BUILD_HASH = Date.now().toString(36);
   BUILD_VERSION = "dev-" + BUILD_HASH;
+  PACKAGE_VERSION = BUILD_VERSION;
   BUILD_DATE = new Date().toISOString().split("T")[0];
 }
 
-export function handleVersion(_req: http.IncomingMessage, res: http.ServerResponse): void {
-  sendJson(res, 200, {
+export function getBuildVersionInfo(): BuildVersionInfo {
+  return {
     version: BUILD_VERSION,
+    packageVersion: PACKAGE_VERSION,
     date: BUILD_DATE,
     hash: BUILD_HASH,
     gitHash: GIT_HASH,
+  };
+}
+
+export function handleVersion(_req: http.IncomingMessage, res: http.ServerResponse): void {
+  const info = getBuildVersionInfo();
+  sendJson(res, 200, {
+    version: info.version,
+    date: info.date,
+    hash: info.hash,
+    gitHash: info.gitHash,
     features: {
       modelExtraction: true,
       logListWithoutBody: true,

--- a/packages/core/src/database/drivers/postgres/driver.ts
+++ b/packages/core/src/database/drivers/postgres/driver.ts
@@ -25,7 +25,12 @@ import type {
   StatsQuery,
   DatabaseInitializeOptions,
 } from "../../types";
-import { utf8StringToBlob, dbRowToLog, dbRowToLogWithoutBody } from "../../shared-utils";
+import {
+  utf8StringToBlob,
+  dbRowToLog,
+  dbRowToLogWithoutBody,
+  filterProviderBreakdownByTokenUsage,
+} from "../../shared-utils";
 
 /**
  * PostgreSQL driver implementation
@@ -643,7 +648,7 @@ export class PostgresDriver implements DatabaseDriver {
       outputTpsSampleCount: filteredCount,
       p50Duration: Math.round(fnum(base.p50Duration)),
       p90Duration: Math.round(fnum(base.p90Duration)),
-      providerBreakdown,
+      providerBreakdown: filterProviderBreakdownByTokenUsage(providerBreakdown),
     };
   }
 

--- a/packages/core/src/database/drivers/sqlite/cli.ts
+++ b/packages/core/src/database/drivers/sqlite/cli.ts
@@ -38,6 +38,7 @@ import {
   utf8StringToBlob,
   dbRowToLogWithoutBody,
   dbRowToLog,
+  filterProviderBreakdownByTokenUsage,
 } from "../../shared-utils";
 import { buildInsertSql, normalizeCliRow, type SqlInsertParam } from "./utils";
 import { sqlLiteralForBlob } from "./cli-wire";
@@ -1429,7 +1430,7 @@ export class SqliteCliDriver implements DatabaseDriver {
       outputTpsSampleCount: filteredCount,
       p50Duration,
       p90Duration,
-      providerBreakdown,
+      providerBreakdown: filterProviderBreakdownByTokenUsage(providerBreakdown),
     };
   }
 

--- a/packages/core/src/database/drivers/sqlite/native.ts
+++ b/packages/core/src/database/drivers/sqlite/native.ts
@@ -38,6 +38,7 @@ import {
   utf8StringToBlob,
   dbRowToLogWithoutBody,
   dbRowToLog,
+  filterProviderBreakdownByTokenUsage,
 } from "../../shared-utils";
 import { buildInsertSql } from "./utils";
 
@@ -495,7 +496,7 @@ export class SqliteNativeDriver implements DatabaseDriver {
       outputTpsSampleCount: filteredCount,
       p50Duration,
       p90Duration,
-      providerBreakdown,
+      providerBreakdown: filterProviderBreakdownByTokenUsage(providerBreakdown),
     };
   }
 

--- a/packages/core/src/database/shared-utils.ts
+++ b/packages/core/src/database/shared-utils.ts
@@ -189,3 +189,16 @@ export function dbRowToLog(row: Record<string, unknown>): RequestLog {
     ...models,
   };
 }
+
+/** Omit per-provider breakdown rows with no token usage (Input, Output, Cache all zero). */
+export function filterProviderBreakdownByTokenUsage<
+  T extends {
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    totalCacheTokens: number;
+  },
+>(rows: T[]): T[] {
+  return rows.filter(
+    row => row.totalInputTokens > 0 || row.totalOutputTokens > 0 || row.totalCacheTokens > 0
+  );
+}

--- a/packages/core/src/server/handler.ts
+++ b/packages/core/src/server/handler.ts
@@ -28,6 +28,7 @@ import {
 import { LeaderElection } from "./leaderElection";
 import { isStaticRequest, serveStatic } from "./static";
 import { isApiRequest, handleApiRequest } from "../api";
+import { cancelUpdateCheck, scheduleUpdateCheck } from "./updateCheck";
 import { ProxyExecutor } from "./proxy/executor";
 import { QueueManager } from "./queueManager";
 import { ResponseLogger } from "./responseLogger";
@@ -568,6 +569,7 @@ export class ProxyServer {
         if (this.modelCatalog.isEnabled()) {
           void this.modelCatalog.ensureReady();
         }
+        scheduleUpdateCheck();
         resolve(undefined);
       });
 
@@ -607,6 +609,7 @@ export class ProxyServer {
    * Stop only the HTTP server (no election cleanup)
    */
   private async stopServerOnly(): Promise<void> {
+    cancelUpdateCheck();
     return new Promise((resolve, reject) => {
       if (!this.server || !this.isRunning) {
         resolve();

--- a/packages/core/src/server/updateCheck.ts
+++ b/packages/core/src/server/updateCheck.ts
@@ -1,0 +1,230 @@
+/**
+ * Checks GitHub for a newer formal release than the running build.
+ * Uses the latest non-prerelease GitHub Release (not main branch package.json).
+ * Scheduled on leader HTTP start: once after 60s, then every 24 hours.
+ */
+
+import semver from "semver";
+import { getBuildVersionInfo } from "../api/version";
+import { ScopedLogger } from "../utils/logger";
+
+const log = new ScopedLogger("UpdateCheck");
+
+const REPO = "inflaborg/ccrelay";
+const LATEST_RELEASE_URL = `https://api.github.com/repos/${REPO}/releases/latest`;
+const CHECK_DELAY_MS = 60_000;
+const DAILY_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 15_000;
+
+export type UpdateCheckStatus = "pending" | "checking" | "idle" | "available";
+
+export type UpdateCheckState = {
+  status: UpdateCheckStatus;
+  currentVersion: string;
+  latestVersion?: string;
+  releaseUrl?: string;
+  releaseNotes?: string;
+  checkedAt?: string;
+};
+
+type GitHubRelease = {
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- GitHub API field
+  tag_name?: string;
+  prerelease?: boolean;
+  draft?: boolean;
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- GitHub API field
+  html_url?: string;
+  body?: string;
+};
+
+let startupTimer: ReturnType<typeof setTimeout> | null = null;
+let dailyInterval: ReturnType<typeof setInterval> | null = null;
+let schedulersStarted = false;
+let checkInProgress = false;
+
+let cachedState: UpdateCheckState = {
+  status: "pending",
+  currentVersion: getBuildVersionInfo().packageVersion,
+};
+
+function userAgent(): string {
+  return `CCRelay/${cachedState.currentVersion}`;
+}
+
+function fetchWithTimeout(url: string, init?: RequestInit): Promise<Response> {
+  return fetch(url, {
+    ...init,
+    headers: {
+      // eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP header names
+      Accept: "application/json",
+      // eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP header names
+      "User-Agent": userAgent(),
+      ...init?.headers,
+    },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+}
+
+function parseReleaseVersion(tagName: string): string | null {
+  const stripped = tagName.trim().replace(/^v/i, "");
+  return semver.coerce(stripped)?.version ?? null;
+}
+
+function finishIdle(): void {
+  cachedState = {
+    status: "idle",
+    currentVersion: getBuildVersionInfo().packageVersion,
+    checkedAt: new Date().toISOString(),
+  };
+}
+
+function finishAvailable(latestVersion: string, releaseUrl: string, releaseNotes: string): void {
+  cachedState = {
+    status: "available",
+    currentVersion: getBuildVersionInfo().packageVersion,
+    latestVersion,
+    releaseUrl,
+    releaseNotes,
+    checkedAt: new Date().toISOString(),
+  };
+}
+
+function clearSchedulers(): void {
+  if (startupTimer !== null) {
+    clearTimeout(startupTimer);
+    startupTimer = null;
+  }
+  if (dailyInterval !== null) {
+    clearInterval(dailyInterval);
+    dailyInterval = null;
+  }
+  schedulersStarted = false;
+}
+
+export function getUpdateCheckState(): UpdateCheckState {
+  return { ...cachedState };
+}
+
+export function cancelUpdateCheck(): void {
+  clearSchedulers();
+  checkInProgress = false;
+  cachedState = {
+    status: "pending",
+    currentVersion: getBuildVersionInfo().packageVersion,
+  };
+  log.info("Update check cancelled (server stopped)");
+}
+
+/** Run an update check immediately (e.g. user clicked "check again" in the UI). */
+export async function requestUpdateCheck(): Promise<UpdateCheckState> {
+  log.info("Manual update check requested");
+  if (startupTimer !== null) {
+    clearTimeout(startupTimer);
+    startupTimer = null;
+  }
+  if (!checkInProgress) {
+    await runUpdateCheck();
+  } else {
+    log.debug("Update check already in progress (manual request ignored)");
+  }
+  return getUpdateCheckState();
+}
+
+export function scheduleUpdateCheck(): void {
+  if (schedulersStarted) {
+    return;
+  }
+  schedulersStarted = true;
+
+  const currentVersion = getBuildVersionInfo().packageVersion;
+  cachedState = {
+    status: "pending",
+    currentVersion,
+  };
+
+  log.info(
+    `Update check scheduled: first in ${CHECK_DELAY_MS / 1000}s, then every ${DAILY_INTERVAL_MS / 1000 / 60 / 60}h (current version ${currentVersion})`
+  );
+
+  startupTimer = setTimeout(() => {
+    startupTimer = null;
+    void runUpdateCheck();
+  }, CHECK_DELAY_MS);
+
+  dailyInterval = setInterval(() => {
+    log.info("Daily update check triggered");
+    void runUpdateCheck();
+  }, DAILY_INTERVAL_MS);
+}
+
+export async function runUpdateCheck(): Promise<void> {
+  if (checkInProgress) {
+    log.debug("Update check already in progress, skipping duplicate run");
+    return;
+  }
+  checkInProgress = true;
+
+  const buildInfo = getBuildVersionInfo();
+  cachedState = {
+    status: "checking",
+    currentVersion: buildInfo.packageVersion,
+  };
+
+  log.info(`Starting update check (current version ${buildInfo.packageVersion})`);
+
+  try {
+    log.debug(`Fetching latest release from ${LATEST_RELEASE_URL}`);
+    const releaseRes = await fetchWithTimeout(LATEST_RELEASE_URL);
+    if (!releaseRes.ok) {
+      log.warn(`latest release fetch failed: HTTP ${releaseRes.status}`);
+      finishIdle();
+      return;
+    }
+
+    const release = (await releaseRes.json()) as GitHubRelease;
+    if (release.draft === true || release.prerelease === true) {
+      log.info("Latest release is draft or prerelease, update check complete");
+      finishIdle();
+      return;
+    }
+
+    const tagName = release.tag_name;
+    if (!tagName || typeof tagName !== "string") {
+      log.warn("latest release missing tag_name");
+      finishIdle();
+      return;
+    }
+
+    const latestForCompare = parseReleaseVersion(tagName);
+    const currentCoerced =
+      semver.coerce(buildInfo.packageVersion) ?? semver.coerce(buildInfo.version);
+    const currentForCompare = currentCoerced?.version ?? "0.0.0";
+
+    log.info(
+      `Latest release ${tagName} (resolved ${latestForCompare ?? "invalid"}), current ${currentForCompare}`
+    );
+
+    if (!latestForCompare || !semver.gt(latestForCompare, currentForCompare)) {
+      log.info("No newer formal release, update check complete");
+      finishIdle();
+      return;
+    }
+
+    const releaseUrl =
+      typeof release.html_url === "string"
+        ? release.html_url
+        : `https://github.com/${REPO}/releases/tag/v${latestForCompare}`;
+    const releaseNotes = typeof release.body === "string" ? release.body : "";
+
+    finishAvailable(latestForCompare, releaseUrl, releaseNotes);
+    log.info(
+      `Update available: v${latestForCompare} (current ${buildInfo.packageVersion}), release ${releaseUrl}`
+    );
+  } catch (err) {
+    log.warn(`Update check failed: ${err instanceof Error ? err.message : String(err)}`);
+    finishIdle();
+  } finally {
+    checkInProgress = false;
+    log.debug(`Update check ended (status=${cachedState.status})`);
+  }
+}

--- a/packages/desktop-tauri/src-tauri/Cargo.lock
+++ b/packages/desktop-tauri/src-tauri/Cargo.lock
@@ -424,8 +424,9 @@ dependencies = [
 
 [[package]]
 name = "ccrelay"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
+ "open",
  "serde",
  "serde_json",
  "tauri",
@@ -435,6 +436,7 @@ dependencies = [
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/packages/desktop-tauri/src-tauri/Cargo.toml
+++ b/packages/desktop-tauri/src-tauri/Cargo.toml
@@ -20,4 +20,6 @@ tauri-plugin-autostart = "2"
 tauri-plugin-process = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+open = "5"
+url = "2"
 tokio = { version = "1", features = ["full"] }

--- a/packages/desktop-tauri/src-tauri/src/sidecar.rs
+++ b/packages/desktop-tauri/src-tauri/src/sidecar.rs
@@ -6,6 +6,23 @@ use tauri_plugin_shell::{process::CommandChild, ShellExt};
 
 use crate::tray;
 
+/// Keep proxy UI in the webview; open other http(s) URLs in the system browser.
+fn should_navigate_in_webview(url: &url::Url, proxy_port: u16) -> bool {
+    if url.scheme() != "http" && url.scheme() != "https" {
+        return true;
+    }
+    let port = url.port_or_known_default().unwrap_or(80);
+    if port != proxy_port {
+        return false;
+    }
+    match url.host() {
+        Some(url::Host::Domain(h)) if h == "localhost" || h == "127.0.0.1" => true,
+        Some(url::Host::Ipv4(ip)) if ip.is_loopback() => true,
+        Some(url::Host::Ipv6(ip)) if ip.is_loopback() => true,
+        _ => false,
+    }
+}
+
 fn dev_js_entry_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../out/ccrelay-server.js")
 }
@@ -196,6 +213,7 @@ fn show_dashboard(app: &AppHandle, port: u16, host: &str, token: &str) {
         #[cfg(target_os = "macos")]
         let _ = app.set_activation_policy(tauri::ActivationPolicy::Regular);
     } else {
+        let proxy_port = port;
         match WebviewWindowBuilder::new(
             app,
             "dashboard",
@@ -204,6 +222,15 @@ fn show_dashboard(app: &AppHandle, port: u16, host: &str, token: &str) {
         .title("CCRelay")
         .inner_size(1024.0, 720.0)
         .min_inner_size(640.0, 480.0)
+        .on_navigation(move |nav_url| {
+            if should_navigate_in_webview(nav_url, proxy_port) {
+                return true;
+            }
+            if nav_url.scheme() == "http" || nav_url.scheme() == "https" {
+                let _ = open::that(nav_url.as_str());
+            }
+            false
+        })
         .build()
         {
             Ok(window) => {

--- a/packages/desktop/src/externalLinks.ts
+++ b/packages/desktop/src/externalLinks.ts
@@ -1,0 +1,34 @@
+/**
+ * Open http(s) links in the system browser instead of the dashboard webview.
+ */
+
+import type { WebContents } from "electron";
+import { shell } from "electron";
+import { DASHBOARD_PROTOCOL } from "./dashboardProtocol";
+
+function isHttpUrl(url: string): boolean {
+  return url.startsWith("http://") || url.startsWith("https://");
+}
+
+function isDashboardUrl(url: string): boolean {
+  return url.startsWith(`${DASHBOARD_PROTOCOL}://`);
+}
+
+export function attachExternalLinkHandlers(webContents: WebContents): void {
+  webContents.setWindowOpenHandler(({ url }) => {
+    if (isHttpUrl(url)) {
+      void shell.openExternal(url);
+    }
+    return { action: "deny" };
+  });
+
+  webContents.on("will-navigate", (event, url) => {
+    if (isDashboardUrl(url)) {
+      return;
+    }
+    event.preventDefault();
+    if (isHttpUrl(url)) {
+      void shell.openExternal(url);
+    }
+  });
+}

--- a/packages/desktop/src/tray.ts
+++ b/packages/desktop/src/tray.ts
@@ -6,7 +6,7 @@ import { Tray, Menu, shell, nativeImage, app } from "electron";
 import * as path from "path";
 import { getLogDir, type ConfigManager, type ProxyServer } from "@ccrelay/core";
 import { setOpenAtLogin, getOpenAtLogin } from "./autoLaunch";
-import { showDashboardWindow } from "./window";
+import { showDashboardWindow, updateDashboardInjectConfig } from "./window";
 
 /** macOS tray uses template (monochrome); Windows/Linux use the full-color asset. */
 function trayIconFile(): string {
@@ -149,7 +149,10 @@ export function createTray(server: ProxyServer, config: ConfigManager): Tray {
 
   server.onRoleChanged(() => updateMenu());
   server.getRouter().onProviderChanged(() => updateMenu());
-  config.onConfigChanged(() => updateMenu());
+  config.onConfigChanged(() => {
+    updateDashboardInjectConfig(server, config);
+    updateMenu();
+  });
 
   tray.setToolTip("CCRelay");
 

--- a/packages/desktop/src/window.ts
+++ b/packages/desktop/src/window.ts
@@ -10,6 +10,7 @@ import {
   setDashboardInjectConfig,
   type DashboardInjectConfig,
 } from "./dashboardProtocol";
+import { attachExternalLinkHandlers } from "./externalLinks";
 
 let dashboardWin: BrowserWindow | null = null;
 
@@ -57,6 +58,8 @@ export function showDashboardWindow(server: ProxyServer, config: ConfigManager):
       sandbox: true,
     },
   });
+
+  attachExternalLinkHandlers(dashboardWin.webContents);
 
   void dashboardWin.loadURL(url).catch(() => {
     /* ERR_CONNECTION_* etc.: user sees Electron error page */

--- a/packages/desktop/src/window.ts
+++ b/packages/desktop/src/window.ts
@@ -27,8 +27,12 @@ function buildInjectConfig(server: ProxyServer, config: ConfigManager): Dashboar
   };
 }
 
-export function showDashboardWindow(server: ProxyServer, config: ConfigManager): void {
+export function updateDashboardInjectConfig(server: ProxyServer, config: ConfigManager): void {
   setDashboardInjectConfig(buildInjectConfig(server, config));
+}
+
+export function showDashboardWindow(server: ProxyServer, config: ConfigManager): void {
+  updateDashboardInjectConfig(server, config);
   const url = dashboardLocalUrl();
 
   if (dashboardWin) {

--- a/tests/unit/api/index.test.ts
+++ b/tests/unit/api/index.test.ts
@@ -18,6 +18,7 @@ import {
   handleApiRequest,
 } from "@/api/index";
 import { resetProxyServerForApi, setProxyServerForApi } from "@/api/serverRef";
+import { cancelUpdateCheck } from "@/server/updateCheck";
 import type { ProxyServer } from "@/server/handler";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { EventEmitter } from "stream";
@@ -622,5 +623,58 @@ describe("api: handleApiRequest specific routes", () => {
     // Version endpoint doesn't require server initialization
     // It should return 200 with version info
     expect(res.statusCode).toBe(200);
+  });
+
+  it("should handle GET /ccrelay/api/update-check", () => {
+    const req = new MockIncomingMessage(
+      "/ccrelay/api/update-check",
+      "GET"
+    ) as unknown as MockIncomingMessage & IncomingMessage;
+    const res = new MockServerResponse() as unknown as MockServerResponse & ServerResponse;
+
+    handleApiRequest(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as { status: string; currentVersion: string };
+    expect(body.status).toBe("pending");
+    expect(typeof body.currentVersion).toBe("string");
+  });
+
+  it("should handle POST /ccrelay/api/update-check", async () => {
+    cancelUpdateCheck();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (url.includes("/releases/latest")) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                // eslint-disable-next-line @typescript-eslint/naming-convention -- GitHub API field
+                tag_name: "v0.0.1",
+                prerelease: false,
+              }),
+          });
+        }
+        return Promise.resolve({ ok: false, status: 404 });
+      })
+    );
+
+    const req = new MockIncomingMessage(
+      "/ccrelay/api/update-check",
+      "POST"
+    ) as unknown as MockIncomingMessage & IncomingMessage;
+    const res = new MockServerResponse() as unknown as MockServerResponse & ServerResponse;
+
+    handleApiRequest(req, res);
+
+    await vi.waitFor(() => expect(res.ended).toBe(true));
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as { status: string; checkedAt?: string };
+    expect(body.status).toBe("idle");
+    expect(body.checkedAt).toBeDefined();
+
+    vi.unstubAllGlobals();
+    cancelUpdateCheck();
   });
 });

--- a/tests/unit/database/log-db-migration.test.ts
+++ b/tests/unit/database/log-db-migration.test.ts
@@ -147,7 +147,7 @@ describe.skipIf(!nativeForNode)("log-db-migration", () => {
             request_body, response_body, original_request_body, original_response_body,
             status_code, duration, success, error_message, client_id, status, route_type,
             input_tokens, output_tokens, cache_tokens, ttfb
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         ).run(...params);
       },
       "migrate"

--- a/tests/unit/server/updateCheck.test.ts
+++ b/tests/unit/server/updateCheck.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getBuildVersionInfo } = vi.hoisted(() => ({
+  getBuildVersionInfo: vi.fn(() => ({
+    version: "0.2.5",
+    packageVersion: "0.2.5",
+    date: "2026-01-01",
+    hash: "abc",
+    gitHash: "def",
+  })),
+}));
+
+vi.mock("@/api/version", () => ({
+  getBuildVersionInfo,
+}));
+
+import {
+  cancelUpdateCheck,
+  getUpdateCheckState,
+  requestUpdateCheck,
+  runUpdateCheck,
+  scheduleUpdateCheck,
+} from "@/server/updateCheck";
+
+function mockLatestRelease(payload: {
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- GitHub API field
+  tag_name: string;
+  prerelease?: boolean;
+  draft?: boolean;
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- GitHub API field
+  html_url?: string;
+  body?: string;
+}): void {
+  mockFetch(url => {
+    if (url.includes("/releases/latest")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(payload),
+      });
+    }
+    return Promise.reject(new Error(`unexpected url: ${url}`));
+  });
+}
+
+function mockFetch(
+  handler: (url: string) => Promise<{
+    ok: boolean;
+    status?: number;
+    json?: () => Promise<unknown>;
+  }>
+): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((url: string) => handler(url))
+  );
+}
+
+/* eslint-disable @typescript-eslint/naming-convention -- GitHub API response fixtures */
+describe("updateCheck", () => {
+  beforeEach(() => {
+    cancelUpdateCheck();
+    getBuildVersionInfo.mockReturnValue({
+      version: "0.2.5",
+      packageVersion: "0.2.5",
+      date: "2026-01-01",
+      hash: "abc",
+      gitHash: "def",
+    });
+  });
+
+  afterEach(() => {
+    cancelUpdateCheck();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("starts in pending state", () => {
+    expect(getUpdateCheckState().status).toBe("pending");
+    expect(getUpdateCheckState().currentVersion).toBe("0.2.5");
+  });
+
+  it("reports available when latest release is newer than current", async () => {
+    getBuildVersionInfo.mockReturnValue({
+      version: "0.2.3",
+      packageVersion: "0.2.3",
+      date: "2026-01-01",
+      hash: "abc",
+      gitHash: "def",
+    });
+    mockLatestRelease({
+      tag_name: "v0.2.4",
+      prerelease: false,
+      html_url: "https://github.com/inflaborg/ccrelay/releases/tag/v0.2.4",
+      body: "## What's Changed\n- Feature",
+    });
+
+    await runUpdateCheck();
+
+    const state = getUpdateCheckState();
+    expect(state.status).toBe("available");
+    expect(state.latestVersion).toBe("0.2.4");
+    expect(state.releaseUrl).toContain("v0.2.4");
+    expect(state.releaseNotes).toContain("What's Changed");
+    expect(state.checkedAt).toBeDefined();
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports idle when latest release is not newer (ignores main bump)", async () => {
+    mockLatestRelease({
+      tag_name: "v0.2.4",
+      prerelease: false,
+      html_url: "https://github.com/inflaborg/ccrelay/releases/tag/v0.2.4",
+      body: "",
+    });
+
+    await runUpdateCheck();
+    expect(getUpdateCheckState().status).toBe("idle");
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports idle when current is ahead of latest release", async () => {
+    getBuildVersionInfo.mockReturnValue({
+      version: "0.2.6",
+      packageVersion: "0.2.6",
+      date: "2026-01-01",
+      hash: "abc",
+      gitHash: "def",
+    });
+    mockLatestRelease({
+      tag_name: "v0.2.4",
+      prerelease: false,
+    });
+
+    await runUpdateCheck();
+    expect(getUpdateCheckState().status).toBe("idle");
+  });
+
+  it("reports idle when latest release endpoint returns 404", async () => {
+    mockFetch(() => Promise.resolve({ ok: false, status: 404 }));
+
+    await runUpdateCheck();
+    expect(getUpdateCheckState().status).toBe("idle");
+  });
+
+  it("reports idle when latest release is prerelease", async () => {
+    mockLatestRelease({
+      tag_name: "v0.2.6",
+      prerelease: true,
+    });
+
+    await runUpdateCheck();
+    expect(getUpdateCheckState().status).toBe("idle");
+  });
+
+  it("reports idle when fetch throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("network")))
+    );
+
+    await runUpdateCheck();
+    expect(getUpdateCheckState().status).toBe("idle");
+  });
+
+  it("scheduleUpdateCheck runs after 60s", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes("/releases/latest")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              tag_name: "v0.2.5",
+              prerelease: false,
+            }),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    scheduleUpdateCheck();
+    expect(getUpdateCheckState().status).toBe("pending");
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.waitFor(() => expect(getUpdateCheckState().status).toBe("idle"));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("requestUpdateCheck runs immediately and cancels scheduled timer", async () => {
+    vi.useFakeTimers();
+    mockLatestRelease({
+      tag_name: "v0.2.5",
+      prerelease: false,
+    });
+
+    scheduleUpdateCheck();
+    const state = await requestUpdateCheck();
+
+    expect(state.status).toBe("idle");
+    expect(state.checkedAt).toBeDefined();
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancelUpdateCheck clears scheduled timer", async () => {
+    vi.useFakeTimers();
+    mockLatestRelease({
+      tag_name: "v0.2.6",
+      prerelease: false,
+    });
+
+    scheduleUpdateCheck();
+    cancelUpdateCheck();
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(getUpdateCheckState().status).toBe("pending");
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it("scheduleUpdateCheck runs again after 24h interval", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes("/releases/latest")) {
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              tag_name: "v0.2.5",
+              prerelease: false,
+            }),
+        });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    scheduleUpdateCheck();
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("updates available state when a newer release is found on recheck", async () => {
+    getBuildVersionInfo.mockReturnValue({
+      version: "0.2.3",
+      packageVersion: "0.2.3",
+      date: "2026-01-01",
+      hash: "abc",
+      gitHash: "def",
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockImplementationOnce(() =>
+          Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                tag_name: "v0.2.4",
+                prerelease: false,
+                html_url: "https://github.com/inflaborg/ccrelay/releases/tag/v0.2.4",
+                body: "Notes for 0.2.4",
+              }),
+          })
+        )
+        .mockImplementationOnce(() =>
+          Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                tag_name: "v0.2.5",
+                prerelease: false,
+                html_url: "https://github.com/inflaborg/ccrelay/releases/tag/v0.2.5",
+                body: "Notes for 0.2.5",
+              }),
+          })
+        )
+    );
+
+    await runUpdateCheck();
+    expect(getUpdateCheckState().latestVersion).toBe("0.2.4");
+    expect(getUpdateCheckState().releaseNotes).toContain("0.2.4");
+
+    await runUpdateCheck();
+    const state = getUpdateCheckState();
+    expect(state.status).toBe("available");
+    expect(state.latestVersion).toBe("0.2.5");
+    expect(state.releaseNotes).toContain("0.2.5");
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
 import {
   Activity,
   Server,
@@ -10,6 +11,7 @@ import {
   Route,
 } from "lucide-react";
 import { api } from "./api/client";
+import { applyAppLocale, parseAppLocale } from "./i18n";
 import ClientConfig from "./features/client-config/ClientConfig";
 import Dashboard from "./features/dashboard/Dashboard";
 import Providers from "./features/providers/Providers";
@@ -73,31 +75,28 @@ function useHashTab(defaultTab: Tab): [Tab, (tab: Tab) => void] {
 function App() {
   const { t, i18n } = useTranslation();
   const [activeTab, setActiveTab] = useHashTab("clientConfig");
-  const [showLangModal, setShowLangModal] = useState(false);
-  const [loggingEnabled, setLoggingEnabled] = useState(true);
+  const [languagePromptDismissed, setLanguagePromptDismissed] = useState(false);
 
+  const { data: config } = useQuery({
+    queryKey: ["config"],
+    queryFn: () => api.getConfig(),
+  });
+
+  const loggingEnabled = config?.logging?.enabled ?? true;
+
+  const showLanguagePrompt =
+    config !== undefined &&
+    !languagePromptDismissed &&
+    !parseAppLocale(config.server?.locale) &&
+    !parseAppLocale(window.CCRELAY_LOCALE);
+
+  // Sync language when config changes (e.g. Settings save in Electron).
   useEffect(() => {
-    const vsLocale = window.CCRELAY_LOCALE;
-    if (vsLocale) {
-      void i18n.changeLanguage(vsLocale);
+    const locale = parseAppLocale(config?.server?.locale) ?? parseAppLocale(window.CCRELAY_LOCALE);
+    if (locale) {
+      void applyAppLocale(locale);
     }
-    api
-      .getConfig()
-      .then(cfg => {
-        if (!vsLocale) {
-          const locale = cfg.server?.locale as string | undefined;
-          if (locale) {
-            void i18n.changeLanguage(locale);
-          } else {
-            setShowLangModal(true);
-          }
-        }
-        setLoggingEnabled(cfg.logging?.enabled ?? false);
-      })
-      .catch(() => {
-        if (!vsLocale) setShowLangModal(true);
-      });
-  }, [i18n]);
+  }, [config?.server?.locale]);
 
   // Redirect away from logs tab if logging is disabled
   useEffect(() => {
@@ -106,8 +105,10 @@ function App() {
     }
   }, [loggingEnabled, activeTab, setActiveTab]);
 
+  const uiLanguageKey = i18n.resolvedLanguage ?? i18n.language;
+
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
+    <div key={uiLanguageKey} className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
       {/* Header - Tab Style */}
       <header className="bg-card flex-shrink-0 border-b border-border">
         <div className="max-w-full px-2 sm:px-4">
@@ -233,7 +234,12 @@ function App() {
         </div>
       </footer>
 
-      <LanguageModal open={showLangModal} onOpenChange={setShowLangModal} />
+      <LanguageModal
+        open={showLanguagePrompt}
+        onOpenChange={open => {
+          if (!open) setLanguagePromptDismissed(true);
+        }}
+      />
     </div>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ import Logs from "./features/logs/Logs";
 import Settings from "./features/settings/Settings";
 import Capabilities from "./features/capabilities/Capabilities";
 import { LanguageModal } from "./components/LanguageModal";
+import { VersionFooter } from "./components/VersionFooter";
 
 // CCRelay icon as data URI (works in VSCode webview)
 const iconSvg = `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Cdefs%3E%3ClinearGradient id='purpleGradient' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' style='stop-color:%239B59B6;stop-opacity:1' /%3E%3Cstop offset='100%25' style='stop-color:%238E44AD;stop-opacity:1' /%3E%3C/linearGradient%3E%3ClinearGradient id='grayGradient' x1='0%25' y1='0%25' x2='100%25' y2='100%25'%3E%3Cstop offset='0%25' style='stop-color:%2395A5A6;stop-opacity:1' /%3E%3Cstop offset='100%25' style='stop-color:%237F8C8D;stop-opacity:1' /%3E%3C/linearGradient%3E%3C/defs%3E%3Ccircle cx='64' cy='64' r='56' fill='%232C3E50' opacity='0.1'/%3E%3Cpath d='M 32 75 Q 32 45 50 45 L 64 45' stroke='url(%23purpleGradient)' stroke-width='10' stroke-linecap='round' fill='none'/%3E%3Cpath d='M 52 35 L 66 45 L 52 55' fill='url(%23purpleGradient)' stroke='url(%23purpleGradient)' stroke-width='3' stroke-linejoin='round'/%3E%3Cpath d='M 96 53 Q 96 83 78 83 L 64 83' stroke='url(%23grayGradient)' stroke-width='10' stroke-linecap='round' fill='none'/%3E%3Cpath d='M 76 93 L 62 83 L 76 73' fill='url(%23grayGradient)' stroke='url(%23grayGradient)' stroke-width='3' stroke-linejoin='round'/%3E%3Ccircle cx='64' cy='64' r='8' fill='url(%23purpleGradient)'/%3E%3Ccircle cx='64' cy='64' r='4' fill='%23FFFFFF'/%3E%3Cline x1='22' y1='64' x2='32' y2='64' stroke='%237F8C8D' stroke-width='4' stroke-linecap='round'/%3E%3Cline x1='96' y1='64' x2='106' y2='64' stroke='%237F8C8D' stroke-width='4' stroke-linecap='round'/%3E%3Ccircle cx='18' cy='64' r='4' fill='%2395A5A6'/%3E%3Ccircle cx='110' cy='64' r='4' fill='%2395A5A6'/%3E%3C/svg%3E`;
@@ -72,16 +73,8 @@ function useHashTab(defaultTab: Tab): [Tab, (tab: Tab) => void] {
 function App() {
   const { t, i18n } = useTranslation();
   const [activeTab, setActiveTab] = useHashTab("clientConfig");
-  const [version, setVersion] = useState<string | null>(null);
   const [showLangModal, setShowLangModal] = useState(false);
   const [loggingEnabled, setLoggingEnabled] = useState(true);
-
-  useEffect(() => {
-    api
-      .getVersion()
-      .then(v => setVersion(v.version))
-      .catch(() => {});
-  }, []);
 
   useEffect(() => {
     const vsLocale = window.CCRELAY_LOCALE;
@@ -236,7 +229,7 @@ function App() {
             </a>{" "}
             {t("app.footer.project")}
           </p>
-          {version && <span className="text-[11px] text-muted-foreground">{version}</span>}
+          <VersionFooter />
         </div>
       </footer>
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -7,6 +7,7 @@ import type {
   LogsQuery,
   LogStats,
   VersionResponse,
+  UpdateCheckResponse,
   AddProviderRequest,
   AddProviderResponse,
   DuplicateProviderRequest,
@@ -190,6 +191,20 @@ export const api = {
 
   // Version
   getVersion: (): Promise<VersionResponse> => fetchAPI<VersionResponse>("/version"),
+
+  getUpdateCheck: (): Promise<UpdateCheckResponse> =>
+    fetchAPI<UpdateCheckResponse>("/update-check"),
+
+  triggerUpdateCheck: async (): Promise<UpdateCheckResponse> => {
+    const response = await fetch(`${API_BASE}/update-check`, {
+      method: "POST",
+      headers: buildDefaultHeaders(false),
+    });
+    if (!response.ok) {
+      throw new Error(`Update check failed: ${response.status}`);
+    }
+    return (await response.json()) as UpdateCheckResponse;
+  },
 
   getClientConfig: (): Promise<ClientConfigGetResponse> =>
     fetchAPI<ClientConfigGetResponse>("/client-config"),

--- a/web/src/components/LanguageModal.tsx
+++ b/web/src/components/LanguageModal.tsx
@@ -1,5 +1,7 @@
 import { useTranslation } from "react-i18next";
+import { useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
+import { applyAppLocale } from "@/i18n";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "./ui/dialog";
 import { Button } from "./ui/button";
 
@@ -10,14 +12,16 @@ export function LanguageModal({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
 
   const handleSelect = async (locale: "en" | "zh") => {
-    await i18n.changeLanguage(locale);
+    await applyAppLocale(locale);
     try {
       await api.patchConfig({ section: "server", data: { locale } });
+      await queryClient.invalidateQueries({ queryKey: ["config"] });
     } catch {
-      // locale saved to i18n for this session; backend failure is non-fatal
+      // locale applied for this session; backend failure is non-fatal
     }
     onOpenChange(false);
   };

--- a/web/src/components/UpdateAvailableModal.tsx
+++ b/web/src/components/UpdateAvailableModal.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from "react-i18next";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "./ui/dialog";
+import { Button } from "./ui/button";
+import { MarkdownViewer } from "./ui/markdown-viewer";
+
+export function UpdateAvailableModal({
+  open,
+  onOpenChange,
+  currentVersion,
+  latestVersion,
+  releaseUrl,
+  releaseNotes,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentVersion: string;
+  latestVersion: string;
+  releaseUrl: string;
+  releaseNotes: string;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{t("update.modalTitle", { version: latestVersion })}</DialogTitle>
+          <DialogDescription>{t("update.current", { version: currentVersion })}</DialogDescription>
+        </DialogHeader>
+        <div className="max-h-[50vh] overflow-y-auto text-xs">
+          {releaseNotes.trim() ? (
+            <MarkdownViewer content={releaseNotes} />
+          ) : (
+            <p className="text-muted-foreground">{t("update.noNotes")}</p>
+          )}
+        </div>
+        <DialogFooter>
+          <Button
+            size="sm"
+            onClick={() => {
+              window.open(releaseUrl, "_blank", "noopener,noreferrer");
+            }}
+          >
+            {t("update.download")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/VersionFooter.tsx
+++ b/web/src/components/VersionFooter.tsx
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Loader2 } from "lucide-react";
+import { api } from "@/api/client";
+import type { UpdateCheckResponse, UpdateCheckStatus } from "@/types/api";
+import { UpdateAvailableModal } from "./UpdateAvailableModal";
+
+const POLL_INTERVAL_MS = 2000;
+
+function shouldStopPolling(status: UpdateCheckStatus): boolean {
+  return status === "idle" || status === "available";
+}
+
+function statusTitleKey(status: UpdateCheckStatus): string {
+  switch (status) {
+    case "pending":
+      return "update.checkNowHint";
+    case "idle":
+      return "update.recheckHint";
+    default:
+      return "";
+  }
+}
+
+export function VersionFooter() {
+  const { t } = useTranslation();
+  const [version, setVersion] = useState<string | null>(null);
+  const [updateCheck, setUpdateCheck] = useState<UpdateCheckResponse | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [manualChecking, setManualChecking] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  /** Last latestVersion we auto-opened the modal for (re-open when a newer release appears). */
+  const lastAutoShownVersionRef = useRef<string | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current !== null) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const startPolling = useCallback(() => {
+    stopPolling();
+    pollRef.current = setInterval(() => {
+      void api
+        .getUpdateCheck()
+        .then(state => {
+          setUpdateCheck(state);
+          if (shouldStopPolling(state.status)) {
+            stopPolling();
+          }
+        })
+        .catch(() => {
+          stopPolling();
+        });
+    }, POLL_INTERVAL_MS);
+  }, [stopPolling]);
+
+  useEffect(() => {
+    api
+      .getVersion()
+      .then(v => setVersion(v.version))
+      .catch(() => {});
+  }, []);
+
+  const pollUpdateCheck = useCallback(async () => {
+    try {
+      const state = await api.getUpdateCheck();
+      setUpdateCheck(state);
+      if (shouldStopPolling(state.status)) {
+        stopPolling();
+      }
+    } catch {
+      stopPolling();
+    }
+  }, [stopPolling]);
+
+  useEffect(() => {
+    void pollUpdateCheck();
+    startPolling();
+    return () => stopPolling();
+  }, [pollUpdateCheck, startPolling, stopPolling]);
+
+  useEffect(() => {
+    if (
+      updateCheck?.status !== "available" ||
+      !updateCheck.latestVersion ||
+      !updateCheck.releaseUrl
+    ) {
+      return;
+    }
+    if (lastAutoShownVersionRef.current === updateCheck.latestVersion) {
+      return;
+    }
+    lastAutoShownVersionRef.current = updateCheck.latestVersion;
+    setModalOpen(true);
+  }, [updateCheck]);
+
+  const handleRecheck = async () => {
+    if (manualChecking || updateCheck?.status === "checking") {
+      return;
+    }
+    setManualChecking(true);
+    startPolling();
+    try {
+      const state = await api.triggerUpdateCheck();
+      setUpdateCheck(state);
+      if (shouldStopPolling(state.status)) {
+        stopPolling();
+      }
+    } catch {
+      stopPolling();
+    } finally {
+      setManualChecking(false);
+    }
+  };
+
+  const displayVersion = version ?? updateCheck?.currentVersion ?? null;
+  const status: UpdateCheckStatus = updateCheck?.status ?? "pending";
+  const isChecking = manualChecking || status === "checking";
+  const isUpdateAvailable = status === "available";
+
+  const statusLabel = (() => {
+    if (isChecking) {
+      return t("update.checking");
+    }
+    switch (status) {
+      case "pending":
+        return t("update.pending");
+      case "idle":
+        return t("update.upToDate");
+      case "available":
+        return t("update.available");
+      default:
+        return t("update.pending");
+    }
+  })();
+
+  const titleKey = isChecking ? "" : statusTitleKey(status);
+  const statusButtonClass =
+    status === "available"
+      ? "text-primary hover:underline"
+      : "text-muted-foreground hover:text-foreground hover:underline";
+
+  const handleStatusClick = () => {
+    if (isChecking) {
+      return;
+    }
+    if (status === "available") {
+      setModalOpen(true);
+      return;
+    }
+    void handleRecheck();
+  };
+
+  return (
+    <>
+      <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+        {isChecking && <Loader2 className="h-3 w-3 animate-spin shrink-0" aria-hidden />}
+        {displayVersion && <span>{displayVersion}</span>}
+        <button
+          type="button"
+          className={`shrink-0 disabled:opacity-50 disabled:pointer-events-none ${statusButtonClass}`}
+          title={titleKey ? t(titleKey) : undefined}
+          disabled={isChecking}
+          onClick={handleStatusClick}
+        >
+          {statusLabel}
+        </button>
+      </div>
+      {isUpdateAvailable && updateCheck?.latestVersion && updateCheck.releaseUrl && (
+        <UpdateAvailableModal
+          key={updateCheck.latestVersion}
+          open={modalOpen}
+          onOpenChange={setModalOpen}
+          currentVersion={updateCheck.currentVersion}
+          latestVersion={updateCheck.latestVersion}
+          releaseUrl={updateCheck.releaseUrl}
+          releaseNotes={updateCheck.releaseNotes ?? ""}
+        />
+      )}
+    </>
+  );
+}

--- a/web/src/features/settings/Settings.tsx
+++ b/web/src/features/settings/Settings.tsx
@@ -29,9 +29,11 @@ import {
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import { api } from "@/api/client";
+import { applyAppLocale } from "@/i18n";
 import type {
   LoggingSettings,
   ConcurrencySettings,
+  PatchConfigResponse,
   ServerSettings,
   RoutingSettings,
   RoutingBlockRule,
@@ -139,13 +141,18 @@ function cloneRouting(routing: RoutingSettings): RoutingSettings {
 function SaveBar({
   mutation,
   onSave,
-  restartRequired,
 }: {
-  mutation: { isPending: boolean; isError: boolean; error: unknown; isSuccess: boolean };
+  mutation: {
+    isPending: boolean;
+    isError: boolean;
+    error: unknown;
+    isSuccess: boolean;
+    data?: PatchConfigResponse;
+  };
   onSave: () => void;
-  restartRequired?: boolean;
 }) {
   const { t } = useTranslation();
+  const restartRequired = Boolean(mutation.isSuccess && mutation.data?.restartRequired);
   return (
     <div className="space-y-2 pt-2">
       <div className="flex items-center justify-end gap-2">
@@ -231,33 +238,104 @@ function RoutingSaveBar({
 
 // ─── section wrapper (always expanded) ─────────────────────────────────────
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: React.ReactNode;
+}) {
   return (
     <Card className="p-0">
       <CardHeader className="p-3 pb-2">
         <CardTitle className="text-xs font-medium">{title}</CardTitle>
+        {description ? (
+          <p className="text-[10px] text-muted-foreground font-normal leading-snug">
+            {description}
+          </p>
+        ) : null}
       </CardHeader>
       <CardContent className="p-3 pt-0 space-y-3">{children}</CardContent>
     </Card>
   );
 }
 
+// ─── Language (auto-save) ───────────────────────────────────────────────────
+
+function LanguageSettingsSection({ locale }: { locale?: string }) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const [value, setValue] = useState(locale ?? "");
+
+  const localeMutation = useMutation({
+    mutationFn: (nextLocale: string | undefined) =>
+      api.patchConfig({ section: "server", data: { locale: nextLocale } }),
+    onSuccess: async (_res, nextLocale) => {
+      await applyAppLocale(nextLocale);
+      await queryClient.invalidateQueries({ queryKey: ["config"] });
+    },
+  });
+
+  const handleLocaleChange = (locale: string) => {
+    const nextLocale = locale || undefined;
+    setValue(locale);
+    void applyAppLocale(nextLocale);
+    localeMutation.mutate(nextLocale);
+  };
+
+  return (
+    <Section title={t("language.title")} description={t("settings.server.languageAutoSave")}>
+      <div className="flex items-center gap-2">
+        <SelectField
+          value={value}
+          options={[
+            { value: "", label: t("common.na") },
+            { value: "en", label: t("language.en") },
+            { value: "zh", label: t("language.zh") },
+          ]}
+          onChange={handleLocaleChange}
+          className="h-8 flex-1 text-xs"
+          disabled={localeMutation.isPending}
+        />
+        {localeMutation.isPending ? (
+          <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+        ) : localeMutation.isSuccess ? (
+          <span className="shrink-0 text-[10px] text-green-600 dark:text-green-500">
+            {t("settings.saved")}
+          </span>
+        ) : null}
+      </div>
+      {localeMutation.isError ? (
+        <p className="text-[10px] text-destructive">{(localeMutation.error as Error).message}</p>
+      ) : null}
+    </Section>
+  );
+}
+
 // ─── Server section ─────────────────────────────────────────────────────────
 
 function ServerSection({ data }: { data: ServerSettings }) {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const queryClient = useQueryClient();
-  const [form, setForm] = useState(data);
+  const [form, setForm] = useState({
+    port: data.port,
+    host: data.host,
+    autoStart: data.autoStart,
+  });
 
-  const mutation = useMutation({
+  const serverMutation = useMutation({
     mutationFn: (d: Record<string, unknown>) => api.patchConfig({ section: "server", data: d }),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["config"] }),
   });
 
-  const handleLocaleChange = (locale: string) => {
-    setForm(f => ({ ...f, locale }));
-    void i18n.changeLanguage(locale);
-    mutation.mutate({ ...form, locale });
+  const saveServerSettings = () => {
+    serverMutation.mutate({
+      port: form.port,
+      host: form.host,
+      autoStart: form.autoStart,
+    });
   };
 
   return (
@@ -284,23 +362,7 @@ function ServerSection({ data }: { data: ServerSettings }) {
         onChange={v => setForm(f => ({ ...f, autoStart: v }))}
         label={t("settings.server.autoStart")}
       />
-      <Field label={t("settings.server.language")}>
-        <SelectField
-          value={form.locale || ""}
-          options={[
-            { value: "", label: t("common.na") },
-            { value: "en", label: t("language.en") },
-            { value: "zh", label: t("language.zh") },
-          ]}
-          onChange={handleLocaleChange}
-          className="h-8 text-xs"
-        />
-      </Field>
-      <SaveBar
-        mutation={mutation}
-        onSave={() => mutation.mutate(form as unknown as Record<string, unknown>)}
-        restartRequired
-      />
+      <SaveBar mutation={serverMutation} onSave={saveServerSettings} />
     </Section>
   );
 }
@@ -1209,7 +1271,7 @@ function LoggingSection({ data }: { data: LoggingSettings }) {
           </div>
         </div>
       )}
-      <SaveBar mutation={mutation} onSave={() => mutation.mutate(form)} restartRequired />
+      <SaveBar mutation={mutation} onSave={() => mutation.mutate(form)} />
     </Section>
   );
 }
@@ -1251,7 +1313,18 @@ export default function Settings() {
         </Card>
       ) : data ? (
         <>
-          <ServerSection key={JSON.stringify(data.server)} data={data.server} />
+          <LanguageSettingsSection
+            key={`locale:${data.server?.locale ?? ""}`}
+            locale={data.server?.locale}
+          />
+          <ServerSection
+            key={JSON.stringify({
+              port: data.server?.port,
+              host: data.server?.host,
+              autoStart: data.server?.autoStart,
+            })}
+            data={data.server}
+          />
           <RoutingSection
             key={JSON.stringify(data.routing)}
             routing={{

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -610,7 +610,8 @@
       "port": "Port",
       "host": "Host",
       "autoStart": "Auto-start server on extension activation",
-      "language": "Language"
+      "language": "Language",
+      "languageAutoSave": "Applies immediately when changed."
     },
     "routing": {
       "title": "Routing",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -29,6 +29,18 @@
       "project": "Project CCRelay"
     }
   },
+  "update": {
+    "pending": "Check scheduled",
+    "checkNowHint": "Click to check now",
+    "upToDate": "Up to date",
+    "recheckHint": "Click to check again",
+    "checking": "Checking…",
+    "available": "Update available",
+    "modalTitle": "New version {{version}}",
+    "download": "View release on GitHub",
+    "current": "Current version: {{version}}",
+    "noNotes": "No release notes provided."
+  },
   "language": {
     "title": "Choose Language",
     "description": "Select your preferred language for the interface.",

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -3,16 +3,34 @@ import { initReactI18next } from "react-i18next";
 import en from "./en.json";
 import zh from "./zh.json";
 
-const locale = window.CCRELAY_LOCALE || undefined;
+export type AppLocale = "en" | "zh";
+
+const initialLocale = window.CCRELAY_LOCALE || undefined;
+
+export function parseAppLocale(locale: unknown): AppLocale | undefined {
+  return locale === "en" || locale === "zh" ? locale : undefined;
+}
+
+/** Apply UI language immediately and keep Electron/VS Code inject in sync. */
+export async function applyAppLocale(locale: unknown): Promise<void> {
+  const lng = parseAppLocale(locale);
+  if (!lng) return;
+  window.CCRELAY_LOCALE = lng;
+  await i18n.changeLanguage(lng);
+}
 
 i18n.use(initReactI18next).init({
   resources: {
     en: { translation: en },
     zh: { translation: zh },
   },
-  lng: locale || "en",
+  lng: parseAppLocale(initialLocale) || "en",
   fallbackLng: "en",
   interpolation: { escapeValue: false },
+  react: {
+    useSuspense: false,
+    bindI18n: "languageChanged loaded",
+  },
 });
 
 export default i18n;

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -610,7 +610,8 @@
       "port": "端口",
       "host": "主机",
       "autoStart": "扩展激活时自动启动服务器",
-      "language": "语言"
+      "language": "语言",
+      "languageAutoSave": "切换后立即生效，无需点击保存。"
     },
     "routing": {
       "title": "路由",

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -29,6 +29,18 @@
       "project": "CCRelay 项目组"
     }
   },
+  "update": {
+    "pending": "等待检查",
+    "checkNowHint": "点击立即检查",
+    "upToDate": "已是最新",
+    "recheckHint": "点击重新检查",
+    "checking": "检查中…",
+    "available": "有新版本",
+    "modalTitle": "新版本 {{version}}",
+    "download": "在 GitHub 查看发布",
+    "current": "当前版本：{{version}}",
+    "noNotes": "暂无发布说明。"
+  },
   "language": {
     "title": "选择语言",
     "description": "请选择界面语言。",

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -263,6 +263,17 @@ export interface VersionResponse {
   };
 }
 
+export type UpdateCheckStatus = "pending" | "checking" | "idle" | "available";
+
+export interface UpdateCheckResponse {
+  status: UpdateCheckStatus;
+  currentVersion: string;
+  latestVersion?: string;
+  releaseUrl?: string;
+  releaseNotes?: string;
+  checkedAt?: string;
+}
+
 export type ClientConfigItemStatus = "ok" | "missing" | "wrong_target" | "invalid";
 
 export interface ClientConfigField {


### PR DESCRIPTION
## Summary

- **Release update check**: Footer compares the running build to the latest formal GitHub Release (60s after proxy start + every 24h). Auto-opens a modal with release notes; GitHub links open in the system browser on desktop/Tauri.
- **Dashboard**: Hide provider breakdown rows where input, output, and cache tokens are all zero.
- **Language settings**: Split into its own card with immediate auto-save; server port/host/auto-start stay in a separate card with Save. UI refreshes without restart when only locale changes; Electron syncs locale via config query and updated dashboard inject.
- **Fixes**: Align `split_metrics` migration test INSERT placeholders with 21 columns; finalize CHANGELOG for 0.2.5.

## Test plan

- [ ] Start proxy; confirm footer update check runs and “up to date” / new-version modal behaves as expected
- [ ] On Electron desktop, change language in Settings → UI switches immediately without restart; server Save still shows restart hint only when port/host/auto-start change
- [ ] Dashboard provider breakdown omits rows with zero input/output/cache tokens
- [ ] `npm run test` and `npm run lint` pass locally


Made with [Cursor](https://cursor.com)