### PR TITLE
Add Tuning Engines provider

### DIFF
--- a/web/src/features/providers/wizard/presets.ts
+++ b/web/src/features/providers/wizard/presets.ts
@@ -9,6 +9,8 @@ const VENDOR_DISPLAY: Record<string, string> = {
   gemini: "Gemini",
   deepseek: "DeepSeek",
   claude: "Claude",
+  llama: "Llama",
+  qwen: "Qwen",
 };
 
 /**
@@ -126,6 +128,27 @@ export const GENERIC_ENDPOINT_PRESETS: readonly PartnerPreset[] = [
 ];
 
 export const PARTNER_PRESETS: readonly PartnerPreset[] = [
+  {
+    id: "tuning-engines",
+    nameKey: "wizard.brand.tuningEngines",
+    mode: "inject",
+    idPrefix: "tuning-engines",
+    namePrefix: "Tuning-Engines",
+    defaultModelIds: ["llama-3.3-70b-fp8", "qwen-2.5-coder-32b"],
+    defaultCustomModels: true,
+    authHeader: "authorization",
+    fixedBaseUrl: "https://api.tuningengines.com/v1",
+    options: [],
+    segmentRules: [],
+    variants: [
+      {
+        providerType: "openai_chat",
+        urlTemplate: "{fixedBaseUrl}",
+        idSuffix: "openai",
+        nameSuffix: "",
+      },
+    ],
+  },
   {
     id: "glm",
     nameKey: "wizard.brand.glm",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -270,6 +270,7 @@
     "brand": {
       "genericOpenaiChat": "OpenAI Chat",
       "genericAnthropic": "Anthropic",
+      "tuningEngines": "Tuning Engines",
       "glm": "Zhipu GLM",
       "xiaomi": "Xiaomi MiMo",
       "azure": "Azure OpenAI",


### PR DESCRIPTION
Adds Tuning Engines as an OpenAI-compatible provider option.

This includes the Tuning Engines API base URL, key placeholder, and starter model IDs where this project exposes provider presets, examples, or configuration docs.

Validation:
- git diff --check
