### PR TITLE
fix: reasoning-to-tool streaming and log SSE analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+**UI**
+
+- Request log **Response → Analysis** now reconstructs OpenAI Chat Completions streaming bodies (including `reasoning_content` and streamed tool calls) and OpenAI Responses API streaming bodies, so MiMo and cross-protocol Responses streams show a readable merged JSON instead of a blank panel.
+
+**Protocol/Conversion**
+
+- Cross-protocol Chat-to-Responses streaming no longer opens an empty assistant message item when the model goes from reasoning straight to tool calls; function calls keep the correct output index and clients parse the stream reliably.
+
 ## [0.2.5] - 2026-05-28
 
 Smart Routing aggregates provider models with unified `/v1/models` routing. The dashboard adds an offline gate, client configuration, a metrics split so statistics survive log clears, and release update checks against GitHub. Desktop can open the bundled UI without a running proxy; multi-instance leader election follows the active proxy port.

--- a/packages/core/src/converter/streaming/openai-chat-stream-to-responses.ts
+++ b/packages/core/src/converter/streaming/openai-chat-stream-to-responses.ts
@@ -176,24 +176,19 @@ export function processStreamingChunk(state: StreamingConversionState, line: str
 
   // Tool call deltas
   if (Array.isArray(delta.tool_calls) && delta.tool_calls.length > 0) {
-    // Tool-only prelude: emit response/message shell so function_call sits at correct output indices.
     if (state.phase === "initial") {
       events.push(...emitResponseCreated(state));
       state.phase = "created";
-    }
-    if (state.phase === "created") {
-      state.phase = "text";
-      events.push(...emitOutputItemAdded(state, "message"));
-      events.push(...emitContentPartAdded(state, state.messageId, "output_text"));
     }
     // MiMo et al.: reasoning_content deltas then tool_calls with no intervening assistant text
     if (state.phase === "reasoning") {
       events.push(...emitReasoningTextDone(state));
       events.push(...emitReasoningItemDone(state));
       state.outputIndex++;
-      state.phase = "text";
-      events.push(...emitOutputItemAdded(state, "message"));
-      events.push(...emitContentPartAdded(state, state.messageId, "output_text"));
+    }
+    // created/reasoning → tool directly; only open message when delta.content arrives
+    if (state.phase === "created" || state.phase === "reasoning") {
+      state.phase = "tool";
     }
 
     for (const tc of delta.tool_calls as Record<string, unknown>[]) {

--- a/tests/unit/converter/streaming/openai-chat-stream-to-responses.test.ts
+++ b/tests/unit/converter/streaming/openai-chat-stream-to-responses.test.ts
@@ -234,8 +234,120 @@ describe("processStreamingChunk", () => {
     expect(idxReasoningTextDone).toBeGreaterThanOrEqual(0);
     expect(idxReasoningItemDone).toBeGreaterThan(idxReasoningTextDone);
     expect(idxFnItemAdded).toBeGreaterThan(idxReasoningItemDone);
-    expect(types).toContain("response.content_part.added");
+    expect(types).not.toContain("response.content_part.added");
+    const messageItemAdded = events.filter(
+      (e: string) =>
+        e.includes('"type":"response.output_item.added"') &&
+        e.includes('"type":"message"') &&
+        !e.includes('"type":"reasoning"')
+    );
+    expect(messageItemAdded).toHaveLength(0);
     expect(state.phase).toBe("tool");
+  });
+
+  it("MiMo log regression: role → reasoning → tool_calls(fields) → finish → usage → [DONE]", () => {
+    const state = createStreamingState();
+    const allEvents: string[] = [];
+
+    allEvents.push(
+      ...processStreamingChunk(
+        state,
+        chunk({
+          role: "assistant",
+          content: "",
+          reasoning_content: null,
+        })
+      )
+    );
+    expect(state.phase).toBe("created");
+
+    for (const piece of ["用户询问", "的是", '"10k']) {
+      allEvents.push(
+        ...processStreamingChunk(state, chunk({ content: null, reasoning_content: piece }))
+      );
+    }
+    expect(state.phase).toBe("reasoning");
+
+    allEvents.push(
+      ...processStreamingChunk(
+        state,
+        chunk({
+          tool_calls: [
+            {
+              index: 0,
+              id: "call_ad44e7079f6946deac787adb",
+              type: "function",
+              function: { name: "fields", arguments: "" },
+            },
+          ],
+        })
+      )
+    );
+    allEvents.push(
+      ...processStreamingChunk(
+        state,
+        chunk({
+          tool_calls: [
+            {
+              index: 0,
+              function: { arguments: "{}" },
+            },
+          ],
+        })
+      )
+    );
+
+    allEvents.push(...processStreamingChunk(state, chunk({}, "tool_calls")));
+
+    const usageOnly = JSON.stringify({
+      id: "2825b425dc434407addf27684a090fc9",
+      object: "chat.completion.chunk",
+      created: 1780150873,
+      model: "mimo-v2.5-pro",
+      choices: [],
+      usage: {
+        prompt_tokens: 3350,
+        completion_tokens: 168,
+        total_tokens: 3518,
+        completion_tokens_details: { reasoning_tokens: 154 },
+      },
+    });
+    allEvents.push(...processStreamingChunk(state, usageOnly));
+    allEvents.push(...processStreamingChunk(state, "[DONE]"));
+
+    const joined = allEvents.join("");
+    expect(joined).not.toContain('"type":"message"');
+    expect(joined).not.toContain("response.content_part.added");
+
+    const outputIndices: number[] = [];
+    for (const e of allEvents) {
+      const m = e.match(/"output_index":(\d+)/);
+      if (m) {
+        outputIndices.push(Number(m[1]));
+      }
+    }
+    expect(outputIndices.filter((i: number) => i === 1).length).toBeGreaterThan(0);
+    expect(outputIndices.filter((i: number) => i === 0).length).toBeGreaterThan(0);
+
+    const completedEvent = allEvents.find((e: string) => e.includes("response.completed"));
+    expect(completedEvent).toBeDefined();
+    const dataLine =
+      completedEvent!
+        .split("\n")
+        .find((l: string) => l.startsWith("data:"))
+        ?.slice("data:".length)
+        .trim() ?? "{}";
+    const parsed = JSON.parse(dataLine) as {
+      response?: { output?: Array<Record<string, unknown>> };
+    };
+    const output = parsed.response?.output ?? [];
+    expect(output).toHaveLength(2);
+    expect(output[0]?.type).toBe("reasoning");
+    expect(output[1]?.type).toBe("function_call");
+    expect(output[1]?.name).toBe("fields");
+    expect(output[1]?.arguments).toBe("{}");
+    expect(state.accumulatedReasoning).toContain("用户询问");
+    expect(state.phase).toBe("done");
   });
 
   it("handles tool call streaming", () => {

--- a/tests/unit/web/reconstructOpenAIChatSseMessage.test.ts
+++ b/tests/unit/web/reconstructOpenAIChatSseMessage.test.ts
@@ -1,0 +1,139 @@
+/* eslint-disable @typescript-eslint/naming-convention -- OpenAI Chat Completions wire field names */
+import { describe, expect, it } from "vitest";
+import {
+  isOpenAIChatCompletionSseBody,
+  reconstructOpenAIChatFromSseLogBody,
+} from "../../../web/src/features/logs/reconstructOpenAIChatSseMessage";
+
+function chunk(delta: Record<string, unknown>, finishReason?: string | null): string {
+  return `data: ${JSON.stringify({
+    id: "chatcmpl-mimo",
+    object: "chat.completion.chunk",
+    created: 1780150868,
+    model: "mimo-v2.5-pro",
+    choices: [{ index: 0, delta, finish_reason: finishReason ?? null }],
+  })}`;
+}
+
+describe("reconstructOpenAIChatFromSseLogBody", () => {
+  it("returns not_openai_chat_sse for Anthropic SSE", () => {
+    const sse =
+      'data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"m","content":[]}}';
+    expect(isOpenAIChatCompletionSseBody(sse)).toBe(false);
+    const r = reconstructOpenAIChatFromSseLogBody(sse);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe("not_openai_chat_sse");
+    }
+  });
+
+  it("MiMo regression: reasoning then tool_calls(fields) with usage", () => {
+    const lines = [
+      chunk({
+        role: "assistant",
+        content: "",
+        tool_calls: null,
+        reasoning_content: null,
+      }),
+      chunk({ content: null, reasoning_content: "用户询问" }),
+      chunk({ content: null, reasoning_content: "的是" }),
+      chunk({ content: null, reasoning_content: '"10k' }),
+      chunk({
+        tool_calls: [
+          {
+            index: 0,
+            id: "call_ad44e7079f6946deac787adb",
+            type: "function",
+            function: { name: "fields", arguments: "" },
+          },
+        ],
+        reasoning_content: null,
+      }),
+      chunk({
+        tool_calls: [
+          {
+            index: 0,
+            id: null,
+            function: { arguments: "{}", name: null },
+            type: "function",
+          },
+        ],
+        reasoning_content: null,
+      }),
+      chunk({ content: null, tool_calls: null, reasoning_content: null }, "tool_calls"),
+      `data: ${JSON.stringify({
+        id: "chatcmpl-mimo",
+        object: "chat.completion.chunk",
+        created: 1780150873,
+        model: "mimo-v2.5-pro",
+        choices: [],
+        usage: {
+          prompt_tokens: 3350,
+          completion_tokens: 168,
+          total_tokens: 3518,
+          completion_tokens_details: { reasoning_tokens: 154 },
+        },
+      })}`,
+      "data: [DONE]",
+    ];
+
+    const r = reconstructOpenAIChatFromSseLogBody(lines.join("\n\n"));
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      return;
+    }
+    expect(r.message.object).toBe("chat.completion");
+    expect(r.message.model).toBe("mimo-v2.5-pro");
+    const choices = r.message.choices as Record<string, unknown>[];
+    expect(choices).toHaveLength(1);
+    expect(choices[0].finish_reason).toBe("tool_calls");
+    const msg = choices[0].message as Record<string, unknown>;
+    expect(msg.role).toBe("assistant");
+    expect(msg.content).toBeNull();
+    expect(msg.reasoning_content).toBe('用户询问的是"10k');
+    const toolCalls = msg.tool_calls as Record<string, unknown>[];
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0].id).toBe("call_ad44e7079f6946deac787adb");
+    const fn = toolCalls[0].function as Record<string, unknown>;
+    expect(fn.name).toBe("fields");
+    expect(fn.arguments).toBe("{}");
+    const usage = r.message.usage as Record<string, unknown>;
+    expect(usage.prompt_tokens).toBe(3350);
+    expect(usage.completion_tokens).toBe(168);
+  });
+
+  it("merges assistant text and tool_calls after content", () => {
+    const sse = [
+      chunk({ role: "assistant", content: "" }),
+      chunk({ content: "Let me search." }),
+      chunk({
+        tool_calls: [
+          {
+            index: 0,
+            id: "call_abc",
+            type: "function",
+            function: { name: "web_search", arguments: "" },
+          },
+        ],
+      }),
+      chunk({
+        tool_calls: [{ index: 0, function: { arguments: '{"q":"x"}' } }],
+      }),
+      chunk({}, "tool_calls"),
+    ].join("\n\n");
+
+    const r = reconstructOpenAIChatFromSseLogBody(sse);
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      return;
+    }
+    const msg = (r.message.choices as Record<string, unknown>[])[0].message as Record<
+      string,
+      unknown
+    >;
+    expect(msg.content).toBe("Let me search.");
+    const fn = (msg.tool_calls as Record<string, unknown>[])[0].function as Record<string, unknown>;
+    expect(fn.name).toBe("web_search");
+    expect(fn.arguments).toBe('{"q":"x"}');
+  });
+});

--- a/tests/unit/web/reconstructOpenAIResponsesSseMessage.test.ts
+++ b/tests/unit/web/reconstructOpenAIResponsesSseMessage.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  isOpenAIResponsesSseBody,
+  reconstructOpenAIResponsesFromSseLogBody,
+} from "../../../web/src/features/logs/reconstructOpenAIResponsesSseMessage";
+
+describe("reconstructOpenAIResponsesFromSseLogBody", () => {
+  it("returns not_openai_responses_sse for Chat Completions chunks", () => {
+    const sse = 'data: {"object":"chat.completion.chunk","choices":[{"delta":{"content":"hi"}}]}';
+    expect(isOpenAIResponsesSseBody(sse)).toBe(false);
+    const r = reconstructOpenAIResponsesFromSseLogBody(sse);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe("not_openai_responses_sse");
+    }
+  });
+
+  it("extracts response from response.completed", () => {
+    const sse = [
+      "event: response.created",
+      'data: {"type":"response.created","response":{"id":"resp_1","object":"response","status":"in_progress","output":[]}}',
+      "event: response.completed",
+      'data: {"type":"response.completed","response":{"id":"resp_1","object":"response","status":"completed","output":[{"type":"reasoning","id":"rs_1","content":[{"type":"reasoning_text","text":"think"}]},{"type":"message","id":"msg_1","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}',
+      "data: [DONE]",
+    ].join("\n\n");
+
+    const r = reconstructOpenAIResponsesFromSseLogBody(sse);
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      return;
+    }
+    expect(r.message.id).toBe("resp_1");
+    expect(r.message.status).toBe("completed");
+    const output = r.message.output as Record<string, unknown>[];
+    expect(output).toHaveLength(2);
+    expect(output[0].type).toBe("reasoning");
+    expect(output[1].type).toBe("message");
+    const usage = r.message.usage as Record<string, unknown>;
+    expect(usage.total_tokens).toBe(3);
+  });
+
+  it("falls back to output_item.done when response.completed is missing", () => {
+    const sse = [
+      "event: response.created",
+      'data: {"type":"response.created","response":{"id":"resp_2","object":"response","model":"gpt","status":"in_progress","output":[]}}',
+      'data: {"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"rs_2","status":"completed","content":[{"type":"reasoning_text","text":"why"}]}}',
+      'data: {"type":"response.output_item.done","output_index":1,"item":{"type":"message","id":"msg_2","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok"}]}}',
+    ].join("\n\n");
+
+    const r = reconstructOpenAIResponsesFromSseLogBody(sse);
+    expect(r.ok).toBe(true);
+    if (!r.ok) {
+      return;
+    }
+    expect(r.message.id).toBe("resp_2");
+    const output = r.message.output as Record<string, unknown>[];
+    expect(output).toHaveLength(2);
+    expect((output[1].content as Record<string, unknown>[])[0].text).toBe("ok");
+  });
+});

--- a/web/src/features/logs/Logs.tsx
+++ b/web/src/features/logs/Logs.tsx
@@ -33,6 +33,8 @@ import { InfiniteTable, type InfiniteTableColumn } from "@/components/ui/infinit
 import { MarkdownViewer } from "@/components/ui/markdown-viewer";
 import { api, type LogEntry } from "@/api/client";
 import { isSseLogBody, reconstructMessageFromSseLogBody } from "./reconstructAnthropicSseMessage";
+import { reconstructOpenAIChatFromSseLogBody } from "./reconstructOpenAIChatSseMessage";
+import { reconstructOpenAIResponsesFromSseLogBody } from "./reconstructOpenAIResponsesSseMessage";
 
 const PAGE_SIZE = 50;
 
@@ -418,6 +420,14 @@ export default function Logs() {
     const reconstructed = reconstructMessageFromSseLogBody(raw);
     if (reconstructed.ok) {
       return JSON.stringify(reconstructed.message, null, 2);
+    }
+    const openaiResponses = reconstructOpenAIResponsesFromSseLogBody(raw);
+    if (openaiResponses.ok) {
+      return JSON.stringify(openaiResponses.message, null, 2);
+    }
+    const openaiChat = reconstructOpenAIChatFromSseLogBody(raw);
+    if (openaiChat.ok) {
+      return JSON.stringify(openaiChat.message, null, 2);
     }
     if (!isSseLogBody(trimmed)) {
       try {

--- a/web/src/features/logs/reconstructOpenAIChatSseMessage.ts
+++ b/web/src/features/logs/reconstructOpenAIChatSseMessage.ts
@@ -1,0 +1,197 @@
+/**
+ * Reconstruct a merged OpenAI Chat Completions `chat.completion` object from an SSE log body
+ * (`data:` lines with `object: "chat.completion.chunk"`). Supports `reasoning_content` (MiMo/DeepSeek)
+ * and streamed `tool_calls` deltas.
+ */
+
+export type ReconstructOpenAIChatResult =
+  | { ok: true; message: Record<string, unknown> }
+  | { ok: false; reason: string };
+
+interface ToolCallAccum {
+  id?: string;
+  type: string;
+  function: { name: string; arguments: string };
+}
+
+function parseDataPayload(line: string): string | null {
+  const t = line.trim();
+  if (!t.startsWith("data:")) {
+    return null;
+  }
+  const rest = t.slice(5).trimStart();
+  if (!rest || rest === "[DONE]") {
+    return null;
+  }
+  return rest;
+}
+
+/** True when the body contains Chat Completions stream chunks. */
+export function isOpenAIChatCompletionSseBody(body: string): boolean {
+  const trimmed = body.trim();
+  if (!trimmed) {
+    return false;
+  }
+  for (const line of trimmed.split("\n")) {
+    const dataStr = parseDataPayload(line);
+    if (!dataStr) {
+      continue;
+    }
+    try {
+      const data = JSON.parse(dataStr) as Record<string, unknown>;
+      if (data.object === "chat.completion.chunk") {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
+export function reconstructOpenAIChatFromSseLogBody(body: string): ReconstructOpenAIChatResult {
+  const trimmed = body.trim();
+  if (!trimmed) {
+    return { ok: false, reason: "empty" };
+  }
+  if (!isOpenAIChatCompletionSseBody(trimmed)) {
+    return { ok: false, reason: "not_openai_chat_sse" };
+  }
+
+  let id: string | undefined;
+  let created: number | undefined;
+  let model: string | undefined;
+  let role = "assistant";
+  let contentBuf = "";
+  let reasoningBuf = "";
+  let finishReason: string | null = null;
+  let usage: Record<string, unknown> | undefined;
+  const toolCallsByIndex = new Map<number, ToolCallAccum>();
+
+  for (const line of trimmed.split("\n")) {
+    const dataStr = parseDataPayload(line);
+    if (!dataStr) {
+      continue;
+    }
+
+    let data: Record<string, unknown>;
+    try {
+      data = JSON.parse(dataStr) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    if (typeof data.id === "string") {
+      id = data.id;
+    }
+    if (typeof data.created === "number") {
+      created = data.created;
+    }
+    if (typeof data.model === "string" && data.model) {
+      model = data.model;
+    }
+    if (data.usage && typeof data.usage === "object") {
+      usage = { ...(data.usage as Record<string, unknown>) };
+    }
+
+    const choices = data.choices;
+    if (!Array.isArray(choices) || choices.length === 0) {
+      continue;
+    }
+
+    const choice = choices[0] as Record<string, unknown>;
+    if (choice.finish_reason !== undefined && choice.finish_reason !== null) {
+      finishReason = String(choice.finish_reason);
+    }
+
+    const delta = choice.delta as Record<string, unknown> | undefined;
+    if (!delta) {
+      continue;
+    }
+
+    if (typeof delta.role === "string" && delta.role) {
+      role = delta.role;
+    }
+
+    if (typeof delta.content === "string") {
+      contentBuf += delta.content;
+    }
+
+    if (typeof delta.reasoning_content === "string") {
+      reasoningBuf += delta.reasoning_content;
+    }
+
+    const toolCalls = delta.tool_calls;
+    if (Array.isArray(toolCalls)) {
+      for (const tc of toolCalls) {
+        if (!tc || typeof tc !== "object") {
+          continue;
+        }
+        const tco = tc as Record<string, unknown>;
+        const tcIndex = typeof tco.index === "number" ? tco.index : 0;
+        let acc = toolCallsByIndex.get(tcIndex);
+        if (!acc) {
+          acc = { type: "function", function: { name: "", arguments: "" } };
+          toolCallsByIndex.set(tcIndex, acc);
+        }
+        if (typeof tco.id === "string" && tco.id) {
+          acc.id = tco.id;
+        }
+        if (typeof tco.type === "string" && tco.type) {
+          acc.type = tco.type;
+        }
+        const fn = tco.function as Record<string, unknown> | undefined;
+        if (fn) {
+          if (typeof fn.name === "string" && fn.name) {
+            acc.function.name = fn.name;
+          }
+          if (typeof fn.arguments === "string" && fn.arguments) {
+            acc.function.arguments += fn.arguments;
+          }
+        }
+      }
+    }
+  }
+
+  const message: Record<string, unknown> = {
+    role,
+    content: contentBuf.length > 0 ? contentBuf : null,
+  };
+  if (reasoningBuf.length > 0) {
+    message.reasoning_content = reasoningBuf;
+  }
+
+  const toolIndices = [...toolCallsByIndex.keys()].sort((a, b) => a - b);
+  if (toolIndices.length > 0) {
+    message.tool_calls = toolIndices.map(i => {
+      const t = toolCallsByIndex.get(i)!;
+      const out: Record<string, unknown> = {
+        type: t.type,
+        function: { name: t.function.name, arguments: t.function.arguments },
+      };
+      if (t.id) {
+        out.id = t.id;
+      }
+      return out;
+    });
+  }
+
+  const completion: Record<string, unknown> = {
+    id: id ?? "",
+    object: "chat.completion",
+    created: created ?? 0,
+    model: model ?? "",
+    choices: [
+      {
+        index: 0,
+        message,
+        finish_reason: finishReason,
+      },
+    ],
+  };
+  if (usage) {
+    completion.usage = usage;
+  }
+
+  return { ok: true, message: completion };
+}

--- a/web/src/features/logs/reconstructOpenAIResponsesSseMessage.ts
+++ b/web/src/features/logs/reconstructOpenAIResponsesSseMessage.ts
@@ -1,0 +1,113 @@
+/**
+ * Reconstruct an OpenAI Responses API `response` object from an SSE log body
+ * (`event: response.*` + `data:` JSON). Prefers the final `response.completed` payload;
+ * falls back to merging `response.output_item.done` events with the `response.created` shell.
+ */
+
+export type ReconstructOpenAIResponsesResult =
+  | { ok: true; message: Record<string, unknown> }
+  | { ok: false; reason: string };
+
+function parseDataPayload(line: string): string | null {
+  const t = line.trim();
+  if (!t.startsWith("data:")) {
+    return null;
+  }
+  const rest = t.slice(5).trimStart();
+  if (!rest || rest === "[DONE]") {
+    return null;
+  }
+  return rest;
+}
+
+function parseSseDataLines(body: string): Record<string, unknown>[] {
+  const events: Record<string, unknown>[] = [];
+  for (const line of body.trim().split("\n")) {
+    const dataStr = parseDataPayload(line);
+    if (!dataStr) {
+      continue;
+    }
+    try {
+      events.push(JSON.parse(dataStr) as Record<string, unknown>);
+    } catch {
+      continue;
+    }
+  }
+  return events;
+}
+
+/** True when the body contains OpenAI Responses API streaming events. */
+export function isOpenAIResponsesSseBody(body: string): boolean {
+  const trimmed = body.trim();
+  if (!trimmed) {
+    return false;
+  }
+  for (const line of trimmed.split("\n")) {
+    const t = line.trim();
+    if (t.startsWith("event: response.")) {
+      return true;
+    }
+    const dataStr = parseDataPayload(line);
+    if (!dataStr) {
+      continue;
+    }
+    try {
+      const data = JSON.parse(dataStr) as Record<string, unknown>;
+      if (typeof data.type === "string" && data.type.startsWith("response.")) {
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
+export function reconstructOpenAIResponsesFromSseLogBody(
+  body: string
+): ReconstructOpenAIResponsesResult {
+  const trimmed = body.trim();
+  if (!trimmed) {
+    return { ok: false, reason: "empty" };
+  }
+  if (!isOpenAIResponsesSseBody(trimmed)) {
+    return { ok: false, reason: "not_openai_responses_sse" };
+  }
+
+  const events = parseSseDataLines(trimmed);
+
+  for (const data of events) {
+    if (data.type === "response.completed" && data.response && typeof data.response === "object") {
+      return { ok: true, message: data.response as Record<string, unknown> };
+    }
+  }
+
+  let shell: Record<string, unknown> | null = null;
+  const outputByIndex: Record<number, unknown> = {};
+
+  for (const data of events) {
+    if (data.type === "response.created" && data.response && typeof data.response === "object") {
+      shell = structuredClone(data.response) as Record<string, unknown>;
+    }
+    if (data.type === "response.output_item.done") {
+      const index = data.output_index;
+      if (typeof index === "number" && data.item !== undefined) {
+        outputByIndex[index] = data.item;
+      }
+    }
+  }
+
+  if (!shell) {
+    return { ok: false, reason: "no_response_shell" };
+  }
+
+  const indices = Object.keys(outputByIndex)
+    .map(Number)
+    .sort((a, b) => a - b);
+  if (indices.length === 0) {
+    return { ok: false, reason: "no_output_items" };
+  }
+
+  shell.output = indices.map(i => outputByIndex[i]);
+  return { ok: true, message: shell };
+}


### PR DESCRIPTION
## Summary

- Fix cross-protocol Chat-to-Responses streaming when upstream models (e.g. MiMo) emit `reasoning_content` and then `tool_calls` with no assistant text: stop opening an orphan empty message item that shared `output_index` with the function call.
- Add request log **Response → Analysis** reconstruction for OpenAI Chat Completions SSE (`reasoning_content`, streamed tool calls) and OpenAI Responses API SSE (`response.completed` / `output_item.done` fallback).

## Test plan

- [x] Unit tests: `openai-chat-stream-to-responses` (MiMo regression: reasoning → tool_calls)
- [x] Unit tests: `reconstructOpenAIChatSseMessage`, `reconstructOpenAIResponsesSseMessage`
- [ ] Manual: Logs #7848 (Chat Completions SSE) — Analysis shows merged `chat.completion` with reasoning + `fields` tool call
- [ ] Manual: Logs #7814 (Responses API SSE) — Analysis shows `response` with reasoning + message output
- [ ] Manual: Cross-protocol client receives valid Responses stream when MiMo goes reasoning → tool_calls without assistant text


Made with [Cursor](https://cursor.com)