### PR TITLE
feat: log request/response headers with sensitive-value masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+**Logging**
+
+- Request logs now record the request and response headers alongside the bodies (shown in the log detail panel). Sensitive auth headers, such as API keys and Bearer tokens, are masked before storage so secrets are never written to the log database.
+
 ### Changed
 
 **UI**

--- a/packages/core/src/database/drivers/postgres/driver.ts
+++ b/packages/core/src/database/drivers/postgres/driver.ts
@@ -129,8 +129,9 @@ export class PostgresDriver implements DatabaseDriver {
         `INSERT INTO ${TABLE} (
         timestamp, provider_id, provider_name, method, path, target_url,
         request_body, response_body, original_request_body, original_response_body,
-        status_code, duration, success, error_message, client_id, status, route_type
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+        status_code, duration, success, error_message, client_id, status, route_type,
+        request_headers, response_headers
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
         [
           log.timestamp,
           log.providerId,
@@ -149,6 +150,8 @@ export class PostgresDriver implements DatabaseDriver {
           log.clientId ?? null,
           "completed",
           log.routeType ?? null,
+          log.requestHeaders ?? null,
+          null,
         ]
       );
     }
@@ -227,8 +230,9 @@ export class PostgresDriver implements DatabaseDriver {
         `INSERT INTO ${TABLE} (
         timestamp, provider_id, provider_name, method, path, target_url,
         request_body, response_body, original_request_body, original_response_body,
-        status_code, duration, success, error_message, client_id, status, route_type
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+        status_code, duration, success, error_message, client_id, status, route_type,
+        request_headers, response_headers
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
         [
           log.timestamp,
           log.providerId,
@@ -247,6 +251,8 @@ export class PostgresDriver implements DatabaseDriver {
           log.clientId ?? null,
           "pending",
           log.routeType ?? null,
+          log.requestHeaders ?? null,
+          null,
         ]
       );
     }
@@ -269,7 +275,8 @@ export class PostgresDriver implements DatabaseDriver {
     inputTokens?: number,
     outputTokens?: number,
     cacheTokens?: number,
-    ttfb?: number
+    ttfb?: number,
+    responseHeadersMasked?: string
   ): void {
     if (!this.isEnabled) {
       return;
@@ -286,8 +293,9 @@ export class PostgresDriver implements DatabaseDriver {
              duration = $4,
              success = $5,
              error_message = $6,
+             response_headers = $7,
              status = 'completed'
-         WHERE client_id = $7`,
+         WHERE client_id = $8`,
               [
                 statusCode,
                 utf8StringToBlob(responseBody),
@@ -295,6 +303,7 @@ export class PostgresDriver implements DatabaseDriver {
                 duration,
                 success,
                 utf8StringToBlob(errorMessage),
+                responseHeadersMasked ?? null,
                 clientId,
               ]
             ),
@@ -368,8 +377,9 @@ export class PostgresDriver implements DatabaseDriver {
             `INSERT INTO ${TABLE} (
             timestamp, provider_id, provider_name, method, path, target_url,
             request_body, response_body, original_request_body, original_response_body,
-            status_code, duration, success, error_message, client_id, status, route_type
-          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+            status_code, duration, success, error_message, client_id, status, route_type,
+            request_headers, response_headers
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
             [
               log.timestamp,
               log.providerId,
@@ -388,6 +398,8 @@ export class PostgresDriver implements DatabaseDriver {
               log.clientId ?? null,
               "completed",
               log.routeType ?? null,
+              log.requestHeaders ?? null,
+              null,
             ]
           );
         }

--- a/packages/core/src/database/drivers/sqlite/cli.ts
+++ b/packages/core/src/database/drivers/sqlite/cli.ts
@@ -1087,7 +1087,8 @@ export class SqliteCliDriver implements DatabaseDriver {
     inputTokens?: number,
     outputTokens?: number,
     cacheTokens?: number,
-    ttfb?: number
+    ttfb?: number,
+    responseHeadersMasked?: string
   ): void {
     if (!this.isEnabled || !this.writeConn?.started) {
       return;
@@ -1104,6 +1105,7 @@ export class SqliteCliDriver implements DatabaseDriver {
            duration = ?,
            success = ?,
            error_message = ?,
+           response_headers = ?,
            status = 'completed'
        WHERE client_id = ?`,
           [
@@ -1113,6 +1115,7 @@ export class SqliteCliDriver implements DatabaseDriver {
             duration,
             success ? 1 : 0,
             errorMessage ?? null,
+            responseHeadersMasked ?? null,
             clientId,
           ]
         )
@@ -1314,6 +1317,7 @@ export class SqliteCliDriver implements DatabaseDriver {
               hex(v.response_body) as response_body,
               hex(v.original_request_body) as original_request_body,
               hex(v.original_response_body) as original_response_body,
+              v.request_headers, v.response_headers,
               v.status_code, v.duration, v.success, v.error_message, v.client_id, v.status, v.route_type,
               m.input_tokens, m.output_tokens, m.cache_tokens, m.ttfb
        FROM ${TABLE} v

--- a/packages/core/src/database/drivers/sqlite/native.ts
+++ b/packages/core/src/database/drivers/sqlite/native.ts
@@ -185,7 +185,8 @@ export class SqliteNativeDriver implements DatabaseDriver {
     inputTokens?: number,
     outputTokens?: number,
     cacheTokens?: number,
-    ttfb?: number
+    ttfb?: number,
+    responseHeadersMasked?: string
   ): void {
     if (!this.isEnabled) {
       return;
@@ -200,6 +201,7 @@ export class SqliteNativeDriver implements DatabaseDriver {
             duration = ?,
             success = ?,
             error_message = ?,
+            response_headers = ?,
             status = 'completed'
         WHERE client_id = ?
       `);
@@ -210,6 +212,7 @@ export class SqliteNativeDriver implements DatabaseDriver {
           duration,
           success ? 1 : 0,
           errorMessage ?? null,
+          responseHeadersMasked ?? null,
           clientId
         );
       }

--- a/packages/core/src/database/drivers/sqlite/utils.ts
+++ b/packages/core/src/database/drivers/sqlite/utils.ts
@@ -27,8 +27,9 @@ export function buildInsertSql(
     sql: `INSERT INTO ${TABLE} (
       timestamp, provider_id, provider_name, method, path, target_url,
       request_body, response_body, original_request_body, original_response_body,
-      status_code, duration, success, error_message, client_id, status, route_type
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      status_code, duration, success, error_message, client_id, status, route_type,
+      request_headers, response_headers
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     params: [
       log.timestamp,
       log.providerId,
@@ -47,6 +48,8 @@ export function buildInsertSql(
       log.clientId ?? null,
       status,
       log.routeType ?? null,
+      log.requestHeaders ?? null,
+      null,
     ],
   };
 }

--- a/packages/core/src/database/migration.ts
+++ b/packages/core/src/database/migration.ts
@@ -469,6 +469,19 @@ export function runSqliteMigrations(ctx: SqliteMigrationContext): void {
     applied = true;
   }
 
+  if (maxVersion < 3) {
+    logMigration(`Applying v3 add_headers${suffix}`);
+    if (!sqliteColumnExists(ctx.queryScalar, TABLE, "request_headers")) {
+      ctx.exec(`ALTER TABLE ${TABLE} ADD COLUMN request_headers TEXT`);
+    }
+    if (!sqliteColumnExists(ctx.queryScalar, TABLE, "response_headers")) {
+      ctx.exec(`ALTER TABLE ${TABLE} ADD COLUMN response_headers TEXT`);
+    }
+    sqliteRecordMigration(ctx.exec, 3, "add_headers");
+    logMigration(`v3 add_headers applied${suffix}`);
+    applied = true;
+  }
+
   if (!applied) {
     logMigration(`Schema up to date (version ${maxVersion})${suffix}`);
   } else {
@@ -549,6 +562,25 @@ export async function runSqliteMigrationsAsync(ctx: SqliteMigrationAsyncContext)
       logMigration(`Token columns already absent on ${TABLE}${suffix}`);
     }
     logMigration(`v2 split_metrics applied${suffix}`);
+    applied = true;
+  }
+
+  if (maxVersion < 3) {
+    logMigration(`Applying v3 add_headers${suffix}`);
+    const headerColExists = async (col: string): Promise<boolean> =>
+      ((await ctx.queryScalar(
+        `SELECT COUNT(*) as c FROM pragma_table_info('${TABLE}') WHERE name='${col}'`
+      )) ?? 0) > 0;
+    if (!(await headerColExists("request_headers"))) {
+      await ctx.exec(`ALTER TABLE ${TABLE} ADD COLUMN request_headers TEXT`);
+    }
+    if (!(await headerColExists("response_headers"))) {
+      await ctx.exec(`ALTER TABLE ${TABLE} ADD COLUMN response_headers TEXT`);
+    }
+    await ctx.exec(
+      `INSERT OR REPLACE INTO ${MIGRATIONS_TABLE} (version, name, applied_at) VALUES (3, 'add_headers', ${Date.now()})`
+    );
+    logMigration(`v3 add_headers applied${suffix}`);
     applied = true;
   }
 
@@ -655,6 +687,26 @@ export async function runPostgresMigrations(ctx: PostgresMigrationContext): Prom
     await runMigrationV2SplitMetricsPostgres(ctx);
     await postgresRecordMigration(ctx.query, 2, "split_metrics");
     logMigration(`v2 split_metrics applied (dropped token columns from ${TABLE})${suffix}`);
+    applied = true;
+  }
+
+  if (maxVersion < 3) {
+    logMigration(`Applying v3 add_headers${suffix}`);
+    const headerColExists = async (col: string): Promise<boolean> => {
+      const res = (await ctx.query(
+        `SELECT COUNT(*)::int as c FROM information_schema.columns WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2`,
+        [TABLE, col]
+      )) as { rows: Array<{ c: number }> };
+      return (res.rows[0]?.c ?? 0) > 0;
+    };
+    if (!(await headerColExists("request_headers"))) {
+      await ctx.query(`ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS request_headers TEXT`);
+    }
+    if (!(await headerColExists("response_headers"))) {
+      await ctx.query(`ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS response_headers TEXT`);
+    }
+    await postgresRecordMigration(ctx.query, 3, "add_headers");
+    logMigration(`v3 add_headers applied${suffix}`);
     applied = true;
   }
 

--- a/packages/core/src/database/schema.ts
+++ b/packages/core/src/database/schema.ts
@@ -31,7 +31,9 @@ export const SQLITE_CREATE_TABLE_V2 = `
     input_tokens INTEGER,
     output_tokens INTEGER,
     cache_tokens INTEGER,
-    ttfb INTEGER
+    ttfb INTEGER,
+    request_headers TEXT,
+    response_headers TEXT
   )
 `;
 
@@ -64,7 +66,9 @@ export const SQLITE_CREATE_TABLE_V2_FINAL = `
     error_message TEXT,
     client_id TEXT,
     status TEXT DEFAULT 'completed',
-    route_type TEXT
+    route_type TEXT,
+    request_headers TEXT,
+    response_headers TEXT
   )
 `;
 
@@ -125,7 +129,9 @@ export const POSTGRES_CREATE_TABLE_V2 = `
     input_tokens INTEGER,
     output_tokens INTEGER,
     cache_tokens INTEGER,
-    ttfb INTEGER
+    ttfb INTEGER,
+    request_headers TEXT,
+    response_headers TEXT
   )
 `;
 
@@ -157,7 +163,9 @@ export const POSTGRES_CREATE_TABLE_V2_FINAL = `
     error_message TEXT,
     client_id TEXT,
     status TEXT DEFAULT 'completed',
-    route_type TEXT
+    route_type TEXT,
+    request_headers TEXT,
+    response_headers TEXT
   )
 `;
 

--- a/packages/core/src/database/shared-utils.ts
+++ b/packages/core/src/database/shared-utils.ts
@@ -118,6 +118,23 @@ function bodyFieldToString(raw: unknown): string | undefined {
 }
 
 /**
+ * Read a masked-JSON header column (TEXT). Stored as a plain string; Buffer is
+ * handled defensively. Empty/missing values collapse to undefined.
+ */
+function headerFieldToString(raw: unknown): string | undefined {
+  if (raw === null || raw === undefined) {
+    return undefined;
+  }
+  if (Buffer.isBuffer(raw) || raw instanceof Uint8Array) {
+    return blobToUtf8String(raw);
+  }
+  if (typeof raw === "string") {
+    return raw.length > 0 ? raw : undefined;
+  }
+  return undefined;
+}
+
+/**
  * Populate model/mappedModel from stored bodies.
  */
 export function extractModelsFromBodies(
@@ -216,6 +233,8 @@ export function dbRowToLog(row: Record<string, unknown>): RequestLog {
     responseBody: bodyFieldToString(row.response_body),
     originalRequestBody: bodyFieldToString(row.original_request_body),
     originalResponseBody: bodyFieldToString(row.original_response_body),
+    requestHeaders: headerFieldToString(row.request_headers),
+    responseHeaders: headerFieldToString(row.response_headers),
     statusCode: row.status_code as number | undefined,
     duration: row.duration as number,
     success: (row.success as number) !== 0,

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -41,6 +41,10 @@ export interface RequestLog {
   outputTokens?: number;
   cacheTokens?: number;
   ttfb?: number;
+  /** Masked JSON string of upstream-bound request headers (sensitive values masked). */
+  requestHeaders?: string;
+  /** Masked JSON string of upstream response headers (sensitive values masked). */
+  responseHeaders?: string;
 }
 
 /**
@@ -186,7 +190,8 @@ export interface DatabaseDriver {
     inputTokens?: number,
     outputTokens?: number,
     cacheTokens?: number,
-    ttfb?: number
+    ttfb?: number,
+    responseHeadersMasked?: string
   ): void;
 
   /**

--- a/packages/core/src/database/worker/client.ts
+++ b/packages/core/src/database/worker/client.ts
@@ -309,7 +309,8 @@ export class DatabaseWorkerClient implements DatabaseDriver {
     inputTokens?: number,
     outputTokens?: number,
     cacheTokens?: number,
-    ttfb?: number
+    ttfb?: number,
+    responseHeadersMasked?: string
   ): void {
     void this.send("updateLogCompleted", {
       clientId,
@@ -323,6 +324,7 @@ export class DatabaseWorkerClient implements DatabaseDriver {
       outputTokens,
       cacheTokens,
       ttfb,
+      responseHeadersMasked,
     }).catch(err => {
       this.log.error("[DatabaseWorker] updateLogCompleted error:", err);
     });

--- a/packages/core/src/database/worker/worker.ts
+++ b/packages/core/src/database/worker/worker.ts
@@ -131,6 +131,7 @@ async function handleMessage(message: WorkerMessage): Promise<WorkerResponse> {
           outputTokens?: number;
           cacheTokens?: number;
           ttfb?: number;
+          responseHeadersMasked?: string;
         };
         driver?.updateLogCompleted(
           p.clientId,
@@ -143,7 +144,8 @@ async function handleMessage(message: WorkerMessage): Promise<WorkerResponse> {
           p.inputTokens,
           p.outputTokens,
           p.cacheTokens,
-          p.ttfb
+          p.ttfb,
+          p.responseHeadersMasked
         );
         return { id, success: true };
       }

--- a/packages/core/src/server/headerMask.ts
+++ b/packages/core/src/server/headerMask.ts
@@ -1,0 +1,68 @@
+/**
+ * Header masking for request-log persistence.
+ *
+ * Headers may carry secrets (auth tokens). Before storing request/response headers
+ * in the log database, sensitive header values are masked: keep the first 4 and
+ * last 4 characters, replace the middle with "***". Auth scheme prefixes
+ * (`Bearer `, `Basic `) are preserved and only the credential is masked.
+ */
+
+/** Header names whose values must be masked before logging (compared case-insensitively). */
+export const SENSITIVE_HEADER_NAMES = new Set([
+  "authorization",
+  "x-api-key",
+  "proxy-authorization",
+]);
+
+/** Fully masked placeholder for secrets too short to safely show first/last 4. */
+const FULL_MASK = "********";
+
+/**
+ * Mask a single secret value: keep first 4 + last 4, middle becomes "***".
+ * Values of length <= 8 are fully masked (first4+last4 would leak most of a short secret).
+ * A leading auth scheme token (`Bearer <token>`, `Basic <token>`) is preserved.
+ */
+export function maskSecretValue(value: string): string {
+  if (value.length <= 8) {
+    return FULL_MASK;
+  }
+  const spaceIdx = value.indexOf(" ");
+  if (spaceIdx > 0 && spaceIdx < value.length - 1) {
+    const scheme = value.slice(0, spaceIdx + 1);
+    const credential = value.slice(spaceIdx + 1);
+    if (credential.length <= 8) {
+      return `${scheme}${FULL_MASK}`;
+    }
+    return `${scheme}${credential.slice(0, 4)}***${credential.slice(-4)}`;
+  }
+  return `${value.slice(0, 4)}***${value.slice(-4)}`;
+}
+
+/**
+ * Build a masked, JSON-serializable copy of a header set for log storage.
+ * Returns `undefined` when there are no headers (stored as NULL).
+ *
+ * Accepts both string and string[] values (response headers such as `set-cookie`
+ * may be arrays). Sensitive header values are masked; all others pass through.
+ */
+export function maskHeadersForLog(
+  headers: Record<string, string | string[]> | undefined | null
+): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+  const keys = Object.keys(headers);
+  if (keys.length === 0) {
+    return undefined;
+  }
+  const out: Record<string, string | string[]> = {};
+  for (const key of keys) {
+    const value = headers[key];
+    if (SENSITIVE_HEADER_NAMES.has(key.toLowerCase())) {
+      out[key] = Array.isArray(value) ? value.map(v => maskSecretValue(v)) : maskSecretValue(value);
+    } else {
+      out[key] = value;
+    }
+  }
+  return JSON.stringify(out);
+}

--- a/packages/core/src/server/proxy/executor.ts
+++ b/packages/core/src/server/proxy/executor.ts
@@ -9,6 +9,7 @@ import * as http from "http";
 import * as https from "https";
 import * as url from "url";
 import { ScopedLogger } from "../../utils/logger";
+import { maskHeadersForLog } from "../headerMask";
 import { providerHasConfigurableModelMap } from "../../utils/model-map";
 import {
   convertAnthropicResponseToOpenAI,
@@ -133,6 +134,8 @@ interface ExecutionContext {
   /** When true, mirror upstream/client response bytes for metrics or body logging. */
   captureResponse: boolean;
   originalResponseBody?: string;
+  /** Masked JSON of upstream response headers, persisted on log completion. */
+  responseHeadersMasked?: string;
   clientDisconnected: boolean;
   /**
    * Set true once the upstream Readable emitted `'end'` (i.e. fully delivered the response).
@@ -615,6 +618,7 @@ export class ProxyExecutor {
         responseHeaders[key] = value;
       }
     }
+    ctx.responseHeadersMasked = maskHeadersForLog(responseHeaders);
 
     const isJsonResponse = proxyRes.headers["content-type"]?.includes("application/json");
 
@@ -933,7 +937,9 @@ export class ProxyExecutor {
         ctx.responseChunks,
         aborted ? "Client disconnected" : undefined,
         this.upstreamLogBody(upstreamLog),
-        ttfbForStreamLog(ctx, true)
+        ttfbForStreamLog(ctx, true),
+        undefined,
+        ctx.responseHeadersMasked
       );
       resolve({
         statusCode: aborted ? 499 : status,
@@ -1049,7 +1055,9 @@ export class ProxyExecutor {
         ctx.responseChunks,
         aborted ? "Client disconnected" : undefined,
         this.upstreamLogBody(upstreamLog),
-        ttfbForStreamLog(ctx, true)
+        ttfbForStreamLog(ctx, true),
+        undefined,
+        ctx.responseHeadersMasked
       );
 
       resolve({
@@ -1170,7 +1178,9 @@ export class ProxyExecutor {
         ctx.responseChunks,
         err.message,
         upstreamBody,
-        ttfbForStreamLog(ctx, false)
+        ttfbForStreamLog(ctx, false),
+        undefined,
+        ctx.responseHeadersMasked
       );
 
       resolve({
@@ -1247,7 +1257,9 @@ export class ProxyExecutor {
           ctx.responseChunks,
           undefined,
           ctx.originalResponseBody,
-          ttfbForStreamLog(ctx, false)
+          ttfbForStreamLog(ctx, false),
+          undefined,
+          ctx.responseHeadersMasked
         );
 
         resolve({
@@ -1280,7 +1292,9 @@ export class ProxyExecutor {
           ctx.responseChunks,
           `OpenAI conversion failed: ${errMsg}`,
           ctx.originalResponseBody,
-          ttfbForStreamLog(ctx, false)
+          ttfbForStreamLog(ctx, false),
+          undefined,
+          ctx.responseHeadersMasked
         );
 
         resolve({
@@ -1346,7 +1360,9 @@ export class ProxyExecutor {
           ctx.responseChunks,
           undefined,
           ctx.originalResponseBody,
-          ttfbForStreamLog(ctx, false)
+          ttfbForStreamLog(ctx, false),
+          undefined,
+          ctx.responseHeadersMasked
         );
 
         resolve({
@@ -1379,7 +1395,9 @@ export class ProxyExecutor {
           ctx.responseChunks,
           `Responses conversion failed: ${errMsg}`,
           ctx.originalResponseBody,
-          ttfbForStreamLog(ctx, false)
+          ttfbForStreamLog(ctx, false),
+          undefined,
+          ctx.responseHeadersMasked
         );
 
         resolve({
@@ -1440,7 +1458,9 @@ export class ProxyExecutor {
             ctx.responseChunks,
             undefined,
             ctx.originalResponseBody,
-            ttfbForStreamLog(ctx, false)
+            ttfbForStreamLog(ctx, false),
+            undefined,
+            ctx.responseHeadersMasked
           );
           resolve({
             statusCode: status,
@@ -1460,7 +1480,9 @@ export class ProxyExecutor {
             ctx.responseChunks,
             undefined,
             ctx.originalResponseBody,
-            ttfbForStreamLog(ctx, false)
+            ttfbForStreamLog(ctx, false),
+            undefined,
+            ctx.responseHeadersMasked
           );
           resolve({
             statusCode: status,
@@ -1489,7 +1511,9 @@ export class ProxyExecutor {
           ctx.responseChunks,
           `Anthropic to OpenAI conversion failed: ${errMsg}`,
           ctx.originalResponseBody,
-          ttfbForStreamLog(ctx, false)
+          ttfbForStreamLog(ctx, false),
+          undefined,
+          ctx.responseHeadersMasked
         );
         resolve({
           statusCode: 502,
@@ -1566,7 +1590,9 @@ export class ProxyExecutor {
             ctx.responseChunks,
             undefined,
             ctx.originalResponseBody,
-            ttfbForStreamLog(ctx, false)
+            ttfbForStreamLog(ctx, false),
+            undefined,
+            ctx.responseHeadersMasked
           );
           resolve({
             statusCode: status,
@@ -1586,7 +1612,9 @@ export class ProxyExecutor {
             ctx.responseChunks,
             undefined,
             ctx.originalResponseBody,
-            ttfbForStreamLog(ctx, false)
+            ttfbForStreamLog(ctx, false),
+            undefined,
+            ctx.responseHeadersMasked
           );
           resolve({
             statusCode: status,
@@ -1611,7 +1639,9 @@ export class ProxyExecutor {
           ctx.responseChunks,
           `Chat to Responses failed: ${errMsg}`,
           ctx.originalResponseBody,
-          ttfbForStreamLog(ctx, false)
+          ttfbForStreamLog(ctx, false),
+          undefined,
+          ctx.responseHeadersMasked
         );
         resolve({
           statusCode: 502,
@@ -1721,7 +1751,9 @@ export class ProxyExecutor {
         ctx.responseChunks,
         aborted ? "Client disconnected" : undefined,
         this.upstreamLogBody(upstreamLog),
-        ttfbForStreamLog(ctx, true)
+        ttfbForStreamLog(ctx, true),
+        undefined,
+        ctx.responseHeadersMasked
       );
 
       resolve({
@@ -1798,7 +1830,9 @@ export class ProxyExecutor {
             ctx.responseChunks,
             undefined,
             ctx.originalResponseBody,
-            ttfbForStreamLog(ctx, false)
+            ttfbForStreamLog(ctx, false),
+            undefined,
+            ctx.responseHeadersMasked
           );
           resolve({
             statusCode: status,
@@ -1818,7 +1852,9 @@ export class ProxyExecutor {
             ctx.responseChunks,
             undefined,
             ctx.originalResponseBody,
-            ttfbForStreamLog(ctx, false)
+            ttfbForStreamLog(ctx, false),
+            undefined,
+            ctx.responseHeadersMasked
           );
           resolve({
             statusCode: status,
@@ -1843,7 +1879,9 @@ export class ProxyExecutor {
           ctx.responseChunks,
           `A to Responses failed: ${errMsg}`,
           ctx.originalResponseBody,
-          ttfbForStreamLog(ctx, false)
+          ttfbForStreamLog(ctx, false),
+          undefined,
+          ctx.responseHeadersMasked
         );
         resolve({
           statusCode: 502,
@@ -1929,7 +1967,9 @@ export class ProxyExecutor {
           ctx.responseChunks,
           "Client disconnected",
           undefined,
-          ttfbForStreamLog(ctx, false)
+          ttfbForStreamLog(ctx, false),
+          undefined,
+          ctx.responseHeadersMasked
         );
         resolve({
           statusCode: 499,
@@ -1982,7 +2022,9 @@ export class ProxyExecutor {
         ctx.responseChunks,
         undefined,
         undefined,
-        ttfbForStreamLog(ctx, false)
+        ttfbForStreamLog(ctx, false),
+        undefined,
+        ctx.responseHeadersMasked
       );
       resolve({
         statusCode: status,
@@ -2098,7 +2140,9 @@ export class ProxyExecutor {
         ctx.responseChunks,
         aborted ? "Client disconnected" : undefined,
         undefined,
-        ttfbForStreamLog(ctx, true)
+        ttfbForStreamLog(ctx, true),
+        undefined,
+        ctx.responseHeadersMasked
       );
       if (!aborted) {
         task.streamCompleted = true;
@@ -2300,7 +2344,9 @@ export class ProxyExecutor {
         ctx.responseChunks,
         undefined,
         undefined,
-        ttfbForStreamLog(ctx, false)
+        ttfbForStreamLog(ctx, false),
+        undefined,
+        ctx.responseHeadersMasked
       );
       resolve({
         statusCode: outStatus,
@@ -2353,7 +2399,9 @@ export class ProxyExecutor {
             ctx.responseChunks,
             undefined,
             undefined,
-            ttfbForStreamLog(ctx, true)
+            ttfbForStreamLog(ctx, true),
+            undefined,
+            ctx.responseHeadersMasked
           );
           resolve({
             statusCode: 200,
@@ -2374,7 +2422,9 @@ export class ProxyExecutor {
           ctx.responseChunks,
           "Client disconnected",
           undefined,
-          ttfbForStreamLog(ctx, false)
+          ttfbForStreamLog(ctx, false),
+          undefined,
+          ctx.responseHeadersMasked
         );
         resolve({
           statusCode: 499,

--- a/packages/core/src/server/request/index.ts
+++ b/packages/core/src/server/request/index.ts
@@ -205,6 +205,7 @@ export class RequestHandler {
     this.taskExecutor.insertPendingLog(routing, bodyResult, clientId, {
       routeType: intercepted.routeType,
       targetUrl: "service",
+      requestHeaders: routing.headers,
     });
 
     const responseWriter = new ResponseWriter(res);

--- a/packages/core/src/server/request/taskExecutor.ts
+++ b/packages/core/src/server/request/taskExecutor.ts
@@ -11,6 +11,7 @@ import type { QueueManager } from "../queueManager";
 import type { ProxyExecutor } from "../proxy/executor";
 import { ScopedLogger } from "../../utils/logger";
 import { extractModelFromPartialJson } from "../../database/shared-utils";
+import { maskHeadersForLog } from "../headerMask";
 
 const log = new ScopedLogger("TaskExecutor");
 
@@ -102,7 +103,12 @@ export class TaskExecutor {
     routing: RoutingContext,
     bodyResult: BodyProcessResult,
     clientId: string,
-    options?: { routeType?: RouteType; targetUrl?: string }
+    options?: {
+      routeType?: RouteType;
+      targetUrl?: string;
+      /** Upstream-bound request headers (sensitive values masked before storage). */
+      requestHeaders?: Record<string, string>;
+    }
   ): void {
     if (!this.database.enabled) {
       return;
@@ -129,6 +135,7 @@ export class TaskExecutor {
       targetUrl: options?.targetUrl ?? routing.targetUrl,
       requestBody: bodyResult.requestBodyLog,
       originalRequestBody: bodyResult.originalRequestBody,
+      requestHeaders: maskHeadersForLog(options?.requestHeaders),
       statusCode: undefined,
       duration: 0,
       success: false,
@@ -171,7 +178,8 @@ export class TaskExecutor {
         requestBodyLog: task.requestBodyLog,
         originalRequestBody: task.originalRequestBody,
       } as BodyProcessResult,
-      clientId
+      clientId,
+      { requestHeaders: task.headers }
     );
 
     // Track if client disconnected
@@ -253,7 +261,8 @@ export class TaskExecutor {
         requestBodyLog: task.requestBodyLog,
         originalRequestBody: task.originalRequestBody,
       } as BodyProcessResult,
-      clientId
+      clientId,
+      { requestHeaders: task.headers }
     );
 
     // Execute directly

--- a/packages/core/src/server/responseLogger.ts
+++ b/packages/core/src/server/responseLogger.ts
@@ -155,7 +155,8 @@ export class ResponseLogger {
     errorMessage: string | undefined,
     originalResponseBody?: string,
     ttfb?: number,
-    tokenOverrides?: LogResponseTokenOverrides
+    tokenOverrides?: LogResponseTokenOverrides,
+    responseHeadersMasked?: string
   ): void {
     if (!this.database.enabled) {
       this.log.info(`logResponse skipped - database not enabled. clientId=${clientId}`);
@@ -222,7 +223,8 @@ export class ResponseLogger {
       tokens.inputTokens,
       tokens.outputTokens,
       tokens.cacheTokens,
-      ttfb
+      ttfb,
+      responseHeadersMasked
     );
   }
 }

--- a/tests/unit/database/log-headers.test.ts
+++ b/tests/unit/database/log-headers.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as os from "os";
+import * as path from "path";
+import * as fs from "fs";
+import { SqliteNativeDriver } from "@/database/drivers/sqlite/native";
+import { maskHeadersForLog } from "@/server/headerMask";
+
+function isBetterSqlite3AvailableForNode(): boolean {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/naming-convention -- probe better-sqlite3 availability
+    const BetterSqlite3Ctor = require("better-sqlite3") as new (path: string) => { close(): void };
+    const db = new BetterSqlite3Ctor(":memory:");
+    db.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Skips when better-sqlite3 was rebuilt for Electron (e.g. after desktop postinstall). */
+const nativeForNode = isBetterSqlite3AvailableForNode();
+
+describe.skipIf(!nativeForNode)("request log header storage", () => {
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `ccrelay-headers-test-${Date.now()}.db`);
+  });
+
+  afterEach(() => {
+    try {
+      fs.unlinkSync(dbPath);
+    } catch {
+      // ignore
+    }
+  });
+
+  it("persists masked request headers at pending insert and response headers on completion", async () => {
+    const driver = new SqliteNativeDriver({ type: "sqlite", path: dbPath });
+    await driver.initialize({ logsEnabled: true });
+
+    const clientId = "client-headers-1";
+    const reqHeaders: Record<string, string> = { authorization: "Bearer tokensecret123456" };
+    reqHeaders["content-type"] = "application/json";
+    reqHeaders["x-api-key"] = "sk-secretkey123456";
+    const requestHeaders = maskHeadersForLog(reqHeaders);
+
+    driver.insertLogPending({
+      timestamp: Date.now(),
+      providerId: "p1",
+      providerName: "Provider",
+      method: "POST",
+      path: "/v1/messages",
+      clientId,
+      duration: 0,
+      success: false,
+      status: "pending",
+      requestHeaders,
+    });
+
+    const resHeaders: Record<string, string> = {};
+    resHeaders["x-request-id"] = "req_abc";
+    resHeaders["request-id"] = "req_abc";
+    const responseHeaders = maskHeadersForLog(resHeaders);
+
+    driver.updateLogCompleted(
+      clientId,
+      200,
+      '{"ok":true}',
+      42,
+      true,
+      undefined,
+      undefined,
+      10,
+      20,
+      0,
+      undefined,
+      responseHeaders
+    );
+
+    const { logs } = await driver.queryLogs({ limit: 10 });
+    const id = logs[0]?.id;
+    expect(id).toBeDefined();
+
+    const detail = await driver.getLogById(id!);
+    expect(detail).not.toBeNull();
+
+    const parsedReqHeaders = JSON.parse(detail!.requestHeaders!) as Record<string, string>;
+    // Non-sensitive header passes through.
+    expect(parsedReqHeaders["content-type"]).toBe("application/json");
+    // Sensitive headers are masked (never stored in the clear).
+    expect(parsedReqHeaders["x-api-key"]).toBe("sk-s***3456");
+    expect(parsedReqHeaders.authorization).toBe("Bearer toke***3456");
+    expect(parsedReqHeaders["x-api-key"]).not.toContain("secretkey");
+
+    const parsedResHeaders = JSON.parse(detail!.responseHeaders!) as Record<string, string>;
+    expect(parsedResHeaders["x-request-id"]).toBe("req_abc");
+
+    await driver.close();
+  });
+
+  it("runs the add_headers migration on a fresh database (columns nullable)", async () => {
+    const driver = new SqliteNativeDriver({ type: "sqlite", path: dbPath });
+    await driver.initialize({ logsEnabled: true });
+
+    const clientId = "client-headers-2";
+    driver.insertLogPending({
+      timestamp: Date.now(),
+      providerId: "p1",
+      providerName: "Provider",
+      method: "GET",
+      path: "/v1/models",
+      clientId,
+      duration: 0,
+      success: false,
+      status: "pending",
+    });
+
+    const { logs } = await driver.queryLogs({ limit: 10 });
+    const id = logs[0]?.id;
+    expect(id).toBeDefined();
+    const detail = await driver.getLogById(id!);
+    // Headers are optional and absent when not captured.
+    expect(detail!.requestHeaders).toBeUndefined();
+    expect(detail!.responseHeaders).toBeUndefined();
+
+    await driver.close();
+  });
+});

--- a/tests/unit/server/headerMask.test.ts
+++ b/tests/unit/server/headerMask.test.ts
@@ -1,0 +1,82 @@
+/* eslint-disable @typescript-eslint/naming-convention -- HTTP header names use hyphens */
+import { describe, it, expect } from "vitest";
+import { maskSecretValue, maskHeadersForLog, SENSITIVE_HEADER_NAMES } from "@/server/headerMask";
+
+describe("server: headerMask", () => {
+  describe("maskSecretValue", () => {
+    it("keeps first 4 + last 4 with *** in the middle for long values", () => {
+      expect(maskSecretValue("sk-abcdefghijklmnop")).toBe("sk-a***mnop");
+    });
+
+    it("fully masks values of length <= 8", () => {
+      expect(maskSecretValue("short")).toBe("********");
+      expect(maskSecretValue("12345678")).toBe("********");
+    });
+
+    it("masks 9-char values with first/last 4", () => {
+      // length 9: first 4 + last 4 leaves 1 hidden char
+      expect(maskSecretValue("123456789")).toBe("1234***6789");
+    });
+
+    it("preserves the Bearer scheme and masks only the credential", () => {
+      expect(maskSecretValue("Bearer sk-abcdefghijklmnopqrstuvwxyz")).toBe("Bearer sk-a***wxyz");
+    });
+
+    it("preserves other space-prefixed schemes (e.g. Basic)", () => {
+      expect(maskSecretValue("Basic dXNlcjpwYXNzd29yZDEyMzQ1")).toBe("Basic dXNl***MzQ1");
+    });
+
+    it("fully masks when the credential after the scheme is short", () => {
+      expect(maskSecretValue("Bearer short")).toBe("Bearer ********");
+    });
+  });
+
+  describe("maskHeadersForLog", () => {
+    it("returns undefined for undefined/empty input", () => {
+      expect(maskHeadersForLog(undefined)).toBeUndefined();
+      expect(maskHeadersForLog(null)).toBeUndefined();
+      expect(maskHeadersForLog({})).toBeUndefined();
+    });
+
+    it("masks sensitive headers and leaves others untouched", () => {
+      const out = maskHeadersForLog({
+        "content-type": "application/json",
+        "x-api-key": "sk-secretkey123456",
+      });
+      const parsed = JSON.parse(out!) as Record<string, string>;
+      expect(parsed["content-type"]).toBe("application/json");
+      expect(parsed["x-api-key"]).toBe("sk-s***3456");
+    });
+
+    it("matches sensitive header names case-insensitively", () => {
+      const out = maskHeadersForLog({ Authorization: "Bearer tokensecret123456" });
+      const parsed = JSON.parse(out!) as Record<string, string>;
+      expect(parsed.Authorization).toBe("Bearer toke***3456");
+    });
+
+    it("masks each element of array-valued sensitive headers", () => {
+      const out = maskHeadersForLog({
+        "x-api-key": ["sk-aaaaaaaa1111", "sk-bbbbbbbb2222"],
+      });
+      const parsed = JSON.parse(out!) as Record<string, string[]>;
+      expect(parsed["x-api-key"]).toEqual(["sk-a***1111", "sk-b***2222"]);
+    });
+
+    it("passes non-sensitive headers (including arrays) through verbatim", () => {
+      const out = maskHeadersForLog({
+        "x-request-id": "abc-123",
+        "set-cookie": ["s=1; Path=/", "t=2"],
+      });
+      const parsed = JSON.parse(out!) as Record<string, unknown>;
+      expect(parsed["x-request-id"]).toBe("abc-123");
+      expect(parsed["set-cookie"]).toEqual(["s=1; Path=/", "t=2"]);
+    });
+
+    it("treats authorization, x-api-key, and proxy-authorization as sensitive", () => {
+      expect(SENSITIVE_HEADER_NAMES.has("authorization")).toBe(true);
+      expect(SENSITIVE_HEADER_NAMES.has("x-api-key")).toBe(true);
+      expect(SENSITIVE_HEADER_NAMES.has("proxy-authorization")).toBe(true);
+      expect(SENSITIVE_HEADER_NAMES.has("content-type")).toBe(false);
+    });
+  });
+});

--- a/web/src/features/logs/Logs.tsx
+++ b/web/src/features/logs/Logs.tsx
@@ -59,6 +59,17 @@ const formatJson = (str: string): string => {
   }
 };
 
+/** Parse a masked-JSON header string into [key, value] entries (arrays joined). */
+const parseHeaderEntries = (headersJson: string | undefined): Array<[string, string]> | null => {
+  if (!headersJson) return null;
+  try {
+    const parsed = JSON.parse(headersJson) as Record<string, string | string[]>;
+    return Object.entries(parsed).map(([k, v]) => [k, Array.isArray(v) ? v.join(", ") : v]);
+  } catch {
+    return null;
+  }
+};
+
 const parseRequestMarkdownAnalysis = (str: string): string => {
   if (!str) return "";
 
@@ -150,6 +161,19 @@ function TabButton({ active, onClick, children }: TabButtonProps) {
   );
 }
 
+function HeaderList({ entries }: { entries: Array<[string, string]> }) {
+  return (
+    <dl className="space-y-0.5">
+      {entries.map(([k, v]) => (
+        <div key={k} className="flex gap-2 text-[11px] font-mono">
+          <dt className="text-muted-foreground shrink-0">{k}:</dt>
+          <dd className="break-all">{v}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
 export default function Logs() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -159,10 +183,12 @@ export default function Logs() {
   const [requestBodyCollapsed, setRequestBodyCollapsed] = useState(false);
   const [responseBodyCollapsed, setResponseBodyCollapsed] = useState(false);
   const [copiedSection, setCopiedSection] = useState<"request" | "response" | null>(null);
-  const [requestTab, setRequestTab] = useState<"analysis" | "tools" | "converted" | "original">(
+  const [requestTab, setRequestTab] = useState<
+    "analysis" | "tools" | "converted" | "original" | "headers"
+  >("analysis");
+  const [responseTab, setResponseTab] = useState<"analysis" | "converted" | "original" | "headers">(
     "analysis"
   );
-  const [responseTab, setResponseTab] = useState<"analysis" | "converted" | "original">("analysis");
   const [refreshing, setRefreshing] = useState(false);
 
   // Use ref for stable data access in callbacks
@@ -410,6 +436,16 @@ export default function Logs() {
   const parsedRequestAnalysis = useMemo(() => {
     return selectedLog?.requestBody ? parseRequestMarkdownAnalysis(selectedLog.requestBody) : "";
   }, [selectedLog?.requestBody]);
+
+  /** Parsed [key, value] entries for the masked request/response header JSON. */
+  const parsedRequestHeaders = useMemo(
+    () => parseHeaderEntries(selectedLog?.requestHeaders),
+    [selectedLog?.requestHeaders]
+  );
+  const parsedResponseHeaders = useMemo(
+    () => parseHeaderEntries(selectedLog?.responseHeaders),
+    [selectedLog?.responseHeaders]
+  );
 
   /** Pretty-printed merged message (SSE) or full JSON body (non-SSE). Empty when not reconstructable. */
   const responseStructuredJson = useMemo(() => {
@@ -1010,6 +1046,14 @@ export default function Logs() {
                               >
                                 {t("logs.detail.tab.original")}
                               </TabButton>
+                              {parsedRequestHeaders && (
+                                <TabButton
+                                  active={requestTab === "headers"}
+                                  onClick={() => setRequestTab("headers")}
+                                >
+                                  {t("logs.detail.requestHeaders")}
+                                </TabButton>
+                              )}
                             </div>
                           )}
                           {!selectedLog.originalRequestBody && !requestBodyCollapsed && (
@@ -1034,25 +1078,46 @@ export default function Logs() {
                               >
                                 {t("logs.detail.tab.raw")}
                               </TabButton>
+                              {parsedRequestHeaders && (
+                                <TabButton
+                                  active={requestTab === "headers"}
+                                  onClick={() => setRequestTab("headers")}
+                                >
+                                  {t("logs.detail.requestHeaders")}
+                                </TabButton>
+                              )}
                             </div>
                           )}
                         </div>
                         <div className="flex items-center gap-2">
-                          <span className="text-[10px] text-muted-foreground font-normal">
-                            {
-                              (requestTab === "original" && selectedLog.originalRequestBody
-                                ? selectedLog.originalRequestBody
-                                : selectedLog.requestBody
-                              ).length
-                            }{" "}
-                            {t("logs.detail.chars")}
-                          </span>
+                          {requestTab !== "headers" && (
+                            <span className="text-[10px] text-muted-foreground font-normal">
+                              {
+                                (requestTab === "original" && selectedLog.originalRequestBody
+                                  ? selectedLog.originalRequestBody
+                                  : selectedLog.requestBody
+                                ).length
+                              }{" "}
+                              {t("logs.detail.chars")}
+                            </span>
+                          )}
                           <Button
                             variant="ghost"
                             size="sm"
                             className="h-6 px-2 text-[10px]"
                             onClick={() => {
-                              if (requestTab === "analysis") {
+                              if (requestTab === "headers") {
+                                handleCopy(
+                                  JSON.stringify(
+                                    parsedRequestHeaders
+                                      ? Object.fromEntries(parsedRequestHeaders)
+                                      : {},
+                                    null,
+                                    2
+                                  ),
+                                  "request"
+                                );
+                              } else if (requestTab === "analysis") {
                                 handleCopy(parsedRequestAnalysis, "request");
                               } else if (requestTab === "tools" && parsedToolsMarkdown) {
                                 handleCopy(parsedToolsMarkdown, "request");
@@ -1084,7 +1149,9 @@ export default function Logs() {
                       </div>
                       {!requestBodyCollapsed && (
                         <div className="bg-card border p-3 rounded overflow-auto max-h-[500px]">
-                          {requestTab === "analysis" ? (
+                          {requestTab === "headers" ? (
+                            <HeaderList entries={parsedRequestHeaders ?? []} />
+                          ) : requestTab === "analysis" ? (
                             <MarkdownViewer content={parsedRequestAnalysis} />
                           ) : requestTab === "tools" && parsedToolsMarkdown ? (
                             <MarkdownViewer content={parsedToolsMarkdown} />
@@ -1137,6 +1204,14 @@ export default function Logs() {
                               >
                                 {t("logs.detail.tab.original")}
                               </TabButton>
+                              {parsedResponseHeaders && (
+                                <TabButton
+                                  active={responseTab === "headers"}
+                                  onClick={() => setResponseTab("headers")}
+                                >
+                                  {t("logs.detail.responseHeaders")}
+                                </TabButton>
+                              )}
                             </div>
                           )}
                           {!selectedLog.originalResponseBody && !responseBodyCollapsed && (
@@ -1153,25 +1228,49 @@ export default function Logs() {
                               >
                                 {t("logs.detail.tab.raw")}
                               </TabButton>
+                              {parsedResponseHeaders && (
+                                <TabButton
+                                  active={responseTab === "headers"}
+                                  onClick={() => setResponseTab("headers")}
+                                >
+                                  {t("logs.detail.responseHeaders")}
+                                </TabButton>
+                              )}
                             </div>
                           )}
                         </div>
                         <div className="flex items-center gap-2">
-                          <span className="text-[10px] text-muted-foreground font-normal">
-                            {
-                              (responseTab === "original" && selectedLog.originalResponseBody
-                                ? selectedLog.originalResponseBody
-                                : selectedLog.responseBody
-                              ).length
-                            }{" "}
-                            {t("logs.detail.chars")}
-                          </span>
+                          {responseTab !== "headers" && (
+                            <span className="text-[10px] text-muted-foreground font-normal">
+                              {
+                                (responseTab === "original" && selectedLog.originalResponseBody
+                                  ? selectedLog.originalResponseBody
+                                  : selectedLog.responseBody
+                                ).length
+                              }{" "}
+                              {t("logs.detail.chars")}
+                            </span>
+                          )}
                           <Button
                             variant="ghost"
                             size="sm"
                             className="h-6 px-2 text-[10px]"
                             onClick={() => {
-                              if (responseTab === "analysis" && hasStructuredResponseAnalysis) {
+                              if (responseTab === "headers") {
+                                handleCopy(
+                                  JSON.stringify(
+                                    parsedResponseHeaders
+                                      ? Object.fromEntries(parsedResponseHeaders)
+                                      : {},
+                                    null,
+                                    2
+                                  ),
+                                  "response"
+                                );
+                              } else if (
+                                responseTab === "analysis" &&
+                                hasStructuredResponseAnalysis
+                              ) {
                                 handleCopy(responseStructuredJson, "response");
                               } else {
                                 handleCopy(
@@ -1201,7 +1300,9 @@ export default function Logs() {
                       </div>
                       {!responseBodyCollapsed && (
                         <div className="bg-card border p-3 rounded overflow-auto max-h-[500px]">
-                          {responseTab === "analysis" && hasStructuredResponseAnalysis ? (
+                          {responseTab === "headers" ? (
+                            <HeaderList entries={parsedResponseHeaders ?? []} />
+                          ) : responseTab === "analysis" && hasStructuredResponseAnalysis ? (
                             <pre className="text-[11px] font-mono m-0 whitespace-pre text-muted-foreground">
                               {responseStructuredJson}
                             </pre>

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -600,6 +600,8 @@
       "loadError": "Failed to load log details",
       "requestBody": "Request Body",
       "responseBody": "Response Body",
+      "requestHeaders": "Request Headers",
+      "responseHeaders": "Response Headers",
       "tab": {
         "analysis": "Analysis",
         "tools": "Tools",

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -599,6 +599,8 @@
       "loadError": "加载日志详情失败",
       "requestBody": "请求体",
       "responseBody": "响应体",
+      "requestHeaders": "请求头",
+      "responseHeaders": "响应头",
       "tab": {
         "analysis": "分析",
         "tools": "工具",

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -143,6 +143,10 @@ export interface LogEntry {
   responseBody?: string;
   originalRequestBody?: string;
   originalResponseBody?: string;
+  /** Masked JSON string of request headers (sensitive values masked). */
+  requestHeaders?: string;
+  /** Masked JSON string of response headers (sensitive values masked). */
+  responseHeaders?: string;
   statusCode: number;
   duration: number;
   success: boolean;


### PR DESCRIPTION
## Summary

Request logs now record the **upstream request headers** and **upstream response headers** alongside the bodies, whenever log storage is enabled. Sensitive auth headers are masked before persistence so secrets are never written to the log database.

## Why

Debugging proxy behavior often requires seeing the exact headers sent to the provider and returned by it (rate limits, request ids, content negotiation, injected auth). Headers carry secrets though, so they must be masked first.

## Changes

- **Masking** (`server/headerMask.ts`, new): `authorization`, `x-api-key`, `proxy-authorization` values are masked — keep first 4 + last 4, middle replaced with `***`; a `Bearer `<token> scheme prefix is preserved and only the credential is masked; ≤8-char values are fully masked.
- **Schema / migration**: add `request_headers` / `response_headers` TEXT columns to `request_logs_v2` (SQLite + Postgres DDL) via an idempotent **v3 `add_headers`** migration (SQLite sync + async + Postgres runners). No new config flag — capture follows the existing `logsEnabled` body-logging gate.
- **Capture**: request headers at pending insert (queue, direct, and service-interceptor paths); response headers computed once per upstream response and threaded through `ResponseLogger.logResponse` → `updateLogCompleted`. All three SQLite/Postgres/worker drivers + the row mapper + worker IPC updated; detail API returns the header JSON.
- **Web UI**: log detail adds a **请求头** tab in the request body section and a **响应头** tab in the response body section (shown only when those headers were captured), with copy support.

## Tests

- New `headerMask` unit tests (mask format, Bearer scheme, short values, case-insensitivity, arrays, sensitive set).
- New DB-level test asserting masked `request_headers` (auth/key never stored in the clear) + `response_headers` are written and read back via `getLogById`, and the migration makes the columns nullable on a fresh DB.
- `npm run format` / `npm run lint` (root + web) and the full unit suite (1028 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)