### PR TITLE
feat: 0.2.6 pre-release — metrics always-on, smart routing fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-06-16 (pre-release)
+
+Pre-release line for 0.2.6.
+
 ## [0.2.5] - 2026-06-02
 
 Smart Routing aggregates provider models with unified `/v1/models` routing and optional `modelRules` for custom model mapping. The dashboard adds an offline gate, client configuration, release update checks, and log metrics that only count genuine SSE streams. Request log Analysis and model mapping are more reliable for large bodies and cross-protocol streams. Desktop can open the bundled UI without a running proxy; multi-instance leader election follows the active proxy port. Default queue wait timeout is removed (`requestTimeout` `0`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+**UI**
+
+- Token usage and performance metrics on the Dashboard are always recorded when the local database is available, even if request/response body logging is disabled. The logging toggle now only controls the Logs tab and stored request bodies.
+- When the local database cannot be opened (for example, sqlite3 CLI is missing in the VS Code extension), the Dashboard shows a clear unavailable state instead of empty statistics.
+
+**Logging database**
+
+- Clearing all logs also clears token metrics, so dashboard statistics stay consistent with log storage.
+
 ## [0.2.6] - 2026-06-16 (pre-release)
 
 Pre-release line for 0.2.6.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccrelay-monorepo",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccrelay-monorepo",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -10347,7 +10347,7 @@
     },
     "packages/core": {
       "name": "@ccrelay/core",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.1",
@@ -10405,7 +10405,7 @@
     },
     "packages/desktop": {
       "name": "ccrelay-desktop",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -10421,7 +10421,7 @@
     },
     "packages/desktop-tauri": {
       "name": "@ccrelay/desktop-tauri",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "hasInstallScript": true,
       "dependencies": {
         "@ccrelay/core": "*",
@@ -11117,7 +11117,7 @@
     },
     "packages/vscode": {
       "name": "ccrelay-vscode",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@ccrelay/core": "*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "ccrelay-monorepo",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "license": "MIT",
   "packageManager": "npm@10.9.4",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ccrelay/core",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "description": "CCRelay proxy server core (Node.js)",
   "license": "MIT",

--- a/packages/core/src/api/logs.ts
+++ b/packages/core/src/api/logs.ts
@@ -31,7 +31,7 @@ export async function handleLogs(
 
   const db = getDatabase();
 
-  if (!db.enabled) {
+  if (!db.enabled || !db.logsEnabled) {
     sendJson(res, 200, {
       logs: [],
       total: 0,
@@ -83,7 +83,7 @@ export async function handleLogDetail(
 
   const db = getDatabase();
 
-  if (!db.enabled) {
+  if (!db.enabled || !db.logsEnabled) {
     sendJson(res, 200, { log: null });
     return;
   }
@@ -112,7 +112,7 @@ export async function handleDeleteLogs(
 
   const db = getDatabase();
 
-  if (!db.enabled) {
+  if (!db.enabled || !db.logsEnabled) {
     sendJson(res, 200, { success: true });
     return;
   }

--- a/packages/core/src/api/stats.ts
+++ b/packages/core/src/api/stats.ts
@@ -27,6 +27,7 @@ export async function handleStats(
 
   if (!db.enabled) {
     sendJson(res, 200, {
+      dbAvailable: false,
       totalLogs: 0,
       successCount: 0,
       errorCount: 0,
@@ -61,6 +62,7 @@ export async function handleStats(
 
   const stats = await db.getStats(since ? { since } : undefined);
   sendJson(res, 200, {
+    dbAvailable: true,
     ...stats,
     providerBreakdown: filterProviderBreakdownByTokenUsage(
       omitVirtualProviderFromBreakdown(stats.providerBreakdown)

--- a/packages/core/src/api/status.ts
+++ b/packages/core/src/api/status.ts
@@ -7,6 +7,7 @@ import * as http from "http";
 import type { ProxyServer } from "../server/handler";
 import type { RouterStatus } from "../types";
 import { resolveEffectiveRoutingStatus } from "../server/smartRouting/virtualProvider";
+import { getDatabase } from "../database";
 import { sendJson } from "./index";
 
 let serverInstance: ProxyServer | null = null;
@@ -42,6 +43,7 @@ export function handleStatus(
     providerMode: routing.providerMode,
     port: config.port,
     host: config.host,
+    dbAvailable: getDatabase().enabled,
   };
 
   sendJson(res, 200, status);

--- a/packages/core/src/config/builders/database.ts
+++ b/packages/core/src/config/builders/database.ts
@@ -3,7 +3,7 @@ import type { DatabaseConfig, LoggingConfigInput } from "../../types";
 export function buildDatabaseConfig(
   logging: LoggingConfigInput | undefined
 ): DatabaseConfig | undefined {
-  if (!logging?.enabled || !logging.database) {
+  if (!logging?.database) {
     return undefined;
   }
   const db = logging.database;

--- a/packages/core/src/database/drivers/postgres/driver.ts
+++ b/packages/core/src/database/drivers/postgres/driver.ts
@@ -41,6 +41,7 @@ export class PostgresDriver implements DatabaseDriver {
   private readonly config: PostgresDriverConfig;
   private readonly log = Logger.getInstance();
   private isInitialized = false;
+  private _logsEnabled = false;
 
   constructor(config: PostgresDriverConfig) {
     this.config = config;
@@ -81,6 +82,7 @@ export class PostgresDriver implements DatabaseDriver {
       dbLabel: `${this.config.host}:${this.config.port}/${this.config.database}`,
     });
     this.isInitialized = true;
+    this._logsEnabled = options?.logsEnabled ?? false;
 
     this.log.info("[PostgresDriver] Connected successfully");
 
@@ -122,32 +124,34 @@ export class PostgresDriver implements DatabaseDriver {
       return;
     }
 
-    await this.pool.query(
-      `INSERT INTO ${TABLE} (
+    if (this._logsEnabled) {
+      await this.pool.query(
+        `INSERT INTO ${TABLE} (
         timestamp, provider_id, provider_name, method, path, target_url,
         request_body, response_body, original_request_body, original_response_body,
         status_code, duration, success, error_message, client_id, status, route_type
       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
-      [
-        log.timestamp,
-        log.providerId,
-        log.providerName,
-        log.method,
-        log.path,
-        log.targetUrl ?? null,
-        utf8StringToBlob(log.requestBody),
-        utf8StringToBlob(log.responseBody),
-        utf8StringToBlob(log.originalRequestBody),
-        utf8StringToBlob(log.originalResponseBody),
-        log.statusCode ?? null,
-        log.duration,
-        log.success,
-        utf8StringToBlob(log.errorMessage),
-        log.clientId ?? null,
-        "completed",
-        log.routeType ?? null,
-      ]
-    );
+        [
+          log.timestamp,
+          log.providerId,
+          log.providerName,
+          log.method,
+          log.path,
+          log.targetUrl ?? null,
+          utf8StringToBlob(log.requestBody),
+          utf8StringToBlob(log.responseBody),
+          utf8StringToBlob(log.originalRequestBody),
+          utf8StringToBlob(log.originalResponseBody),
+          log.statusCode ?? null,
+          log.duration,
+          log.success,
+          utf8StringToBlob(log.errorMessage),
+          log.clientId ?? null,
+          "completed",
+          log.routeType ?? null,
+        ]
+      );
+    }
     if (shouldTrackMetrics(log)) {
       await this.insertMetricsCompleted(log);
     }
@@ -218,32 +222,34 @@ export class PostgresDriver implements DatabaseDriver {
       return;
     }
 
-    await this.pool.query(
-      `INSERT INTO ${TABLE} (
+    if (this._logsEnabled) {
+      await this.pool.query(
+        `INSERT INTO ${TABLE} (
         timestamp, provider_id, provider_name, method, path, target_url,
         request_body, response_body, original_request_body, original_response_body,
         status_code, duration, success, error_message, client_id, status, route_type
       ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
-      [
-        log.timestamp,
-        log.providerId,
-        log.providerName,
-        log.method,
-        log.path,
-        log.targetUrl ?? null,
-        utf8StringToBlob(log.requestBody),
-        utf8StringToBlob(log.responseBody),
-        utf8StringToBlob(log.originalRequestBody),
-        utf8StringToBlob(log.originalResponseBody),
-        log.statusCode ?? null,
-        log.duration,
-        log.success,
-        utf8StringToBlob(log.errorMessage),
-        log.clientId ?? null,
-        "pending",
-        log.routeType ?? null,
-      ]
-    );
+        [
+          log.timestamp,
+          log.providerId,
+          log.providerName,
+          log.method,
+          log.path,
+          log.targetUrl ?? null,
+          utf8StringToBlob(log.requestBody),
+          utf8StringToBlob(log.responseBody),
+          utf8StringToBlob(log.originalRequestBody),
+          utf8StringToBlob(log.originalResponseBody),
+          log.statusCode ?? null,
+          log.duration,
+          log.success,
+          utf8StringToBlob(log.errorMessage),
+          log.clientId ?? null,
+          "pending",
+          log.routeType ?? null,
+        ]
+      );
+    }
     if (shouldTrackMetrics(log)) {
       await this.insertMetricsPending(log);
     }
@@ -270,8 +276,10 @@ export class PostgresDriver implements DatabaseDriver {
     }
 
     Promise.all([
-      this.pool!.query(
-        `UPDATE ${TABLE}
+      ...(this._logsEnabled
+        ? [
+            this.pool!.query(
+              `UPDATE ${TABLE}
          SET status_code = $1,
              response_body = $2,
              original_response_body = $3,
@@ -280,16 +288,18 @@ export class PostgresDriver implements DatabaseDriver {
              error_message = $6,
              status = 'completed'
          WHERE client_id = $7`,
-        [
-          statusCode,
-          utf8StringToBlob(responseBody),
-          utf8StringToBlob(originalResponseBody),
-          duration,
-          success,
-          utf8StringToBlob(errorMessage),
-          clientId,
-        ]
-      ),
+              [
+                statusCode,
+                utf8StringToBlob(responseBody),
+                utf8StringToBlob(originalResponseBody),
+                duration,
+                success,
+                utf8StringToBlob(errorMessage),
+                clientId,
+              ]
+            ),
+          ]
+        : []),
       this.pool!.query(POSTGRES_UPDATE_METRICS_COMPLETED, [
         inputTokens ?? null,
         outputTokens ?? null,
@@ -320,16 +330,20 @@ export class PostgresDriver implements DatabaseDriver {
     }
 
     Promise.all([
-      this.pool.query(
-        `UPDATE ${TABLE}
+      ...(this._logsEnabled
+        ? [
+            this.pool.query(
+              `UPDATE ${TABLE}
          SET status_code = $1,
              duration = $2,
              success = $3,
              error_message = $4,
              status = $5
          WHERE client_id = $6`,
-        [statusCode, duration, false, utf8StringToBlob(errorMessage), status, clientId]
-      ),
+              [statusCode, duration, false, utf8StringToBlob(errorMessage), status, clientId]
+            ),
+          ]
+        : []),
       this.pool.query(POSTGRES_UPDATE_METRICS_STATUS, [duration, false, statusCode, clientId]),
     ]).catch(err => {
       this.log.error("[PostgresDriver] Failed to update log status:", err);
@@ -349,32 +363,34 @@ export class PostgresDriver implements DatabaseDriver {
       await client.query("BEGIN");
 
       for (const log of logs) {
-        await client.query(
-          `INSERT INTO ${TABLE} (
+        if (this._logsEnabled) {
+          await client.query(
+            `INSERT INTO ${TABLE} (
             timestamp, provider_id, provider_name, method, path, target_url,
             request_body, response_body, original_request_body, original_response_body,
             status_code, duration, success, error_message, client_id, status, route_type
           ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
-          [
-            log.timestamp,
-            log.providerId,
-            log.providerName,
-            log.method,
-            log.path,
-            log.targetUrl ?? null,
-            utf8StringToBlob(log.requestBody),
-            utf8StringToBlob(log.responseBody),
-            utf8StringToBlob(log.originalRequestBody),
-            utf8StringToBlob(log.originalResponseBody),
-            log.statusCode ?? null,
-            log.duration,
-            log.success,
-            utf8StringToBlob(log.errorMessage),
-            log.clientId ?? null,
-            "completed",
-            log.routeType ?? null,
-          ]
-        );
+            [
+              log.timestamp,
+              log.providerId,
+              log.providerName,
+              log.method,
+              log.path,
+              log.targetUrl ?? null,
+              utf8StringToBlob(log.requestBody),
+              utf8StringToBlob(log.responseBody),
+              utf8StringToBlob(log.originalRequestBody),
+              utf8StringToBlob(log.originalResponseBody),
+              log.statusCode ?? null,
+              log.duration,
+              log.success,
+              utf8StringToBlob(log.errorMessage),
+              log.clientId ?? null,
+              "completed",
+              log.routeType ?? null,
+            ]
+          );
+        }
         if (shouldTrackMetrics(log)) {
           await this.insertMetricsCompleted(log);
         }
@@ -508,6 +524,7 @@ export class PostgresDriver implements DatabaseDriver {
       return;
     }
     await this.pool.query(`DELETE FROM ${TABLE}`);
+    await this.pool.query(`DELETE FROM ${METRICS_TABLE}`);
   }
 
   /**
@@ -520,6 +537,7 @@ export class PostgresDriver implements DatabaseDriver {
 
     const thirtyDaysAgo = Date.now() - 30 * 24 * 60 * 60 * 1000;
     await this.pool.query(`DELETE FROM ${TABLE} WHERE timestamp < $1`, [thirtyDaysAgo]);
+    await this.pool.query(`DELETE FROM ${METRICS_TABLE} WHERE timestamp < $1`, [thirtyDaysAgo]);
 
     // PostgreSQL doesn't need VACUUM like SQLite, but we can run VACUUM ANALYZE
     // Note: VACUUM cannot run inside a transaction block
@@ -657,6 +675,14 @@ export class PostgresDriver implements DatabaseDriver {
    */
   get enabled(): boolean {
     return this.isEnabled;
+  }
+
+  get logsEnabled(): boolean {
+    return this._logsEnabled;
+  }
+
+  setLogsEnabled(enabled: boolean): void {
+    this._logsEnabled = enabled;
   }
 
   private get isEnabled(): boolean {

--- a/packages/core/src/database/drivers/sqlite/cli.ts
+++ b/packages/core/src/database/drivers/sqlite/cli.ts
@@ -780,6 +780,7 @@ class WriteQueue {
   private readonly batchSize = 50;
   private readonly flushInterval = 1000;
   private isEnabled = false;
+  private logsEnabled = false;
 
   setConnection(conn: CliConnection, failedWritesPath: string): void {
     this.conn = conn;
@@ -791,6 +792,10 @@ class WriteQueue {
     if (!enabled) {
       this.clear();
     }
+  }
+
+  setLogsEnabled(enabled: boolean): void {
+    this.logsEnabled = enabled;
   }
 
   add(log: RequestLog): void {
@@ -860,8 +865,10 @@ class WriteQueue {
     }
     const stmts: string[] = [];
     for (const log of logs) {
-      const { sql, params } = buildInsertSql(log);
-      stmts.push(interpolateSql(sql, params));
+      if (this.logsEnabled) {
+        const { sql, params } = buildInsertSql(log);
+        stmts.push(interpolateSql(sql, params));
+      }
       if (shouldTrackMetrics(log)) {
         const metrics = buildMetricsCompletedInsertSql(log);
         stmts.push(interpolateSql(metrics.sql, metrics.params));
@@ -936,6 +943,7 @@ export class SqliteCliDriver implements DatabaseDriver {
 
   private readonly writeQueue: WriteQueue = new WriteQueue();
   private isEnabled = false;
+  private _logsEnabled = false;
 
   constructor(config: SqliteDriverConfig) {
     this.config = config;
@@ -986,6 +994,8 @@ export class SqliteCliDriver implements DatabaseDriver {
     await this.writeQueue.replayFailedWrites();
 
     this.isEnabled = true;
+    this._logsEnabled = options?.logsEnabled ?? false;
+    this.writeQueue.setLogsEnabled(this._logsEnabled);
     this.writeQueue.setEnabled(true);
 
     this.writeConn.startHealthCheck();
@@ -1051,8 +1061,11 @@ export class SqliteCliDriver implements DatabaseDriver {
       return;
     }
 
-    const { sql, params } = buildInsertSql(log, "pending");
-    const pending = this.writeConn.exec(sql, params);
+    let pending: Promise<void> = Promise.resolve();
+    if (this._logsEnabled) {
+      const { sql, params } = buildInsertSql(log, "pending");
+      pending = this.writeConn.exec(sql, params);
+    }
     let metrics: Promise<void> = Promise.resolve();
     if (shouldTrackMetrics(log)) {
       const m = buildMetricsPendingInsertSql(log);
@@ -1080,9 +1093,11 @@ export class SqliteCliDriver implements DatabaseDriver {
       return;
     }
 
-    Promise.all([
-      this.writeConn.exec(
-        `UPDATE ${TABLE}
+    const updates: Promise<void>[] = [];
+    if (this._logsEnabled) {
+      updates.push(
+        this.writeConn.exec(
+          `UPDATE ${TABLE}
        SET status_code = ?,
            response_body = ?,
            original_response_body = ?,
@@ -1091,16 +1106,19 @@ export class SqliteCliDriver implements DatabaseDriver {
            error_message = ?,
            status = 'completed'
        WHERE client_id = ?`,
-        [
-          statusCode,
-          utf8StringToBlob(responseBody),
-          utf8StringToBlob(originalResponseBody),
-          duration,
-          success ? 1 : 0,
-          errorMessage ?? null,
-          clientId,
-        ]
-      ),
+          [
+            statusCode,
+            utf8StringToBlob(responseBody),
+            utf8StringToBlob(originalResponseBody),
+            duration,
+            success ? 1 : 0,
+            errorMessage ?? null,
+            clientId,
+          ]
+        )
+      );
+    }
+    updates.push(
       this.writeConn.exec(SQLITE_UPDATE_METRICS_COMPLETED, [
         inputTokens ?? null,
         outputTokens ?? null,
@@ -1110,8 +1128,9 @@ export class SqliteCliDriver implements DatabaseDriver {
         success ? 1 : 0,
         statusCode,
         clientId,
-      ]),
-    ]).catch(err => {
+      ])
+    );
+    Promise.all(updates).catch(err => {
       this.log.error("[SqliteCli] Failed to update log:", err);
     });
   }
@@ -1127,19 +1146,25 @@ export class SqliteCliDriver implements DatabaseDriver {
       return;
     }
 
-    Promise.all([
-      this.writeConn.exec(
-        `UPDATE ${TABLE}
+    const updates: Promise<void>[] = [];
+    if (this._logsEnabled) {
+      updates.push(
+        this.writeConn.exec(
+          `UPDATE ${TABLE}
        SET status_code = ?,
            duration = ?,
            success = ?,
            error_message = ?,
            status = ?
        WHERE client_id = ?`,
-        [statusCode, duration, 0, errorMessage ?? null, status, clientId]
-      ),
-      this.writeConn.exec(SQLITE_UPDATE_METRICS_STATUS, [duration, 0, statusCode, clientId]),
-    ]).catch(err => {
+          [statusCode, duration, 0, errorMessage ?? null, status, clientId]
+        )
+      );
+    }
+    updates.push(
+      this.writeConn.exec(SQLITE_UPDATE_METRICS_STATUS, [duration, 0, statusCode, clientId])
+    );
+    Promise.all(updates).catch(err => {
       this.log.error("[SqliteCli] Failed to update log status:", err);
     });
   }
@@ -1151,8 +1176,10 @@ export class SqliteCliDriver implements DatabaseDriver {
 
     const stmts: string[] = [];
     for (const log of logs) {
-      const { sql, params } = buildInsertSql(log);
-      stmts.push(interpolateSql(sql, params));
+      if (this._logsEnabled) {
+        const { sql, params } = buildInsertSql(log);
+        stmts.push(interpolateSql(sql, params));
+      }
       if (shouldTrackMetrics(log)) {
         const metrics = buildMetricsCompletedInsertSql(log);
         stmts.push(interpolateSql(metrics.sql, metrics.params));
@@ -1176,6 +1203,7 @@ export class SqliteCliDriver implements DatabaseDriver {
       return;
     }
     await this.writeConn.exec(`DELETE FROM ${TABLE}`);
+    await this.writeConn.exec(`DELETE FROM ${METRICS_TABLE}`);
     await this.writeConn.exec("VACUUM");
   }
 
@@ -1193,6 +1221,7 @@ export class SqliteCliDriver implements DatabaseDriver {
         SELECT id FROM ${TABLE} ORDER BY timestamp DESC LIMIT ${MAX_LOG_ROWS}
       )
     `);
+    await this.writeConn.exec(`DELETE FROM ${METRICS_TABLE} WHERE timestamp < ?`, [cutoff]);
   }
 
   // ---- Read operations (readConn) ----------------------------------------
@@ -1440,6 +1469,15 @@ export class SqliteCliDriver implements DatabaseDriver {
 
   get enabled(): boolean {
     return this.isEnabled && this.writeConn?.started === true;
+  }
+
+  get logsEnabled(): boolean {
+    return this._logsEnabled;
+  }
+
+  setLogsEnabled(enabled: boolean): void {
+    this._logsEnabled = enabled;
+    this.writeQueue.setLogsEnabled(enabled);
   }
 
   forceFlush(): void {

--- a/packages/core/src/database/drivers/sqlite/native.ts
+++ b/packages/core/src/database/drivers/sqlite/native.ts
@@ -49,6 +49,7 @@ export class SqliteNativeDriver implements DatabaseDriver {
   private readonly log = Logger.getInstance();
   private db: Database.Database | null = null;
   private isEnabled = false;
+  private _logsEnabled = false;
 
   constructor(config: SqliteDriverConfig) {
     this.config = config;
@@ -110,12 +111,29 @@ export class SqliteNativeDriver implements DatabaseDriver {
     );
 
     this.isEnabled = true;
+    this._logsEnabled = options?.logsEnabled ?? false;
 
     setTimeout(() => {
       this.cleanOldLogs().catch(err => {
         this.log.error("[SqliteNative] Background cleanup failed:", err);
       });
     }, 0);
+  }
+
+  get enabled(): boolean {
+    return this.isEnabled;
+  }
+
+  get logsEnabled(): boolean {
+    return this._logsEnabled;
+  }
+
+  setLogsEnabled(enabled: boolean): void {
+    this._logsEnabled = enabled;
+  }
+
+  forceFlush(): void {
+    // Native driver writes synchronously; nothing to flush.
   }
 
   // ---- Write operations ----------------------------------------------------
@@ -125,8 +143,10 @@ export class SqliteNativeDriver implements DatabaseDriver {
       return;
     }
     try {
-      const { sql, params } = buildInsertSql(log);
-      this.d.prepare(sql).run(...params);
+      if (this._logsEnabled) {
+        const { sql, params } = buildInsertSql(log);
+        this.d.prepare(sql).run(...params);
+      }
       if (shouldTrackMetrics(log)) {
         const metrics = buildMetricsCompletedInsertSql(log);
         this.d.prepare(metrics.sql).run(...metrics.params);
@@ -141,8 +161,10 @@ export class SqliteNativeDriver implements DatabaseDriver {
       return;
     }
     try {
-      const { sql, params } = buildInsertSql(log, "pending");
-      this.d.prepare(sql).run(...params);
+      if (this._logsEnabled) {
+        const { sql, params } = buildInsertSql(log, "pending");
+        this.d.prepare(sql).run(...params);
+      }
       if (shouldTrackMetrics(log)) {
         const metrics = buildMetricsPendingInsertSql(log);
         this.d.prepare(metrics.sql).run(...metrics.params);
@@ -169,7 +191,8 @@ export class SqliteNativeDriver implements DatabaseDriver {
       return;
     }
     try {
-      const stmt = this.d.prepare(`
+      if (this._logsEnabled) {
+        const stmt = this.d.prepare(`
         UPDATE ${TABLE}
         SET status_code = ?,
             response_body = ?,
@@ -180,15 +203,16 @@ export class SqliteNativeDriver implements DatabaseDriver {
             status = 'completed'
         WHERE client_id = ?
       `);
-      stmt.run(
-        statusCode,
-        utf8StringToBlob(responseBody),
-        utf8StringToBlob(originalResponseBody),
-        duration,
-        success ? 1 : 0,
-        errorMessage ?? null,
-        clientId
-      );
+        stmt.run(
+          statusCode,
+          utf8StringToBlob(responseBody),
+          utf8StringToBlob(originalResponseBody),
+          duration,
+          success ? 1 : 0,
+          errorMessage ?? null,
+          clientId
+        );
+      }
       this.d
         .prepare(SQLITE_UPDATE_METRICS_COMPLETED)
         .run(
@@ -217,7 +241,8 @@ export class SqliteNativeDriver implements DatabaseDriver {
       return;
     }
     try {
-      const stmt = this.d.prepare(`
+      if (this._logsEnabled) {
+        const stmt = this.d.prepare(`
         UPDATE ${TABLE}
         SET status_code = ?,
             duration = ?,
@@ -226,7 +251,8 @@ export class SqliteNativeDriver implements DatabaseDriver {
             status = ?
         WHERE client_id = ?
       `);
-      stmt.run(statusCode, duration, 0, errorMessage ?? null, status, clientId);
+        stmt.run(statusCode, duration, 0, errorMessage ?? null, status, clientId);
+      }
       this.d.prepare(SQLITE_UPDATE_METRICS_STATUS).run(duration, 0, statusCode, clientId);
     } catch (err) {
       this.log.error("[SqliteNative] Failed to update log status:", err);
@@ -238,11 +264,13 @@ export class SqliteNativeDriver implements DatabaseDriver {
       return;
     }
 
-    const stmt = this.d.prepare(buildInsertSql(logs[0]).sql);
+    const stmt = this._logsEnabled ? this.d.prepare(buildInsertSql(logs[0]).sql) : null;
     const insertMany = this.d.transaction((items: RequestLog[]) => {
       for (const log of items) {
-        const { params } = buildInsertSql(log);
-        stmt.run(...params);
+        if (this._logsEnabled && stmt) {
+          const { params } = buildInsertSql(log);
+          stmt.run(...params);
+        }
         if (shouldTrackMetrics(log)) {
           const metrics = buildMetricsCompletedInsertSql(log);
           this.d.prepare(metrics.sql).run(...metrics.params);
@@ -265,6 +293,7 @@ export class SqliteNativeDriver implements DatabaseDriver {
       return;
     }
     this.d.exec(`DELETE FROM ${TABLE}`);
+    this.d.exec(`DELETE FROM ${METRICS_TABLE}`);
     this.d.exec("VACUUM");
   }
 
@@ -279,6 +308,7 @@ export class SqliteNativeDriver implements DatabaseDriver {
         `DELETE FROM ${TABLE} WHERE id NOT IN (SELECT id FROM ${TABLE} ORDER BY timestamp DESC LIMIT ?)`
       )
       .run(MAX_LOG_ROWS);
+    this.d.prepare(`DELETE FROM ${METRICS_TABLE} WHERE timestamp < ?`).run(cutoff);
   }
 
   // ---- Read operations -----------------------------------------------------
@@ -499,14 +529,6 @@ export class SqliteNativeDriver implements DatabaseDriver {
       p90Duration,
       providerBreakdown: filterProviderBreakdownByTokenUsage(providerBreakdown),
     };
-  }
-
-  get enabled(): boolean {
-    return this.isEnabled;
-  }
-
-  forceFlush(): void {
-    // Native driver writes synchronously — nothing to flush
   }
 
   async close(): Promise<void> {

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -32,6 +32,7 @@ export class LogDatabase {
   private readonly driverConfig: DatabaseDriverConfig;
   private readonly log = Logger.getInstance();
   private initPromise: Promise<void> | null = null;
+  private _logsEnabled = false;
 
   constructor(customDbPath?: string, driverConfig?: DatabaseDriverConfig) {
     // Determine default path
@@ -54,12 +55,21 @@ export class LogDatabase {
   }
 
   /**
-   * Initialize the database
+   * Initialize the database for metrics (always on for leader).
+   * @param active When false, closes the database (followers).
+   * @param logsEnabled When true, also persists request/response bodies to request_logs_v2.
    */
-  async initialize(enabled: boolean): Promise<void> {
-    if (!enabled) {
+  async initialize(active: boolean, logsEnabled = false): Promise<void> {
+    this._logsEnabled = logsEnabled;
+
+    if (!active) {
       await this.close();
-      this.log.info("[LogDatabase] Initialization skipped - disabled by config");
+      this.log.info("[LogDatabase] Initialization skipped - inactive (follower)");
+      return;
+    }
+
+    if (this.driver?.enabled) {
+      this.setLogsEnabled(logsEnabled);
       return;
     }
 
@@ -68,7 +78,7 @@ export class LogDatabase {
       return this.initPromise;
     }
 
-    this.initPromise = this.doInitialize();
+    this.initPromise = this.doInitialize(logsEnabled);
 
     try {
       await this.initPromise;
@@ -77,12 +87,12 @@ export class LogDatabase {
     }
   }
 
-  private async doInitialize(): Promise<void> {
+  private async doInitialize(logsEnabled: boolean): Promise<void> {
     try {
       this.log.info(`[LogDatabase] Creating ${this.driverConfig.type} driver...`);
       this.driver = createDriver(this.driverConfig);
 
-      await this.driver.initialize({ migrationChoice: "migrate" });
+      await this.driver.initialize({ migrationChoice: "migrate", logsEnabled });
 
       this.log.info("[LogDatabase] Initialization complete");
     } catch (err) {
@@ -95,7 +105,7 @@ export class LogDatabase {
 
       if (this.driverConfig.type === "sqlite" && isSqliteCliUnavailableError(err)) {
         this.log.warn(
-          "[LogDatabase] sqlite3 CLI is not installed or not on PATH; continuing without persisted request logs (logging remains enabled in config)."
+          "[LogDatabase] sqlite3 CLI is not installed or not on PATH; metrics and logs cannot be persisted."
         );
         return;
       }
@@ -207,10 +217,25 @@ export class LogDatabase {
   }
 
   /**
-   * Check if database is enabled
+   * Check if database driver is available (metrics can be read/written).
    */
   get enabled(): boolean {
     return this.driver?.enabled ?? false;
+  }
+
+  /**
+   * Whether request/response body logging is enabled.
+   */
+  get logsEnabled(): boolean {
+    return this.driver?.logsEnabled ?? this._logsEnabled;
+  }
+
+  /**
+   * Toggle body logging at runtime (e.g. when logging.enabled changes in config).
+   */
+  setLogsEnabled(enabled: boolean): void {
+    this._logsEnabled = enabled;
+    this.driver?.setLogsEnabled(enabled);
   }
 }
 

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -143,6 +143,8 @@ export type LogDbMigrationChoice = "migrate" | "discard";
 
 export interface DatabaseInitializeOptions {
   migrationChoice?: LogDbMigrationChoice;
+  /** When false, only request_metrics rows are written (no request body logging). */
+  logsEnabled?: boolean;
 }
 
 /**
@@ -237,6 +239,17 @@ export interface DatabaseDriver {
    * Check if the driver is enabled and ready
    */
   readonly enabled: boolean;
+
+  /**
+   * Whether request/response body logging to request_logs_v2 is enabled.
+   * Metrics are always written when the driver is enabled.
+   */
+  readonly logsEnabled: boolean;
+
+  /**
+   * Toggle body logging without closing the database connection.
+   */
+  setLogsEnabled(enabled: boolean): void;
 
   /**
    * Force flush any pending writes

--- a/packages/core/src/database/worker/client.ts
+++ b/packages/core/src/database/worker/client.ts
@@ -26,6 +26,7 @@ import type {
 type WorkerMessageType =
   | "init"
   | "close"
+  | "setLogsEnabled"
   | "insertLog"
   | "insertLogPending"
   | "updateLogCompleted"
@@ -77,6 +78,7 @@ export class DatabaseWorkerClient implements DatabaseDriver {
   > = new Map();
   private log = Logger.getInstance();
   private _enabled: boolean = false;
+  private _logsEnabled: boolean = false;
   private config: DatabaseDriverConfig;
   private isClosing = false;
 
@@ -217,10 +219,12 @@ export class DatabaseWorkerClient implements DatabaseDriver {
    */
   async initialize(options?: DatabaseInitializeOptions): Promise<void> {
     this.isClosing = false;
+    this._logsEnabled = options?.logsEnabled ?? false;
     this.startWorker();
     await this.send("init", {
       config: this.config as SqliteDriverConfig,
       migrationChoice: options?.migrationChoice ?? "migrate",
+      logsEnabled: this._logsEnabled,
     });
     this._enabled = true;
     this.log.info("[DatabaseWorker] Initialized");
@@ -258,6 +262,19 @@ export class DatabaseWorkerClient implements DatabaseDriver {
    */
   get enabled(): boolean {
     return this._enabled;
+  }
+
+  get logsEnabled(): boolean {
+    return this._logsEnabled;
+  }
+
+  setLogsEnabled(enabled: boolean): void {
+    this._logsEnabled = enabled;
+    if (this.worker) {
+      void this.send("setLogsEnabled", { enabled }).catch(err => {
+        this.log.error("[DatabaseWorker] setLogsEnabled error:", err);
+      });
+    }
   }
 
   /**

--- a/packages/core/src/database/worker/worker.ts
+++ b/packages/core/src/database/worker/worker.ts
@@ -28,6 +28,7 @@ import type {
 type WorkerMessageType =
   | "init"
   | "close"
+  | "setLogsEnabled"
   | "insertLog"
   | "insertLogPending"
   | "updateLogCompleted"
@@ -71,9 +72,11 @@ async function handleMessage(message: WorkerMessage): Promise<WorkerResponse> {
         const p = payload as {
           config: SqliteDriverConfig;
           migrationChoice?: LogDbMigrationChoice;
+          logsEnabled?: boolean;
         };
         const initOptions: DatabaseInitializeOptions = {
           migrationChoice: p.migrationChoice ?? "migrate",
+          logsEnabled: p.logsEnabled ?? false,
         };
         driver = createSqliteDriver(p.config);
         try {
@@ -97,6 +100,11 @@ async function handleMessage(message: WorkerMessage): Promise<WorkerResponse> {
           await driver.close();
           driver = null;
         }
+        return { id, success: true };
+      }
+
+      case "setLogsEnabled": {
+        driver?.setLogsEnabled((payload as { enabled: boolean }).enabled);
         return { id, success: true };
       }
 

--- a/packages/core/src/server/handler.ts
+++ b/packages/core/src/server/handler.ts
@@ -197,17 +197,17 @@ export class ProxyServer {
   }
 
   /**
-   * Open persisted logs only on the leader (before HTTP accepts proxy traffic).
+   * Open persisted storage on the leader (metrics always; body logs when logging.enabled).
    */
   private async ensureLeaderLogStorage(): Promise<void> {
-    const enabled = this.config.enableLogStorage;
+    const logsEnabled = this.config.enableLogStorage;
     this.log.info(
-      `[Server:${this.instanceId}] Initializing log database (leader). config.enableLogStorage=${enabled}`
+      `[Server:${this.instanceId}] Initializing database (leader). logging.enabled=${logsEnabled}`
     );
     const dbStart = Date.now();
-    await this.database.initialize(enabled);
+    await this.database.initialize(true, logsEnabled);
     this.log.info(
-      `[Server:${this.instanceId}] Database initialized in ${Date.now() - dbStart}ms. enabled=${this.database.enabled}`
+      `[Server:${this.instanceId}] Database initialized in ${Date.now() - dbStart}ms. available=${this.database.enabled}, logsEnabled=${this.database.logsEnabled}`
     );
   }
 
@@ -409,6 +409,7 @@ export class ProxyServer {
    * - Leader: Broadcast to Followers so they reload local config
    */
   private handleConfigChanged(): void {
+    this.database.setLogsEnabled(this.config.enableLogStorage);
     if (this.wsBroadcaster) {
       this.wsBroadcaster.broadcastConfigChanged();
     }

--- a/packages/core/src/server/proxy/executor.ts
+++ b/packages/core/src/server/proxy/executor.ts
@@ -130,6 +130,8 @@ interface ExecutionContext {
   streamTotalBytes: number;
   firstChunkLogged: boolean;
   responseChunks: Buffer[];
+  /** When true, mirror upstream/client response bytes for metrics or body logging. */
+  captureResponse: boolean;
   originalResponseBody?: string;
   clientDisconnected: boolean;
   /**
@@ -181,7 +183,7 @@ export class ProxyExecutor {
     this.modelCatalog = catalog;
   }
 
-  /** Write converted SSE to the client and mirror into `ctx.responseChunks` when DB logging is on. */
+  /** Write converted SSE to the client and mirror into `ctx.responseChunks` when capture is on. */
   private writeClientStreamForLog(
     clientRes: http.ServerResponse,
     chunk: string | Buffer,
@@ -189,13 +191,17 @@ export class ProxyExecutor {
   ): void {
     const buf = typeof chunk === "string" ? Buffer.from(chunk, "utf-8") : chunk;
     clientRes.write(buf);
-    if (this.responseLogger.enabled) {
+    if (ctx.captureResponse) {
       ctx.responseChunks.push(buf);
     }
   }
 
-  private recordUpstreamChunkForLog(chunk: Buffer, upstreamLog: Buffer[]): void {
-    if (this.responseLogger.enabled) {
+  private recordUpstreamChunkForLog(
+    chunk: Buffer,
+    upstreamLog: Buffer[],
+    ctx: ExecutionContext
+  ): void {
+    if (ctx.captureResponse) {
       upstreamLog.push(chunk);
     }
   }
@@ -486,6 +492,7 @@ export class ProxyExecutor {
       streamTotalBytes: 0,
       firstChunkLogged: false,
       responseChunks: [],
+      captureResponse: this.responseLogger.shouldCaptureResponse(method, task.requestPath),
       originalResponseBody: undefined,
       clientDisconnected: false,
     };
@@ -898,7 +905,7 @@ export class ProxyExecutor {
       if (!ctx.upstreamTerminalSeen && chunkContainsTerminalMarker(chunk)) {
         ctx.upstreamTerminalSeen = true;
       }
-      this.recordUpstreamChunkForLog(chunk, upstreamLog);
+      this.recordUpstreamChunkForLog(chunk, upstreamLog, ctx);
       sseBuffer.push(chunk);
     });
 
@@ -1006,7 +1013,7 @@ export class ProxyExecutor {
       if (!ctx.upstreamTerminalSeen && chunkContainsTerminalMarker(chunk)) {
         ctx.upstreamTerminalSeen = true;
       }
-      this.recordUpstreamChunkForLog(chunk, upstreamLog);
+      this.recordUpstreamChunkForLog(chunk, upstreamLog, ctx);
       sseBuffer.push(chunk);
     });
 
@@ -1101,7 +1108,7 @@ export class ProxyExecutor {
         ctx.upstreamTerminalSeen = true;
       }
       upstreamBody += chunk.toString();
-      if (this.responseLogger.enabled) {
+      if (ctx.captureResponse) {
         ctx.responseChunks.push(chunk);
       }
     });
@@ -1141,7 +1148,7 @@ export class ProxyExecutor {
       );
 
       ctx.originalResponseBody = upstreamBody;
-      if (this.responseLogger.enabled) {
+      if (ctx.captureResponse) {
         ctx.responseChunks = [Buffer.from(sseBody, "utf-8")];
       }
 
@@ -1666,7 +1673,7 @@ export class ProxyExecutor {
       if (!ctx.upstreamTerminalSeen && chunkContainsTerminalMarker(chunk)) {
         ctx.upstreamTerminalSeen = true;
       }
-      this.recordUpstreamChunkForLog(chunk, upstreamLog);
+      this.recordUpstreamChunkForLog(chunk, upstreamLog, ctx);
       if (chunkCount === 1) {
         firstChunkTime = Date.now() - startTime;
         log.debug(`[Chat->Responses SSE] First chunk: ${chunk.length} bytes`);
@@ -1883,7 +1890,7 @@ export class ProxyExecutor {
         ctx.upstreamTerminalSeen = true;
       }
       chunks.push(chunk);
-      if (this.responseLogger.enabled) {
+      if (ctx.captureResponse) {
         ctx.responseChunks.push(chunk);
       }
     });
@@ -1943,7 +1950,7 @@ export class ProxyExecutor {
         rows = applyAnthropicSseRowsPlatformTransform(rows, provider.baseUrl);
         const outgoing = serializeAnthropicSseRows(rows);
 
-        if (this.responseLogger.enabled) {
+        if (ctx.captureResponse) {
           ctx.responseChunks.length = 0;
           if (outgoing.length > 0) {
             ctx.responseChunks.push(Buffer.from(outgoing, "utf-8"));
@@ -1957,7 +1964,7 @@ export class ProxyExecutor {
         log.warn(
           `[${clientId}] Buffered Anthropic SSE transform failed (${provider.id}): ${errMsg}; replaying raw upstream stream`
         );
-        if (this.responseLogger.enabled) {
+        if (ctx.captureResponse) {
           ctx.responseChunks.length = 0;
           for (const c of chunks) {
             ctx.responseChunks.push(c);
@@ -2054,7 +2061,7 @@ export class ProxyExecutor {
         );
       }
 
-      if (this.responseLogger.enabled) {
+      if (ctx.captureResponse) {
         ctx.responseChunks.push(chunk);
       }
     });

--- a/packages/core/src/server/responseLogger.ts
+++ b/packages/core/src/server/responseLogger.ts
@@ -8,6 +8,7 @@
 import * as zlib from "zlib";
 import { ScopedLogger } from "../utils/logger";
 import type { LogDatabase } from "../database";
+import { isTokenUsageRequestPath } from "../converter/paths";
 
 export interface LogResponseTokenOverrides {
   inputTokens?: number;
@@ -117,10 +118,30 @@ export class ResponseLogger {
   constructor(private database: LogDatabase) {}
 
   /**
-   * Check if database logging is enabled
+   * Check if the database driver is available (metrics can be persisted).
    */
   get enabled(): boolean {
     return this.database.enabled;
+  }
+
+  /**
+   * Whether request/response body logging is enabled.
+   */
+  get logsEnabled(): boolean {
+    return this.database.logsEnabled;
+  }
+
+  /**
+   * Whether to capture response chunks for DB writes (body logs or token metrics).
+   */
+  shouldCaptureResponse(method: string, path: string): boolean {
+    if (!this.database.enabled) {
+      return false;
+    }
+    if (this.database.logsEnabled) {
+      return true;
+    }
+    return isTokenUsageRequestPath(method, path);
   }
 
   /**

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -491,6 +491,7 @@ export interface RouterStatus {
   providerMode?: ProviderMode;
   port?: number;
   host?: string;
+  dbAvailable?: boolean;
 }
 
 export interface ProvidersResponse {

--- a/packages/desktop-tauri/package.json
+++ b/packages/desktop-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ccrelay/desktop-tauri",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "description": "CCRelay desktop app (Tauri)",
   "scripts": {

--- a/packages/desktop-tauri/src-tauri/Cargo.lock
+++ b/packages/desktop-tauri/src-tauri/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "ccrelay"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "open",
  "serde",

--- a/packages/desktop-tauri/src-tauri/Cargo.toml
+++ b/packages/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccrelay"
-version = "0.2.5"
+version = "0.2.6"
 description = "CCRelay desktop app"
 authors = ["Inflab"]
 edition = "2021"

--- a/packages/desktop-tauri/src-tauri/tauri.conf.json
+++ b/packages/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CCRelay",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "identifier": "org.inflab.ccrelay",
   "build": {
     "frontendDist": "../web",

--- a/packages/desktop-tauri/src/main.ts
+++ b/packages/desktop-tauri/src/main.ts
@@ -9,6 +9,7 @@
 
 import * as http from "http";
 import * as path from "path";
+import * as os from "os";
 import * as fs from "fs";
 import {
   Api,
@@ -106,10 +107,17 @@ async function main(): Promise<void> {
 
   setLogDatabaseDriverConfigResolver(() => {
     const base = loggingDatabaseConfigToDriver(configManager.configValue.logging.database);
+    if (base?.type === "postgres") {
+      return base;
+    }
     if (base?.type === "sqlite") {
       return { ...base, driver: base.driver === "cli" ? "cli" : "native" };
     }
-    return base;
+    return {
+      type: "sqlite",
+      path: path.join(os.homedir(), ".ccrelay", "logs.db"),
+      driver: "native",
+    };
   });
 
   const leaderElection = new LeaderElection(configManager.port, configManager.host, () =>

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccrelay-desktop",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "description": "CCRelay desktop tray app",
   "license": "MIT",

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -89,10 +89,17 @@ void app.whenReady().then(async () => {
   const configManager = new ConfigManager();
   setLogDatabaseDriverConfigResolver(() => {
     const base = loggingDatabaseConfigToDriver(configManager.configValue.logging.database);
+    if (base?.type === "postgres") {
+      return base;
+    }
     if (base?.type === "sqlite") {
       return { ...base, driver: base.driver === "cli" ? "cli" : "native" };
     }
-    return base;
+    return {
+      type: "sqlite",
+      path: path.join(app.getPath("home"), ".ccrelay", "logs.db"),
+      driver: "native",
+    };
   });
 
   const leaderElection = new LeaderElection(configManager.port, configManager.host, () =>

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "CCRelay",
   "icon": "assets/icon-128.png",
   "description": "VSCode extension with built-in API proxy server - switch between AI providers seamlessly",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "publisher": "inflab",
   "license": "MIT",
   "repository": {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -65,10 +65,17 @@ export function activate(context: vscode.ExtensionContext) {
 
   setLogDatabaseDriverConfigResolver(() => {
     const base = loggingDatabaseConfigToDriver(cm.configValue.logging.database);
+    if (base?.type === "postgres") {
+      return base;
+    }
     if (base?.type === "sqlite") {
       return { ...base, driver: base.driver ?? "cli" };
     }
-    return base;
+    return {
+      type: "sqlite",
+      path: path.join(path.dirname(getLogDir()), "logs.db"),
+      driver: "cli",
+    };
   });
 
   const serverStart = Date.now();

--- a/tests/unit/api/stats.test.ts
+++ b/tests/unit/api/stats.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { IncomingMessage, ServerResponse } from "http";
+import { handleStats } from "@/api/stats";
+import { resetDatabase, getDatabase } from "@/database";
+import { setProxyServerForApi, resetProxyServerForApi } from "@/api/serverRef";
+
+class MockServerResponse {
+  statusCode = 200;
+  ended = false;
+  body = "";
+
+  writeHead(code: number): void {
+    this.statusCode = code;
+  }
+
+  end(data?: string): void {
+    this.ended = true;
+    if (data) {
+      this.body = data;
+    }
+  }
+}
+
+describe("handleStats", () => {
+  beforeEach(() => {
+    resetProxyServerForApi();
+    setProxyServerForApi({
+      getRole: () => "leader",
+    } as never);
+    resetDatabase();
+  });
+
+  afterEach(() => {
+    resetDatabase();
+    resetProxyServerForApi();
+  });
+
+  it("returns dbAvailable false when database driver is not ready", async () => {
+    const db = getDatabase();
+    expect(db.enabled).toBe(false);
+
+    const res = new MockServerResponse();
+    await handleStats(
+      { url: "/ccrelay/api/stats" } as IncomingMessage,
+      res as unknown as ServerResponse,
+      {}
+    );
+
+    expect(res.statusCode).toBe(200);
+    const payload = JSON.parse(res.body) as { dbAvailable: boolean; totalInputTokens: number };
+    expect(payload.dbAvailable).toBe(false);
+    expect(payload.totalInputTokens).toBe(0);
+  });
+});

--- a/tests/unit/config/builders/database.test.ts
+++ b/tests/unit/config/builders/database.test.ts
@@ -6,12 +6,15 @@ describe("buildDatabaseConfig", () => {
     expect(buildDatabaseConfig(undefined)).toBeUndefined();
   });
 
-  it("returns undefined when logging disabled", () => {
-    expect(buildDatabaseConfig({ enabled: false, database: { type: "sqlite" } })).toBeUndefined();
+  it("returns undefined when database missing", () => {
+    expect(buildDatabaseConfig({ enabled: false })).toBeUndefined();
+    expect(buildDatabaseConfig({ enabled: true })).toBeUndefined();
   });
 
-  it("returns undefined when database missing", () => {
-    expect(buildDatabaseConfig({ enabled: true })).toBeUndefined();
+  it("builds sqlite config when database present even if logging disabled", () => {
+    expect(
+      buildDatabaseConfig({ enabled: false, database: { type: "sqlite", path: "/tmp/x.db" } })
+    ).toEqual({ type: "sqlite", path: "/tmp/x.db" });
   });
 
   it("builds sqlite config with optional executable", () => {

--- a/tests/unit/database/metrics-split.test.ts
+++ b/tests/unit/database/metrics-split.test.ts
@@ -72,9 +72,9 @@ describe.skipIf(!nativeForNode)("metrics split (native driver)", () => {
     await driver.close();
   });
 
-  it("completion updates metrics tokens; clear v2 leaves metrics", async () => {
+  it("completion updates metrics tokens; clearAllLogs clears metrics too", async () => {
     const driver = new SqliteNativeDriver({ type: "sqlite", path: dbPath });
-    await driver.initialize();
+    await driver.initialize({ logsEnabled: true });
 
     const clientId = "c-complete";
     driver.insertLogPending({
@@ -102,7 +102,59 @@ describe.skipIf(!nativeForNode)("metrics split (native driver)", () => {
     await driver.clearAllLogs();
 
     const statsAfter = await driver.getStats();
-    expect(statsAfter.totalInputTokens).toBe(10);
+    expect(statsAfter.totalInputTokens).toBe(0);
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/naming-convention
+    const BetterSqlite3 = require("better-sqlite3") as typeof import("better-sqlite3");
+    const db = new BetterSqlite3(dbPath);
+    const v2Count = db.prepare(`SELECT COUNT(*) as c FROM ${TABLE}`).get() as { c: number };
+    const mCount = db.prepare(`SELECT COUNT(*) as c FROM ${METRICS_TABLE}`).get() as { c: number };
+    expect(v2Count.c).toBe(0);
+    expect(mCount.c).toBe(0);
+    db.close();
+
+    await driver.close();
+  });
+
+  it("logsEnabled false writes metrics only (no request_logs_v2 rows)", async () => {
+    const driver = new SqliteNativeDriver({ type: "sqlite", path: dbPath });
+    await driver.initialize({ logsEnabled: false });
+
+    const clientId = "metrics-only";
+    driver.insertLogPending({
+      timestamp: Date.now(),
+      providerId: "p1",
+      providerName: "P",
+      method: "POST",
+      path: "/v1/messages",
+      duration: 0,
+      success: false,
+      clientId,
+      model: "claude-3",
+      requestBody: '{"model":"claude-3"}',
+    });
+
+    driver.updateLogCompleted(
+      clientId,
+      200,
+      '{"usage":{"input_tokens":100,"output_tokens":50}}',
+      80,
+      true,
+      undefined,
+      undefined,
+      100,
+      50,
+      0,
+      30
+    );
+
+    const { logs, total } = await driver.queryLogs({ limit: 10 });
+    expect(total).toBe(0);
+    expect(logs).toHaveLength(0);
+
+    const stats = await driver.getStats();
+    expect(stats.totalInputTokens).toBe(100);
+    expect(stats.totalOutputTokens).toBe(50);
 
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/naming-convention
     const BetterSqlite3 = require("better-sqlite3") as typeof import("better-sqlite3");

--- a/web/src/features/dashboard/Dashboard.tsx
+++ b/web/src/features/dashboard/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Loader2, RotateCw } from "lucide-react";
+import { Loader2, RotateCw, Database } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { api } from "@/api/client";
@@ -87,6 +87,7 @@ export default function Dashboard() {
   };
 
   const provider = getProviderDisplay(status, t);
+  const dbUnavailable = !statsLoading && stats?.dbAvailable === false;
   const totalLogs = stats?.totalLogs ?? 0;
   const successCount = stats?.successCount ?? 0;
   const errorCount = stats?.errorCount ?? 0;
@@ -182,33 +183,41 @@ export default function Dashboard() {
                     <p className="text-[10px] text-muted-foreground mb-1">
                       {t("dashboard.totalRequests.title")}
                     </p>
-                    <p className="text-base font-semibold">{totalLogs}</p>
-                    {totalLogs > 0 ? (
+                    {dbUnavailable ? (
+                      <p className="text-base font-semibold text-muted-foreground">
+                        {t("common.na")}
+                      </p>
+                    ) : (
                       <>
-                        <p className="text-[10px] mt-0.5">
-                          <span className="text-green-600 dark:text-green-500">
-                            {successCount} {t("dashboard.totalRequests.success")}
-                          </span>
-                          {errorCount > 0 ? (
-                            <>
-                              <span className="text-muted-foreground mx-1">·</span>
-                              <span className="text-destructive">
-                                {errorCount} {t("dashboard.totalRequests.errors")}
+                        <p className="text-base font-semibold">{totalLogs}</p>
+                        {totalLogs > 0 ? (
+                          <>
+                            <p className="text-[10px] mt-0.5">
+                              <span className="text-green-600 dark:text-green-500">
+                                {successCount} {t("dashboard.totalRequests.success")}
                               </span>
-                            </>
-                          ) : null}
-                        </p>
-                        <div
-                          className="mt-1.5 h-1 rounded-full bg-muted overflow-hidden"
-                          role="presentation"
-                        >
-                          <div
-                            className="h-full bg-green-500 transition-[width]"
-                            style={{ width: `${successRate}%` }}
-                          />
-                        </div>
+                              {errorCount > 0 ? (
+                                <>
+                                  <span className="text-muted-foreground mx-1">·</span>
+                                  <span className="text-destructive">
+                                    {errorCount} {t("dashboard.totalRequests.errors")}
+                                  </span>
+                                </>
+                              ) : null}
+                            </p>
+                            <div
+                              className="mt-1.5 h-1 rounded-full bg-muted overflow-hidden"
+                              role="presentation"
+                            >
+                              <div
+                                className="h-full bg-green-500 transition-[width]"
+                                style={{ width: `${successRate}%` }}
+                              />
+                            </div>
+                          </>
+                        ) : null}
                       </>
-                    ) : null}
+                    )}
                   </div>
                 </div>
               </>
@@ -216,129 +225,141 @@ export default function Dashboard() {
           </CardContent>
         </Card>
 
-        <div className="grid gap-2 grid-cols-1 sm:grid-cols-2">
-          <Card className="p-0">
-            <CardHeader className="p-3 pb-2">
-              <CardTitle className="text-xs font-medium">
-                {t("dashboard.performance.title")}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="p-3 pt-0">
-              {statsLoading ? (
-                <div className="h-20 animate-pulse bg-muted rounded" />
-              ) : (
-                <div className="space-y-1.5">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-muted-foreground">
-                      {t("dashboard.performance.avgResponseTime")}
-                    </span>
-                    <span className="text-xs font-medium">
-                      {formatDuration(stats?.avgDuration || 0)}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-muted-foreground">
-                      {t("dashboard.performance.p50Latency")}
-                    </span>
-                    <span className="text-xs font-medium">
-                      {formatDuration(stats?.p50Duration || 0)}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-muted-foreground">
-                      {t("dashboard.performance.p90Latency")}
-                    </span>
-                    <span className="text-xs font-medium">
-                      {formatDuration(stats?.p90Duration || 0)}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span
-                      className="text-xs text-muted-foreground"
-                      title={t("dashboard.performance.avgTtfbTooltip")}
-                    >
-                      {t("dashboard.performance.avgTtfb")}
-                    </span>
-                    <span className="text-xs font-medium">
-                      {stats?.avgTtfb ? formatDuration(stats.avgTtfb) : "-"}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-muted-foreground">
-                      {t("dashboard.performance.successRate")}
-                    </span>
-                    <span className="text-xs font-medium">
-                      {stats?.totalLogs
-                        ? `${Math.round((stats.successCount / stats.totalLogs) * 100)}%`
-                        : t("common.na")}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span
-                      className="text-xs text-muted-foreground"
-                      title={t("dashboard.performance.outputTpsTooltip")}
-                    >
-                      {t("dashboard.performance.outputTps")}
-                    </span>
-                    <span className="text-xs font-medium">
-                      {stats?.outputTps ? `${stats.outputTps.toFixed(1)} t/s` : "-"}
-                    </span>
-                  </div>
-                </div>
-              )}
+        {dbUnavailable ? (
+          <Card className="p-0 lg:col-span-1">
+            <CardContent className="p-6 flex flex-col items-center justify-center text-center gap-2 min-h-[12rem]">
+              <Database className="h-8 w-8 text-muted-foreground" aria-hidden />
+              <p className="text-sm font-semibold">{t("dashboard.dbUnavailable.title")}</p>
+              <p className="text-xs text-muted-foreground max-w-sm">
+                {t("dashboard.dbUnavailable.description")}
+              </p>
             </CardContent>
           </Card>
+        ) : (
+          <div className="grid gap-2 grid-cols-1 sm:grid-cols-2 lg:col-span-1">
+            <Card className="p-0">
+              <CardHeader className="p-3 pb-2">
+                <CardTitle className="text-xs font-medium">
+                  {t("dashboard.performance.title")}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="p-3 pt-0">
+                {statsLoading ? (
+                  <div className="h-20 animate-pulse bg-muted rounded" />
+                ) : (
+                  <div className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">
+                        {t("dashboard.performance.avgResponseTime")}
+                      </span>
+                      <span className="text-xs font-medium">
+                        {formatDuration(stats?.avgDuration || 0)}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">
+                        {t("dashboard.performance.p50Latency")}
+                      </span>
+                      <span className="text-xs font-medium">
+                        {formatDuration(stats?.p50Duration || 0)}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">
+                        {t("dashboard.performance.p90Latency")}
+                      </span>
+                      <span className="text-xs font-medium">
+                        {formatDuration(stats?.p90Duration || 0)}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span
+                        className="text-xs text-muted-foreground"
+                        title={t("dashboard.performance.avgTtfbTooltip")}
+                      >
+                        {t("dashboard.performance.avgTtfb")}
+                      </span>
+                      <span className="text-xs font-medium">
+                        {stats?.avgTtfb ? formatDuration(stats.avgTtfb) : "-"}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">
+                        {t("dashboard.performance.successRate")}
+                      </span>
+                      <span className="text-xs font-medium">
+                        {stats?.totalLogs
+                          ? `${Math.round((stats.successCount / stats.totalLogs) * 100)}%`
+                          : t("common.na")}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span
+                        className="text-xs text-muted-foreground"
+                        title={t("dashboard.performance.outputTpsTooltip")}
+                      >
+                        {t("dashboard.performance.outputTps")}
+                      </span>
+                      <span className="text-xs font-medium">
+                        {stats?.outputTps ? `${stats.outputTps.toFixed(1)} t/s` : "-"}
+                      </span>
+                    </div>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
 
-          <Card className="p-0">
-            <CardHeader className="p-3 pb-2">
-              <CardTitle className="text-xs font-medium">{t("dashboard.tokens.title")}</CardTitle>
-            </CardHeader>
-            <CardContent className="p-3 pt-0">
-              {statsLoading ? (
-                <div className="h-20 animate-pulse bg-muted rounded" />
-              ) : (
-                <div className="space-y-1.5">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-muted-foreground">
-                      {t("dashboard.tokens.input")}
-                    </span>
-                    <span className="text-xs font-medium">
-                      {formatTokenCount(stats?.totalInputTokens || 0)}
-                    </span>
+            <Card className="p-0">
+              <CardHeader className="p-3 pb-2">
+                <CardTitle className="text-xs font-medium">{t("dashboard.tokens.title")}</CardTitle>
+              </CardHeader>
+              <CardContent className="p-3 pt-0">
+                {statsLoading ? (
+                  <div className="h-20 animate-pulse bg-muted rounded" />
+                ) : (
+                  <div className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">
+                        {t("dashboard.tokens.input")}
+                      </span>
+                      <span className="text-xs font-medium">
+                        {formatTokenCount(stats?.totalInputTokens || 0)}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">
+                        {t("dashboard.tokens.output")}
+                      </span>
+                      <span className="text-xs font-medium">
+                        {formatTokenCount(stats?.totalOutputTokens || 0)}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">
+                        {t("dashboard.tokens.cache")}
+                      </span>
+                      <span className="text-xs font-medium">
+                        {formatTokenCount(stats?.totalCacheTokens || 0)}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">
+                        {t("dashboard.tokens.cacheHitRate")}
+                      </span>
+                      <span className="text-xs font-medium">
+                        {stats?.cacheHitRate != null ? `${stats.cacheHitRate}%` : "-"}
+                      </span>
+                    </div>
                   </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-muted-foreground">
-                      {t("dashboard.tokens.output")}
-                    </span>
-                    <span className="text-xs font-medium">
-                      {formatTokenCount(stats?.totalOutputTokens || 0)}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-muted-foreground">
-                      {t("dashboard.tokens.cache")}
-                    </span>
-                    <span className="text-xs font-medium">
-                      {formatTokenCount(stats?.totalCacheTokens || 0)}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs text-muted-foreground">
-                      {t("dashboard.tokens.cacheHitRate")}
-                    </span>
-                    <span className="text-xs font-medium">
-                      {stats?.cacheHitRate != null ? `${stats.cacheHitRate}%` : "-"}
-                    </span>
-                  </div>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </div>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        )}
       </div>
 
       {/* Provider Breakdown */}
-      {stats?.providerBreakdown && stats.providerBreakdown.length > 0 && (
+      {!dbUnavailable && stats?.providerBreakdown && stats.providerBreakdown.length > 0 && (
         <Card className="p-0">
           <CardHeader className="p-3 pb-2">
             <CardTitle className="text-xs font-medium">

--- a/web/src/features/settings/Settings.tsx
+++ b/web/src/features/settings/Settings.tsx
@@ -1182,8 +1182,12 @@ function LoggingSection({ data }: { data: LoggingSettings }) {
       <Toggle
         checked={form.enabled}
         onChange={v => setForm(f => ({ ...f, enabled: v }))}
-        label="Enable request log storage"
+        label="Enable request/response body logging"
       />
+      <p className="text-[11px] text-muted-foreground -mt-1">
+        Token usage and performance metrics are always recorded when the database is available. This
+        toggle only controls storing full request and response bodies in the Logs tab.
+      </p>
       <Field label="Database type">
         <SelectField
           value={db.type}

--- a/web/src/features/smart-routing/SmartRouting.tsx
+++ b/web/src/features/smart-routing/SmartRouting.tsx
@@ -9,6 +9,7 @@ import {
   Plus,
   RefreshCw,
   Route,
+  ShieldCheck,
   Trash2,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -73,6 +74,10 @@ function modelRulesForPersist(rules: SmartRoutingModelRule[]): SmartRoutingModel
   return rules.filter(r => r.pattern.trim() && r.provider.trim() && r.model.trim());
 }
 
+function isIncompleteRule(r: SmartRoutingModelRule): boolean {
+  return !(r.pattern.trim() && r.provider.trim() && r.model.trim());
+}
+
 function emptyModelRule(): SmartRoutingModelRule {
   return { pattern: "", provider: "", model: "", enabled: true };
 }
@@ -110,6 +115,8 @@ export default function SmartRouting() {
   const [pendingDrifts, setPendingDrifts] = useState<AliasDrift[]>([]);
   const [driftChoices, setDriftChoices] = useState<Record<string, DriftChoice>>({});
   const [pendingCoreSettings, setPendingCoreSettings] = useState<CoreSettingsDraft | null>(null);
+  const [validateOk, setValidateOk] = useState(false);
+  const validateOkTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { data: config, isLoading: configLoading } = useQuery({
     queryKey: ["config"],
@@ -149,9 +156,9 @@ export default function SmartRouting() {
     mutationFn: (data: Record<string, unknown>) =>
       api.patchConfig({ section: "smartRouting", data }),
     onSuccess: async () => {
-      setModelRulesOverride(null);
-      setExcludeOverride(null);
       await queryClient.invalidateQueries({ queryKey: ["config"] });
+      setExcludeOverride(null);
+      setModelRulesOverride(prev => (prev && prev.some(isIncompleteRule) ? prev : null));
     },
   });
 
@@ -181,6 +188,9 @@ export default function SmartRouting() {
     return () => {
       if (modelRulesSaveTimer.current) {
         clearTimeout(modelRulesSaveTimer.current);
+      }
+      if (validateOkTimer.current) {
+        clearTimeout(validateOkTimer.current);
       }
     };
   }, []);
@@ -313,6 +323,30 @@ export default function SmartRouting() {
     mutationFn: () => api.refreshSmartRoutingCatalog(),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["smartRoutingCatalog"] });
+    },
+  });
+
+  const validateMutation = useMutation({
+    mutationFn: () => api.getSmartRoutingAliasDrift(),
+    onSuccess: ({ drifts }) => {
+      if (drifts.length > 0) {
+        setPendingDrifts(drifts);
+        const initial: Record<string, DriftChoice> = {};
+        for (const d of drifts) {
+          initial[driftKey(d)] = d.collision ? "update" : "keep";
+        }
+        setDriftChoices(initial);
+        setPendingCoreSettings(null);
+        setDriftOpen(true);
+        return;
+      }
+      setValidateOk(true);
+      if (validateOkTimer.current) {
+        clearTimeout(validateOkTimer.current);
+      }
+      validateOkTimer.current = setTimeout(() => {
+        setValidateOk(false);
+      }, 2500);
     },
   });
 
@@ -585,6 +619,26 @@ export default function SmartRouting() {
                 {totalEntries} {t("smartRouting.catalog.models")}
               </Badge>
             )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-[10px]"
+              disabled={validateMutation.isPending}
+              onClick={() => validateMutation.mutate()}
+            >
+              {validateMutation.isPending ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <ShieldCheck className="h-3 w-3" />
+              )}
+              <span className="ml-1">{t("smartRouting.catalog.validate")}</span>
+            </Button>
+            {validateOk ? (
+              <span className="text-[10px] text-green-600 dark:text-green-500">
+                {t("smartRouting.catalog.allAligned")}
+              </span>
+            ) : null}
             <Button
               type="button"
               variant="ghost"

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -89,6 +89,10 @@
       "30d": "30d",
       "all": "All"
     },
+    "dbUnavailable": {
+      "title": "Statistics unavailable",
+      "description": "The local database could not be opened. Token and performance metrics cannot be recorded or displayed. Install sqlite3 on your PATH, or use the Desktop app which includes a built-in database engine."
+    },
     "providerBreakdown": {
       "title": "Provider Breakdown",
       "provider": "Provider",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -289,7 +289,10 @@
       "protocol": "Protocol",
       "source": "Source",
       "excluded": "Excluded",
-      "reload": "Reload view"
+      "reload": "Reload view",
+      "validate": "Validate aliases",
+      "validating": "Validating",
+      "allAligned": "All aliases aligned"
     },
     "providerErrors": {
       "title": "Some providers failed to fetch models",

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -289,7 +289,10 @@
       "protocol": "协议",
       "source": "来源",
       "excluded": "排除",
-      "reload": "重新加载"
+      "reload": "重新加载",
+      "validate": "校验别名",
+      "validating": "校验中",
+      "allAligned": "别名均已对齐"
     },
     "providerErrors": {
       "title": "部分供应商拉取模型失败",

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -89,6 +89,10 @@
       "30d": "30天",
       "all": "全部"
     },
+    "dbUnavailable": {
+      "title": "统计数据不可用",
+      "description": "无法打开本地数据库，Token 与性能指标无法记录或展示。请在 PATH 中安装 sqlite3，或使用内置数据库引擎的 Desktop 版本。"
+    },
     "providerBreakdown": {
       "title": "提供商分布",
       "provider": "提供商",

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -37,6 +37,7 @@ export interface ServerStatus {
   providerMode: "inject" | "passthrough" | null;
   port: number;
   host: string;
+  dbAvailable?: boolean;
 }
 
 export interface SwitchRequest {
@@ -181,6 +182,7 @@ export interface ProviderBreakdownRow {
 }
 
 export interface LogStats {
+  dbAvailable?: boolean;
   totalLogs: number;
   successCount: number;
   errorCount: number;


### PR DESCRIPTION
## Summary

- **Token metrics decoupled from body logging**: Dashboard token/performance stats are always recorded when the local database is available; `logging.enabled` only controls the Logs tab and stored request/response bodies. Extension shows a clear unavailable state when sqlite3 CLI is missing; Desktop keeps using the built-in native SQLite engine.
- **Smart Routing UI**: Validate button and custom rule draft persistence fixes on the Smart Routing settings page.
- **Release line**: 0.2.6 pre-release version bump across the monorepo.

## Test plan

- [ ] Start proxy with `logging.enabled: false` — Dashboard token stats update after LLM requests; Logs tab hidden and no body rows in DB
- [ ] Start proxy with `logging.enabled: true` — Logs tab works; metrics and bodies both persist
- [ ] VS Code extension without sqlite3 on PATH — Dashboard shows database unavailable message
- [ ] Desktop app — metrics persist without sqlite3 CLI installed
- [ ] Smart Routing: edit a custom rule, navigate away and back — draft values persist; Validate button works
- [ ] `npm test` and CI green


Made with [Cursor](https://cursor.com)