### PR TITLE
fix: stabilize update-check API test on CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,6 @@ Smart Routing aggregates provider models with unified `/v1/models` routing and o
 - Request logs for cross-protocol streaming (Chat SSE to Responses SSE) now update from `pending` to `completed` when the stream finishes, matching passthrough streaming behavior.
 - Cross-protocol streaming request logs now store the converted Responses SSE sent to the client and the upstream wire body, not only status and duration.
 - Cross-protocol Chat-to-Responses streaming no longer opens an empty assistant message item when the model goes from reasoning straight to tool calls; function calls keep the correct output index and clients parse the stream reliably.
-- Xiaomi MiMo (Anthropic protocol): Claude Agent SDK requests that put system instructions in `messages` with `role: system` no longer fail upstream validation; those entries are rewritten as user messages and merged with adjacent user turns when needed.
 
 ## [0.2.4] - 2026-05-19
 

--- a/tests/unit/api/index.test.ts
+++ b/tests/unit/api/index.test.ts
@@ -18,6 +18,7 @@ import {
   handleApiRequest,
 } from "@/api/index";
 import { resetProxyServerForApi, setProxyServerForApi } from "@/api/serverRef";
+import * as versionApi from "@/api/version";
 import { cancelUpdateCheck } from "@/server/updateCheck";
 import type { ProxyServer } from "@/server/handler";
 import type { IncomingMessage, ServerResponse } from "node:http";
@@ -641,6 +642,13 @@ describe("api: handleApiRequest specific routes", () => {
   });
 
   it("should handle POST /ccrelay/api/update-check", async () => {
+    const versionSpy = vi.spyOn(versionApi, "getBuildVersionInfo").mockReturnValue({
+      version: "0.2.5",
+      packageVersion: "0.2.5",
+      date: "2026-01-01",
+      hash: "abc",
+      gitHash: "def",
+    });
     cancelUpdateCheck();
     vi.stubGlobal(
       "fetch",
@@ -675,6 +683,7 @@ describe("api: handleApiRequest specific routes", () => {
     expect(body.checkedAt).toBeDefined();
 
     vi.unstubAllGlobals();
+    versionSpy.mockRestore();
     cancelUpdateCheck();
   });
 });


### PR DESCRIPTION
## Summary
- Mock `getBuildVersionInfo` in the POST `/ccrelay/api/update-check` API test so semver comparison does not depend on a local `version.generated.ts` artifact.
- CI runs `npm run test:all` without generating that file, so the fallback `dev-*` version could coerce to `0.0.0` and make the mocked `v0.0.1` release look newer (`available` instead of `idle`).
- Remove an obsolete 0.2.5 Fixed changelog entry superseded by earlier refactors.

## Test plan
- [x] `npx vitest run tests/unit/api/index.test.ts -t "should handle POST /ccrelay/api/update-check"`
- [x] Verified pass with `version.generated.ts` removed (CI-like environment)
- [x] `npm run lint`


Made with [Cursor](https://cursor.com)