### PR TITLE
fix: strip Claude billing header to preserve prompt caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Clearing all logs also clears token metrics, so dashboard statistics stay consistent with log storage.
 
+### Fixed
+
+**Protocol/Conversion**
+
+- Relaying requests from Claude or Cowork now removes volatile billing metadata injected into the system prompt, so prompt caching on upstream Anthropic-compatible providers is not invalidated on every request.
+
 ## [0.2.6] - 2026-06-16 (pre-release)
 
 Pre-release line for 0.2.6.

--- a/packages/core/src/converter/anthropic-request-sanitize.ts
+++ b/packages/core/src/converter/anthropic-request-sanitize.ts
@@ -1,0 +1,83 @@
+/**
+ * Strip Claude/Cowork-injected billing header blocks from Anthropic request bodies.
+ * These volatile system blocks break prompt caching prefixes when cc_version/cch change.
+ */
+
+/** Entire block must be a `key=value;` sequence — no trailing real prompt content. */
+const BILLING_HEADER_FULL_RE = /^x-anthropic-billing-header:\s*(?:[a-z0-9_]+\s*=\s*[^;]*;\s*)+$/i;
+
+export function isBillingHeaderBlock(text: unknown): boolean {
+  if (typeof text !== "string") {
+    return false;
+  }
+  const t = text.trim();
+  if (!BILLING_HEADER_FULL_RE.test(t)) {
+    return false;
+  }
+  return /\bcc_version\s*=/i.test(t) || /\bcch\s*=/i.test(t);
+}
+
+function isBillingHeaderSystemBlock(block: unknown): boolean {
+  if (!block || typeof block !== "object") {
+    return false;
+  }
+  const b = block as Record<string, unknown>;
+  if (b.type !== "text") {
+    return false;
+  }
+  return isBillingHeaderBlock(b.text);
+}
+
+/**
+ * Remove pure billing-header system blocks from an Anthropic Messages API body.
+ * Returns the original buffer when nothing changes.
+ */
+export function stripBillingHeaderFromAnthropicBody(body: Buffer): Buffer {
+  if (!body || body.length === 0) {
+    return body;
+  }
+
+  let data: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(body.toString("utf-8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return body;
+    }
+    data = parsed as Record<string, unknown>;
+  } catch {
+    return body;
+  }
+
+  const system = data.system;
+  if (system === undefined) {
+    return body;
+  }
+
+  let changed = false;
+
+  if (Array.isArray(system)) {
+    const filtered = system.filter(block => {
+      if (isBillingHeaderSystemBlock(block)) {
+        changed = true;
+        return false;
+      }
+      return true;
+    });
+    if (changed) {
+      if (filtered.length === 0) {
+        delete data.system;
+      } else {
+        data.system = filtered;
+      }
+    }
+  } else if (typeof system === "string" && isBillingHeaderBlock(system)) {
+    delete data.system;
+    changed = true;
+  }
+
+  if (!changed) {
+    return body;
+  }
+
+  return Buffer.from(JSON.stringify(data), "utf-8");
+}

--- a/packages/core/src/converter/index.ts
+++ b/packages/core/src/converter/index.ts
@@ -179,3 +179,8 @@ export {
   openaiChatUsesMaxCompletionTokens,
   type OpenAiChatMaxOutputTarget,
 } from "./rules/openai-chat-model-rules";
+
+export {
+  stripBillingHeaderFromAnthropicBody,
+  isBillingHeaderBlock,
+} from "./anthropic-request-sanitize";

--- a/packages/core/src/server/request/bodyProcessor.ts
+++ b/packages/core/src/server/request/bodyProcessor.ts
@@ -13,6 +13,7 @@ import {
   isOpenAIResponsesRequest,
   mapAnthropicWirePathToOpenAiUpstream,
   mapOpenAiWirePathToAnthropicUpstream,
+  stripBillingHeaderFromAnthropicBody,
   type ResponsesRequestEcho,
 } from "../../converter";
 import type { OpenAIMessage } from "../../converter/adapters/anthropic-to-openai-chat-request";
@@ -198,6 +199,10 @@ export class BodyProcessor {
 
     const clientWireModel = extractClientWireModel(rawBody);
     let body = applyModelMapping(rawBody, routing.provider);
+
+    if (clientSurface === "anthropic") {
+      body = stripBillingHeaderFromAnthropicBody(body);
+    }
 
     let upstreamResponseFormat: string | undefined;
 

--- a/tests/unit/converter/anthropic-request-sanitize.test.ts
+++ b/tests/unit/converter/anthropic-request-sanitize.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import {
+  stripBillingHeaderFromAnthropicBody,
+  isBillingHeaderBlock,
+} from "@/converter/anthropic-request-sanitize";
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
+const BILLING_TEXT =
+  "x-anthropic-billing-header: cc_version=2.1.177.e2d; cc_entrypoint=local-agent; cch=c76d1;";
+
+describe("converter: anthropic-request-sanitize", () => {
+  describe("isBillingHeaderBlock", () => {
+    it("matches pure billing header with dynamic cc_version and cch", () => {
+      expect(isBillingHeaderBlock(BILLING_TEXT)).toBe(true);
+      expect(
+        isBillingHeaderBlock(
+          "x-anthropic-billing-header: cc_version=9.9.999.abc; cc_entrypoint=local-agent; cch=deadbeef;"
+        )
+      ).toBe(true);
+    });
+
+    it("rejects header prefix followed by real content", () => {
+      expect(isBillingHeaderBlock(`${BILLING_TEXT}\nYou are a helpful assistant.`)).toBe(false);
+      expect(isBillingHeaderBlock(`${BILLING_TEXT} extra instructions`)).toBe(false);
+    });
+
+    it("rejects key=value shape without cc_version or cch", () => {
+      expect(isBillingHeaderBlock("x-anthropic-billing-header: cc_entrypoint=local-agent;")).toBe(
+        false
+      );
+    });
+
+    it("rejects non-string input", () => {
+      expect(isBillingHeaderBlock(null)).toBe(false);
+      expect(isBillingHeaderBlock(42)).toBe(false);
+    });
+  });
+
+  describe("stripBillingHeaderFromAnthropicBody", () => {
+    it("removes billing block from system array and preserves other blocks", () => {
+      const input = {
+        model: "claude-3",
+        max_tokens: 1024,
+        messages: [{ role: "user", content: "hi" }],
+        system: [
+          { type: "text", text: BILLING_TEXT },
+          {
+            type: "text",
+            text: "You are a Claude agent.",
+            cache_control: { type: "ephemeral", ttl: "1h" },
+          },
+        ],
+      };
+      const body = Buffer.from(JSON.stringify(input), "utf-8");
+      const out = stripBillingHeaderFromAnthropicBody(body);
+      const parsed = JSON.parse(out.toString("utf-8")) as typeof input;
+
+      expect(parsed.system).toHaveLength(1);
+      expect(parsed.system?.[0]).toEqual({
+        type: "text",
+        text: "You are a Claude agent.",
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      });
+    });
+
+    it("deletes system field when billing block is the only entry", () => {
+      const input = {
+        model: "claude-3",
+        max_tokens: 1024,
+        messages: [{ role: "user", content: "hi" }],
+        system: [{ type: "text", text: BILLING_TEXT }],
+      };
+      const body = Buffer.from(JSON.stringify(input), "utf-8");
+      const out = stripBillingHeaderFromAnthropicBody(body);
+      const parsed = JSON.parse(out.toString("utf-8")) as Record<string, unknown>;
+
+      expect(parsed.system).toBeUndefined();
+    });
+
+    it("returns original buffer when no billing block is present", () => {
+      const input = {
+        model: "claude-3",
+        max_tokens: 1024,
+        messages: [{ role: "user", content: "hi" }],
+        system: [{ type: "text", text: "You are helpful." }],
+      };
+      const body = Buffer.from(JSON.stringify(input), "utf-8");
+      const out = stripBillingHeaderFromAnthropicBody(body);
+
+      expect(out).toBe(body);
+    });
+
+    it("does not remove block that starts with billing header but includes real content", () => {
+      const mixed = `${BILLING_TEXT}\nReal system instructions here.`;
+      const input = {
+        model: "claude-3",
+        max_tokens: 1024,
+        messages: [{ role: "user", content: "hi" }],
+        system: [{ type: "text", text: mixed }],
+      };
+      const body = Buffer.from(JSON.stringify(input), "utf-8");
+      const out = stripBillingHeaderFromAnthropicBody(body);
+
+      expect(out).toBe(body);
+    });
+
+    it("removes string system when entire string is billing header", () => {
+      const input = {
+        model: "claude-3",
+        max_tokens: 1024,
+        messages: [{ role: "user", content: "hi" }],
+        system: BILLING_TEXT,
+      };
+      const body = Buffer.from(JSON.stringify(input), "utf-8");
+      const out = stripBillingHeaderFromAnthropicBody(body);
+      const parsed = JSON.parse(out.toString("utf-8")) as Record<string, unknown>;
+
+      expect(parsed.system).toBeUndefined();
+    });
+
+    it("does not strip string system when billing header is followed by real content", () => {
+      const input = {
+        model: "claude-3",
+        max_tokens: 1024,
+        messages: [{ role: "user", content: "hi" }],
+        system: `${BILLING_TEXT}\nReal prompt`,
+      };
+      const body = Buffer.from(JSON.stringify(input), "utf-8");
+      const out = stripBillingHeaderFromAnthropicBody(body);
+
+      expect(out).toBe(body);
+    });
+
+    it("returns original buffer for invalid JSON", () => {
+      const body = Buffer.from("not-json", "utf-8");
+      expect(stripBillingHeaderFromAnthropicBody(body)).toBe(body);
+    });
+
+    it("returns original buffer when system field is absent", () => {
+      const input = {
+        model: "claude-3",
+        max_tokens: 1024,
+        messages: [{ role: "user", content: "hi" }],
+      };
+      const body = Buffer.from(JSON.stringify(input), "utf-8");
+      expect(stripBillingHeaderFromAnthropicBody(body)).toBe(body);
+    });
+  });
+});

--- a/tests/unit/server/request/bodyProcessor.billingHeader.test.ts
+++ b/tests/unit/server/request/bodyProcessor.billingHeader.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { BodyProcessor } from "@/server/request/bodyProcessor";
+import type { RoutingContext } from "@/server/request/context";
+import type { Provider } from "@/types";
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
+const BILLING_TEXT =
+  "x-anthropic-billing-header: cc_version=2.1.177.e2d; cc_entrypoint=local-agent; cch=c76d1;";
+
+describe("BodyProcessor billing header sanitization", () => {
+  const anthropicUpstream: Provider = {
+    id: "official",
+    name: "Official",
+    baseUrl: "https://api.anthropic.com",
+    mode: "passthrough",
+    providerType: "anthropic",
+    apiKey: "sk",
+  };
+
+  const openaiUpstream: Provider = {
+    id: "mimo",
+    name: "Mimo",
+    baseUrl: "https://example.com/v1",
+    mode: "passthrough",
+    providerType: "openai_chat",
+    apiKey: "sk",
+  };
+
+  function makeAnthropicRequestBody(): Buffer {
+    return Buffer.from(
+      JSON.stringify({
+        model: "claude-3-5-sonnet-20241022",
+        max_tokens: 1024,
+        messages: [{ role: "user", content: "hello" }],
+        system: [
+          { type: "text", text: BILLING_TEXT },
+          { type: "text", text: "You are a Claude agent." },
+        ],
+      }),
+      "utf-8"
+    );
+  }
+
+  function makeRouting(overrides: Partial<RoutingContext>): RoutingContext {
+    return {
+      blocked: false,
+      method: "POST",
+      path: "/anthropic/v1/messages",
+      provider: anthropicUpstream,
+      clientHeaders: {},
+      headers: {},
+      targetUrl: "https://api.anthropic.com/v1/messages",
+      targetPath: "/v1/messages",
+      targetQuery: "",
+      isRouted: false,
+      isOpenAIProvider: false,
+      clientSurface: "anthropic",
+      ...overrides,
+    };
+  }
+
+  it("strips billing header on anthropic -> anthropic passthrough", () => {
+    const routing = makeRouting({ provider: anthropicUpstream });
+    const proc = new BodyProcessor();
+    const result = proc.process(makeAnthropicRequestBody(), routing, false);
+
+    const parsed = JSON.parse(result.body.toString("utf-8")) as {
+      system?: { text: string }[];
+    };
+    expect(parsed.system).toHaveLength(1);
+    expect(parsed.system?.[0].text).toBe("You are a Claude agent.");
+    expect(JSON.stringify(parsed)).not.toContain("x-anthropic-billing-header");
+  });
+
+  it("strips billing header on anthropic -> openai conversion", () => {
+    const routing = makeRouting({
+      provider: openaiUpstream,
+      isOpenAIProvider: true,
+      targetUrl: "https://example.com/v1/v1/messages",
+    });
+    const proc = new BodyProcessor();
+    const result = proc.process(makeAnthropicRequestBody(), routing, false);
+
+    const parsed = JSON.parse(result.body.toString("utf-8")) as {
+      messages: { role: string; content: unknown }[];
+    };
+    expect(JSON.stringify(parsed)).not.toContain("x-anthropic-billing-header");
+    const systemMsg = parsed.messages.find(m => m.role === "system");
+    expect(systemMsg).toBeDefined();
+    if (Array.isArray(systemMsg?.content)) {
+      const texts = systemMsg.content.map((p: { text?: string }) => p.text);
+      expect(texts).toEqual(["You are a Claude agent."]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Remove volatile `x-anthropic-billing-header` system blocks injected by Claude/Cowork before relaying Anthropic requests, so upstream prompt caching is not busted on every request.
- Applies to both Anthropic→Anthropic passthrough and Anthropic→OpenAI conversion paths via a single sanitization step in BodyProcessor.
- Detection uses full-block matching plus `cc_version`/`cch` token checks to avoid false positives on real system prompt content.

## Test plan
- [x] Unit tests for sanitizer (match, false positives, array/string forms, invalid JSON)
- [x] BodyProcessor integration tests for A→A passthrough and A→O conversion
- [x] `npm run format` and `npm run lint` pass
- [ ] Manual: relay a Cowork/Claude Code request and confirm cache hit rate improves on upstream Anthropic-compatible provider


Made with [Cursor](https://cursor.com)