### PR TITLE
fix: concurrency hot-reload, Settings save feedback, and split log/metrics clearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Logging database**
 
-- Clearing all logs also clears token metrics, so dashboard statistics stay consistent with log storage.
+- Clearing all logs in the Logs tab removes only stored request/response bodies; dashboard token and performance metrics are kept.
+- **Reset stats** on the Dashboard clears token and performance metrics only; stored request logs are not affected.
 
 ### Fixed
 

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -22,7 +22,7 @@ import {
 } from "./providers";
 import { handleSwitchProvider, setServer as setSwitchServer } from "./switch";
 import { handleLogs, handleLogDetail, handleDeleteLogs, handleClearLogs } from "./logs";
-import { handleStats } from "./stats";
+import { handleStats, handleClearStats } from "./stats";
 import { handleVersion } from "./version";
 import { handleUpdateCheck, handleTriggerUpdateCheck } from "./updateCheck";
 import { handleQueueStats, handleClearQueue, setServer as setQueueServer } from "./queue";
@@ -135,6 +135,17 @@ export function handleApiRequest(req: http.IncomingMessage, res: http.ServerResp
     handleDeleteLogs(req, res).catch(err => {
       log.error("Error handling DELETE /logs", err);
       sendJson(res, 500, { error: "Internal server error" });
+    });
+    return true;
+  }
+
+  // Check for DELETE /ccrelay/api/stats
+  if (reqPath === "/ccrelay/api/stats" && method === "DELETE") {
+    handleClearStats(req, res).catch(err => {
+      log.error("Error handling DELETE /stats", err);
+      if (!res.headersSent) {
+        sendJson(res, 500, { error: "Internal server error" });
+      }
     });
     return true;
   }

--- a/packages/core/src/api/logs.ts
+++ b/packages/core/src/api/logs.ts
@@ -112,7 +112,7 @@ export async function handleDeleteLogs(
 
   const db = getDatabase();
 
-  if (!db.enabled || !db.logsEnabled) {
+  if (!db.enabled) {
     sendJson(res, 200, { success: true });
     return;
   }
@@ -123,7 +123,16 @@ export async function handleDeleteLogs(
     if (data.clearAll) {
       await db.clearAllLogs();
       log.info("Cleared all logs via API");
-    } else if (data.ids && data.ids.length > 0) {
+      sendJson(res, 200, { success: true });
+      return;
+    }
+
+    if (!db.logsEnabled) {
+      sendJson(res, 200, { success: true });
+      return;
+    }
+
+    if (data.ids && data.ids.length > 0) {
       await db.deleteLogs(data.ids);
       log.info(`Deleted ${data.ids.length} log(s) via API`);
     }

--- a/packages/core/src/api/stats.ts
+++ b/packages/core/src/api/stats.ts
@@ -1,6 +1,7 @@
 /**
  * Stats API endpoint
  * GET /ccrelay/api/stats?range=1d|7d|30d|all
+ * DELETE /ccrelay/api/stats — clear token / performance metrics
  */
 
 import * as http from "http";
@@ -9,6 +10,9 @@ import { filterProviderBreakdownByTokenUsage } from "../database/shared-utils";
 import { sendJson } from "./index";
 import { rejectLogStorageApiIfNotLeader } from "./serverRef";
 import { SMART_ROUTING_PROVIDER_ID } from "../server/smartRouting/virtualProvider";
+import { ScopedLogger } from "../utils/logger";
+
+const log = new ScopedLogger("StatsAPI");
 
 function omitVirtualProviderFromBreakdown<T extends { providerId: string }>(rows: T[]): T[] {
   return rows.filter(row => row.providerId !== SMART_ROUTING_PROVIDER_ID);
@@ -68,4 +72,32 @@ export async function handleStats(
       omitVirtualProviderFromBreakdown(stats.providerBreakdown)
     ),
   });
+}
+
+/**
+ * DELETE /ccrelay/api/stats — reset dashboard token and performance metrics.
+ */
+export async function handleClearStats(
+  _req: http.IncomingMessage,
+  res: http.ServerResponse
+): Promise<void> {
+  if (rejectLogStorageApiIfNotLeader(res)) {
+    return;
+  }
+
+  const db = getDatabase();
+
+  if (!db.enabled) {
+    sendJson(res, 200, { success: true });
+    return;
+  }
+
+  try {
+    await db.clearAllMetrics();
+    log.info("Cleared all metrics via API");
+    sendJson(res, 200, { success: true });
+  } catch (err) {
+    log.error("Error clearing metrics", err);
+    sendJson(res, 500, { error: "Failed to clear metrics" });
+  }
 }

--- a/packages/core/src/database/drivers/postgres/driver.ts
+++ b/packages/core/src/database/drivers/postgres/driver.ts
@@ -536,6 +536,12 @@ export class PostgresDriver implements DatabaseDriver {
       return;
     }
     await this.pool.query(`DELETE FROM ${TABLE}`);
+  }
+
+  async clearAllMetrics(): Promise<void> {
+    if (!this.pool) {
+      return;
+    }
     await this.pool.query(`DELETE FROM ${METRICS_TABLE}`);
   }
 

--- a/packages/core/src/database/drivers/sqlite/cli.ts
+++ b/packages/core/src/database/drivers/sqlite/cli.ts
@@ -1206,6 +1206,13 @@ export class SqliteCliDriver implements DatabaseDriver {
       return;
     }
     await this.writeConn.exec(`DELETE FROM ${TABLE}`);
+    await this.writeConn.exec("VACUUM");
+  }
+
+  async clearAllMetrics(): Promise<void> {
+    if (!this.writeConn?.started) {
+      return;
+    }
     await this.writeConn.exec(`DELETE FROM ${METRICS_TABLE}`);
     await this.writeConn.exec("VACUUM");
   }

--- a/packages/core/src/database/drivers/sqlite/native.ts
+++ b/packages/core/src/database/drivers/sqlite/native.ts
@@ -296,6 +296,13 @@ export class SqliteNativeDriver implements DatabaseDriver {
       return;
     }
     this.d.exec(`DELETE FROM ${TABLE}`);
+    this.d.exec("VACUUM");
+  }
+
+  async clearAllMetrics(): Promise<void> {
+    if (!this.isEnabled) {
+      return;
+    }
     this.d.exec(`DELETE FROM ${METRICS_TABLE}`);
     this.d.exec("VACUUM");
   }

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -168,10 +168,17 @@ export class LogDatabase {
   }
 
   /**
-   * Clear all logs
+   * Clear all request log rows (bodies only).
    */
   async clearAllLogs(): Promise<void> {
     await this.driver?.clearAllLogs();
+  }
+
+  /**
+   * Clear all dashboard metrics.
+   */
+  async clearAllMetrics(): Promise<void> {
+    await this.driver?.clearAllMetrics();
   }
 
   /**

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -226,9 +226,14 @@ export interface DatabaseDriver {
   deleteLogs(ids: number[]): Promise<void>;
 
   /**
-   * Clear all logs
+   * Clear all request log rows (bodies only; metrics are kept).
    */
   clearAllLogs(): Promise<void>;
+
+  /**
+   * Clear all token / performance metrics (dashboard statistics).
+   */
+  clearAllMetrics(): Promise<void>;
 
   /**
    * Get database statistics

--- a/packages/core/src/database/worker/client.ts
+++ b/packages/core/src/database/worker/client.ts
@@ -36,6 +36,7 @@ type WorkerMessageType =
   | "getLogById"
   | "deleteLogs"
   | "clearAllLogs"
+  | "clearAllMetrics"
   | "getStats"
   | "cleanOldLogs"
   | "forceFlush";
@@ -398,6 +399,13 @@ export class DatabaseWorkerClient implements DatabaseDriver {
    */
   async clearAllLogs(): Promise<void> {
     await this.send("clearAllLogs");
+  }
+
+  /**
+   * Clear all dashboard metrics
+   */
+  async clearAllMetrics(): Promise<void> {
+    await this.send("clearAllMetrics");
   }
 
   /**

--- a/packages/core/src/database/worker/worker.ts
+++ b/packages/core/src/database/worker/worker.ts
@@ -38,6 +38,7 @@ type WorkerMessageType =
   | "getLogById"
   | "deleteLogs"
   | "clearAllLogs"
+  | "clearAllMetrics"
   | "getStats"
   | "cleanOldLogs"
   | "forceFlush";
@@ -184,6 +185,11 @@ async function handleMessage(message: WorkerMessage): Promise<WorkerResponse> {
 
       case "clearAllLogs": {
         await driver?.clearAllLogs();
+        return { id, success: true };
+      }
+
+      case "clearAllMetrics": {
+        await driver?.clearAllMetrics();
         return { id, success: true };
       }
 

--- a/packages/core/src/queue/concurrency-manager.ts
+++ b/packages/core/src/queue/concurrency-manager.ts
@@ -432,6 +432,21 @@ export class ConcurrencyManager {
   }
 
   /**
+   * Apply updated concurrency settings without recreating the manager.
+   * In-flight and queued tasks keep their existing timeout handles.
+   */
+  applyConfig(next: ConcurrencyConfig): void {
+    if (next.maxWorkers !== this.config.maxWorkers) {
+      this.updateMaxWorkers(next.maxWorkers);
+    }
+    this.config.maxQueueSize = next.maxQueueSize;
+    this.config.requestTimeout = next.requestTimeout;
+    if (next.retry429 !== undefined) {
+      this.config.retry429 = next.retry429;
+    }
+  }
+
+  /**
    * Update the max workers limit
    */
   updateMaxWorkers(newMax: number): void {

--- a/packages/core/src/server/handler.ts
+++ b/packages/core/src/server/handler.ts
@@ -410,6 +410,7 @@ export class ProxyServer {
    */
   private handleConfigChanged(): void {
     this.database.setLogsEnabled(this.config.enableLogStorage);
+    this.queueManager.reloadFromConfig();
     if (this.wsBroadcaster) {
       this.wsBroadcaster.broadcastConfigChanged();
     }

--- a/packages/core/src/server/queueManager.ts
+++ b/packages/core/src/server/queueManager.ts
@@ -5,7 +5,14 @@
 import { ScopedLogger } from "../utils/logger";
 import { ConcurrencyManager } from "../queue";
 import type { ConfigManager } from "../config";
-import type { RequestTask, QueueStats, QueueOverview, ProxyResult } from "../types";
+import type {
+  ConcurrencyConfig,
+  RequestTask,
+  QueueStats,
+  QueueOverview,
+  ProxyResult,
+  RouteQueueConfig,
+} from "../types";
 
 const log = new ScopedLogger("QueueManager");
 
@@ -32,42 +39,85 @@ export class QueueManager {
    */
   setExecutor(executor: ProxyExecutor): void {
     this.executor = executor;
-    this.initializeQueues();
+    this.reloadFromConfig();
   }
 
   /**
-   * Initialize default and route-specific queues from config
+   * Sync queue managers with the current config (startup and hot-reload).
    */
-  private initializeQueues(): void {
+  reloadFromConfig(): void {
     if (!this.executor) {
       return;
     }
 
-    // Initialize default concurrency manager
+    this.syncDefaultQueue();
+    this.syncRouteQueues();
+  }
+
+  private routeConfigToConcurrencyConfig(routeConfig: RouteQueueConfig): ConcurrencyConfig {
+    return {
+      enabled: true,
+      maxWorkers: routeConfig.maxWorkers,
+      maxQueueSize: routeConfig.maxQueueSize,
+      requestTimeout: routeConfig.requestTimeout,
+    };
+  }
+
+  private syncDefaultQueue(): void {
+    const executor = this.executor!;
     const concurrencyConfig = this.config.configValue.concurrency;
+
     if (concurrencyConfig?.enabled) {
-      this.defaultQueue = new ConcurrencyManager(concurrencyConfig, this.executor);
-      log.info(
-        `Default queue initialized: maxWorkers=${concurrencyConfig.maxWorkers}, maxQueueSize=${concurrencyConfig.maxQueueSize ?? "unlimited"}`
-      );
+      if (this.defaultQueue) {
+        this.defaultQueue.applyConfig(concurrencyConfig);
+        log.info(
+          `Default queue reloaded: maxWorkers=${concurrencyConfig.maxWorkers}, maxQueueSize=${concurrencyConfig.maxQueueSize ?? "unlimited"}`
+        );
+      } else {
+        this.defaultQueue = new ConcurrencyManager(concurrencyConfig, executor);
+        log.info(
+          `Default queue initialized: maxWorkers=${concurrencyConfig.maxWorkers}, maxQueueSize=${concurrencyConfig.maxQueueSize ?? "unlimited"}`
+        );
+      }
+      return;
+    }
+
+    if (this.defaultQueue) {
+      log.info("Default queue disabled");
     } else {
       log.info(
         `Default queue disabled. Config: ${JSON.stringify(concurrencyConfig ?? "undefined")}`
       );
     }
+    this.defaultQueue = null;
+  }
 
-    // Initialize route-specific queues
-    const routeQueueConfigs = this.config.routeQueues;
-    if (routeQueueConfigs && routeQueueConfigs.length > 0) {
-      for (const routeConfig of routeQueueConfigs) {
-        const queueName = routeConfig.name ?? routeConfig.pattern;
-        const queueConfig = {
-          enabled: true,
-          maxWorkers: routeConfig.maxWorkers,
-          maxQueueSize: routeConfig.maxQueueSize,
-          requestTimeout: routeConfig.requestTimeout,
-        };
-        const routeQueue = new ConcurrencyManager(queueConfig, this.executor);
+  private syncRouteQueues(): void {
+    const executor = this.executor!;
+    const routeQueueConfigs = this.config.routeQueues ?? [];
+    const desiredNames = new Set(
+      routeQueueConfigs.map(routeConfig => routeConfig.name ?? routeConfig.pattern)
+    );
+
+    for (const queueName of this.routeQueues.keys()) {
+      if (!desiredNames.has(queueName)) {
+        this.routeQueues.delete(queueName);
+        log.info(`RouteQueue "${queueName}" removed from config`);
+      }
+    }
+
+    for (const routeConfig of routeQueueConfigs) {
+      const queueName = routeConfig.name ?? routeConfig.pattern;
+      const queueConfig = this.routeConfigToConcurrencyConfig(routeConfig);
+      const existing = this.routeQueues.get(queueName);
+
+      if (existing) {
+        existing.applyConfig(queueConfig);
+        log.info(
+          `RouteQueue "${queueName}" reloaded: pattern=${routeConfig.pattern}, maxWorkers=${routeConfig.maxWorkers}, maxQueueSize=${routeConfig.maxQueueSize ?? "unlimited"}`
+        );
+      } else {
+        const routeQueue = new ConcurrencyManager(queueConfig, executor);
         this.routeQueues.set(queueName, routeQueue);
         log.info(
           `RouteQueue "${queueName}" initialized: pattern=${routeConfig.pattern}, maxWorkers=${routeConfig.maxWorkers}, maxQueueSize=${routeConfig.maxQueueSize ?? "unlimited"}`

--- a/tests/integration/handler/concurrency-hot-reload.test.ts
+++ b/tests/integration/handler/concurrency-hot-reload.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Integration Test: Concurrency hot reload
+ */
+
+/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+
+import * as http from "http";
+import type { AddressInfo } from "net";
+import { describe, it, expect, afterEach } from "vitest";
+import request from "supertest";
+import type { ConfigManager } from "@/config";
+import { QueueManager } from "@/server/queueManager";
+import { resolveInboundClientSurface } from "@/server/request/apiSurfaceDetector";
+import type { ConcurrencyConfig, Provider, ProxyResult, RequestTask } from "@/types";
+import { MockProvider } from "../fixtures";
+import { createTestConcurrencyConfig, createTestProvider } from "../utils";
+
+class QueueHotReloadHarness {
+  private server: http.Server | null = null;
+  private readonly state: {
+    concurrency: ConcurrencyConfig | undefined;
+    provider: Provider;
+  };
+  private readonly queueManager: QueueManager;
+  private readonly upstreamBaseUrl: string;
+
+  constructor(concurrency: ConcurrencyConfig | undefined, provider: Provider) {
+    this.state = { concurrency, provider };
+    this.upstreamBaseUrl = provider.baseUrl;
+    const state = this.state;
+    const configManager = {
+      get configValue() {
+        return {
+          concurrency: state.concurrency,
+          routeQueues: [],
+        };
+      },
+      get routeQueues() {
+        return [];
+      },
+    } as unknown as ConfigManager;
+    this.queueManager = new QueueManager(configManager);
+    this.queueManager.setExecutor(task => this.executeProxyRequest(task));
+  }
+
+  reloadConcurrency(concurrency: ConcurrencyConfig | undefined): void {
+    this.state.concurrency = concurrency;
+    this.queueManager.reloadFromConfig();
+  }
+
+  getQueueStats() {
+    return this.queueManager.getDefaultQueue()?.getStats() ?? null;
+  }
+
+  async start(): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.server = http.createServer((req, res) => {
+        void this.handleRequest(req, res).catch(err => {
+          if (!res.headersSent) {
+            res.writeHead(500, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: String(err) }));
+          }
+        });
+      });
+
+      this.server.listen(0, "127.0.0.1", () => resolve());
+      this.server.on("error", reject);
+    });
+  }
+
+  async stop(): Promise<void> {
+    this.queueManager.getDefaultQueue()?.shutdown();
+    await new Promise<void>((resolve, reject) => {
+      if (!this.server) {
+        resolve();
+        return;
+      }
+      this.server.close(err => {
+        if (err) {
+          reject(err);
+        } else {
+          this.server = null;
+          resolve();
+        }
+      });
+    });
+  }
+
+  get baseUrl(): string {
+    if (!this.server) {
+      throw new Error("Server not started");
+    }
+    const port = (this.server.address() as AddressInfo).port;
+    return `http://127.0.0.1:${port}`;
+  }
+
+  private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const path = req.url ?? "/";
+    const method = req.method ?? "GET";
+    const body = await this.readBody(req);
+    const headers = Object.fromEntries(
+      Object.entries(req.headers).map(([k, v]) => [k, Array.isArray(v) ? v[0] : (v ?? "")])
+    );
+
+    const queueInfo = this.queueManager.getQueueForPath(path);
+    const provider = this.state.provider;
+    const clientSurface = resolveInboundClientSurface(method, path, provider);
+
+    const task: RequestTask = {
+      id: `it-${Date.now()}`,
+      method,
+      targetUrl: `${this.upstreamBaseUrl}${path}`,
+      headers,
+      body,
+      provider,
+      inboundPath: path,
+      requestPath: path,
+      requestBodyLog: "",
+      originalRequestBody: "",
+      isOpenAIProvider: provider.providerType === "openai",
+      clientSurface,
+      clientId: "integration-client",
+      createdAt: Date.now(),
+      res,
+    };
+
+    if (!queueInfo) {
+      const result = await this.executeProxyRequest(task);
+      this.sendProxyResult(res, result);
+      return;
+    }
+
+    const result = await queueInfo.queue.submit(task);
+    this.sendProxyResult(res, result);
+  }
+
+  private sendProxyResult(res: http.ServerResponse, result: ProxyResult): void {
+    if (res.writableEnded) {
+      return;
+    }
+    if (result.error) {
+      res.writeHead(result.statusCode >= 400 ? result.statusCode : 502, {
+        "Content-Type": "application/json",
+      });
+      res.end(JSON.stringify({ error: result.errorMessage ?? result.error.message }));
+      return;
+    }
+    res.writeHead(result.statusCode, { "Content-Type": "application/json" });
+    const payload =
+      typeof result.body === "string"
+        ? result.body
+        : result.body
+          ? result.body.toString("utf-8")
+          : "{}";
+    res.end(payload);
+  }
+
+  private readBody(req: http.IncomingMessage): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      req.on("data", chunk => chunks.push(Buffer.from(chunk)));
+      req.on("end", () => resolve(Buffer.concat(chunks)));
+      req.on("error", reject);
+    });
+  }
+
+  private async executeProxyRequest(task: RequestTask): Promise<ProxyResult> {
+    const start = Date.now();
+    const requestBody = task.body ?? Buffer.alloc(0);
+    const response = await fetch(task.targetUrl, {
+      method: task.method,
+      headers: task.headers,
+      body: requestBody.length > 0 ? requestBody : undefined,
+    });
+    const text = await response.text();
+    return {
+      statusCode: response.status,
+      headers: Object.fromEntries(response.headers.entries()),
+      body: text,
+      duration: Date.now() - start,
+    };
+  }
+}
+
+describe("Integration: Concurrency hot reload", () => {
+  let mockProvider: MockProvider;
+  let harness: QueueHotReloadHarness;
+
+  afterEach(async () => {
+    if (harness) {
+      await harness.stop();
+    }
+    if (mockProvider) {
+      await mockProvider.stop();
+    }
+  });
+
+  it("IT14-01: should process a second request in parallel after maxWorkers hot reload", async () => {
+    mockProvider = new MockProvider();
+    await mockProvider.start();
+
+    const taskDuration = 1000;
+    mockProvider.onPost("/v1/messages", {
+      status: 200,
+      body: { content: "completed" },
+      delay: taskDuration,
+    });
+
+    const provider = createTestProvider({ baseUrl: mockProvider.baseUrl });
+    harness = new QueueHotReloadHarness(
+      createTestConcurrencyConfig({
+        maxWorkers: 1,
+        maxQueueSize: 10,
+        requestTimeout: 30,
+      }),
+      provider
+    );
+    await harness.start();
+
+    const req1Promise = fetch(`${harness.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": "test-key",
+      },
+      body: JSON.stringify({ model: "test-1", messages: [] }),
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      const start = Date.now();
+      const check = () => {
+        const stats = harness.getQueueStats();
+        if (stats?.activeWorkers === 1) {
+          resolve();
+        } else if (Date.now() - start > 5000) {
+          reject(new Error(`Timed out waiting for active worker. Stats: ${JSON.stringify(stats)}`));
+        } else {
+          setTimeout(check, 25);
+        }
+      };
+      check();
+    });
+
+    harness.reloadConcurrency(
+      createTestConcurrencyConfig({
+        maxWorkers: 2,
+        maxQueueSize: 10,
+        requestTimeout: 30,
+      })
+    );
+
+    const startTime = Date.now();
+    const req2 = request(harness.baseUrl)
+      .post("/v1/messages")
+      .set("x-api-key", "test-key")
+      .send({ model: "test-2", messages: [] })
+      .timeout(30000);
+
+    const [res1, res2] = await Promise.all([
+      req1Promise.then(async r => ({
+        status: r.status,
+        body: await r.json(),
+      })),
+      req2,
+    ]);
+    const totalTime = Date.now() - startTime;
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(res1.body).toEqual({ content: "completed" });
+
+    // Sequential would be ~2s; parallel after reload should finish closer to ~1s.
+    expect(totalTime).toBeLessThan(taskDuration * 1.8);
+    expect(totalTime).toBeGreaterThanOrEqual(taskDuration - 150);
+  });
+});

--- a/tests/unit/api/index.test.ts
+++ b/tests/unit/api/index.test.ts
@@ -32,6 +32,7 @@ vi.mock("@/database", () => ({
     getLogById: vi.fn(),
     deleteLogs: vi.fn(),
     clearAllLogs: vi.fn(),
+    clearAllMetrics: vi.fn(),
   })),
 }));
 

--- a/tests/unit/api/providers.test.ts
+++ b/tests/unit/api/providers.test.ts
@@ -23,6 +23,7 @@ vi.mock("@/database", () => ({
     getLogById: vi.fn(),
     deleteLogs: vi.fn(),
     clearAllLogs: vi.fn(),
+    clearAllMetrics: vi.fn(),
   })),
 }));
 

--- a/tests/unit/api/status.test.ts
+++ b/tests/unit/api/status.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/database", () => ({
     getLogById: vi.fn(),
     deleteLogs: vi.fn(),
     clearAllLogs: vi.fn(),
+    clearAllMetrics: vi.fn(),
   })),
 }));
 

--- a/tests/unit/api/switch.test.ts
+++ b/tests/unit/api/switch.test.ts
@@ -25,6 +25,7 @@ vi.mock("@/database", () => ({
     getLogById: vi.fn(),
     deleteLogs: vi.fn(),
     clearAllLogs: vi.fn(),
+    clearAllMetrics: vi.fn(),
   })),
 }));
 

--- a/tests/unit/database/index.test.ts
+++ b/tests/unit/database/index.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/database/drivers/sqlite/cli", async importOriginal => {
         getLogById: vi.fn().mockResolvedValue(null),
         deleteLogs: vi.fn().mockResolvedValue(undefined),
         clearAllLogs: vi.fn().mockResolvedValue(undefined),
+        clearAllMetrics: vi.fn().mockResolvedValue(undefined),
         getStats: vi.fn().mockResolvedValue({
           totalLogs: 0,
           successCount: 0,

--- a/tests/unit/database/metrics-split.test.ts
+++ b/tests/unit/database/metrics-split.test.ts
@@ -72,7 +72,7 @@ describe.skipIf(!nativeForNode)("metrics split (native driver)", () => {
     await driver.close();
   });
 
-  it("completion updates metrics tokens; clearAllLogs clears metrics too", async () => {
+  it("completion updates metrics tokens; clearAllLogs keeps metrics", async () => {
     const driver = new SqliteNativeDriver({ type: "sqlite", path: dbPath });
     await driver.initialize({ logsEnabled: true });
 
@@ -101,8 +101,8 @@ describe.skipIf(!nativeForNode)("metrics split (native driver)", () => {
 
     await driver.clearAllLogs();
 
-    const statsAfter = await driver.getStats();
-    expect(statsAfter.totalInputTokens).toBe(0);
+    const statsAfterClearLogs = await driver.getStats();
+    expect(statsAfterClearLogs.totalInputTokens).toBe(10);
 
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/naming-convention
     const BetterSqlite3 = require("better-sqlite3") as typeof import("better-sqlite3");
@@ -110,8 +110,13 @@ describe.skipIf(!nativeForNode)("metrics split (native driver)", () => {
     const v2Count = db.prepare(`SELECT COUNT(*) as c FROM ${TABLE}`).get() as { c: number };
     const mCount = db.prepare(`SELECT COUNT(*) as c FROM ${METRICS_TABLE}`).get() as { c: number };
     expect(v2Count.c).toBe(0);
-    expect(mCount.c).toBe(0);
+    expect(mCount.c).toBe(1);
     db.close();
+
+    await driver.clearAllMetrics();
+
+    const statsAfterClearMetrics = await driver.getStats();
+    expect(statsAfterClearMetrics.totalInputTokens).toBe(0);
 
     await driver.close();
   });

--- a/tests/unit/database/sqlite-cli.test.ts
+++ b/tests/unit/database/sqlite-cli.test.ts
@@ -95,6 +95,10 @@ describe("SqliteCliDriver", () => {
       expect(typeof driver.clearAllLogs).toBe("function");
     });
 
+    it("should have clearAllMetrics method", () => {
+      expect(typeof driver.clearAllMetrics).toBe("function");
+    });
+
     it("should have getStats method", () => {
       expect(typeof driver.getStats).toBe("function");
     });

--- a/tests/unit/queue/concurrency-manager.test.ts
+++ b/tests/unit/queue/concurrency-manager.test.ts
@@ -430,6 +430,66 @@ describe("ConcurrencyManager", () => {
       expect(() => manager.updateMaxWorkers(0)).toThrow("greater than 0");
       expect(() => manager.updateMaxWorkers(-1)).toThrow("greater than 0");
     });
+
+    it("CM010: applyConfig should update maxWorkers via updateMaxWorkers", async () => {
+      config.maxWorkers = 1;
+
+      let releaseTask1: () => void;
+      const blockingTask = new Promise<ProxyResult>(resolve => {
+        releaseTask1 = () => resolve({ statusCode: 200 } as ProxyResult);
+      });
+
+      const executor = vi.fn().mockImplementation(() => blockingTask);
+      manager = new ConcurrencyManager(config, executor);
+
+      const p1 = manager.submit(createMockTask("task1"));
+      const p2 = manager.submit(createMockTask("task2"));
+
+      await new Promise(r => setTimeout(r, 10));
+      expect(manager.getStats().queueLength).toBe(1);
+
+      manager.applyConfig({
+        ...config,
+        maxWorkers: 2,
+      });
+
+      await new Promise(r => setTimeout(r, 200));
+      expect(manager.getStats().activeWorkers).toBe(2);
+      expect(manager.getStats().queueLength).toBe(0);
+
+      releaseTask1!();
+      await Promise.all([p1, p2]);
+    });
+
+    it("CM011: applyConfig should update maxQueueSize for new submissions", async () => {
+      config.maxWorkers = 1;
+      config.maxQueueSize = 2;
+
+      let releaseTask1: () => void;
+      const blockingTask = new Promise<ProxyResult>(resolve => {
+        releaseTask1 = () => resolve({ statusCode: 200 } as ProxyResult);
+      });
+
+      const executor = vi.fn().mockImplementation(() => blockingTask);
+      manager = new ConcurrencyManager(config, executor);
+
+      void manager.submit(createMockTask("task1"));
+      void manager.submit(createMockTask("task2"));
+      const p3 = manager.submit(createMockTask("task3"));
+
+      await new Promise(r => setTimeout(r, 10));
+      expect(manager.getStats().queueLength).toBe(2);
+
+      manager.applyConfig({
+        ...config,
+        maxQueueSize: 1,
+      });
+
+      await expect(manager.submit(createMockTask("task4"))).rejects.toThrow(/Queue is full/);
+
+      releaseTask1!();
+      await p3;
+    });
   });
 
   describe("CM010: Queue clearing", () => {

--- a/tests/unit/server/queueManager.test.ts
+++ b/tests/unit/server/queueManager.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { ConfigManager } from "@/config";
+import { QueueManager } from "@/server/queueManager";
+import type { ConcurrencyConfig, ProxyResult, RequestTask, RouteQueueConfig } from "@/types";
+
+vi.mock("vscode", () => ({
+  window: {
+    createOutputChannel: vi.fn().mockReturnValue({
+      appendLine: vi.fn(),
+      show: vi.fn(),
+      clear: vi.fn(),
+      dispose: vi.fn(),
+    }),
+  },
+}));
+
+interface MockConfigState {
+  concurrency?: ConcurrencyConfig;
+  routeQueues?: RouteQueueConfig[];
+}
+
+function createMockConfigManager(initial: MockConfigState = {}) {
+  const state: MockConfigState = {
+    concurrency: initial.concurrency,
+    routeQueues: initial.routeQueues ?? [],
+  };
+
+  const manager = {
+    get configValue() {
+      return {
+        concurrency: state.concurrency,
+        routeQueues: state.routeQueues,
+      };
+    },
+    get routeQueues() {
+      return state.routeQueues;
+    },
+  } as unknown as ConfigManager;
+
+  return {
+    manager,
+    setConcurrency(concurrency: ConcurrencyConfig | undefined) {
+      state.concurrency = concurrency;
+    },
+    setRouteQueues(routeQueues: RouteQueueConfig[] | undefined) {
+      state.routeQueues = routeQueues;
+    },
+  };
+}
+
+const createMockTask = (id: string): RequestTask => ({
+  id,
+  method: "POST",
+  targetUrl: "https://api.example.com/v1/messages",
+  headers: {},
+  body: Buffer.from("{}"),
+  provider: {
+    id: "test",
+    name: "Test",
+    baseUrl: "https://api.example.com",
+    mode: "passthrough",
+    providerType: "anthropic",
+  },
+  inboundPath: "/v1/messages",
+  requestPath: "/v1/messages",
+  requestBodyLog: "",
+  originalRequestBody: "",
+  isOpenAIProvider: false,
+  clientSurface: "anthropic",
+  originalModel: "claude-sonnet-4",
+  clientId: "client-1",
+  createdAt: Date.now(),
+});
+
+describe("QueueManager.reloadFromConfig", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is a no-op before setExecutor", () => {
+    const mock = createMockConfigManager({
+      concurrency: { enabled: true, maxWorkers: 2, maxQueueSize: 5 },
+    });
+    const queueManager = new QueueManager(mock.manager);
+
+    expect(() => queueManager.reloadFromConfig()).not.toThrow();
+    expect(queueManager.getQueueForPath("/v1/messages")).toBeNull();
+  });
+
+  it("applies increased maxWorkers without recreating the default queue", async () => {
+    const mock = createMockConfigManager({
+      concurrency: { enabled: true, maxWorkers: 1, maxQueueSize: 10 },
+    });
+
+    let releaseTask1: () => void;
+    const blockingTask = new Promise<ProxyResult>(resolve => {
+      releaseTask1 = () => resolve({ statusCode: 200, headers: {}, duration: 0 });
+    });
+    const executor = vi.fn().mockImplementation(() => blockingTask);
+
+    const queueManager = new QueueManager(mock.manager);
+    queueManager.setExecutor(executor);
+    const defaultQueue = queueManager.getDefaultQueue()!;
+
+    const p1 = defaultQueue.submit(createMockTask("task1"));
+    const p2 = defaultQueue.submit(createMockTask("task2"));
+
+    await new Promise(r => setTimeout(r, 10));
+    expect(defaultQueue.getStats().activeWorkers).toBe(1);
+    expect(defaultQueue.getStats().queueLength).toBe(1);
+
+    mock.setConcurrency({ enabled: true, maxWorkers: 2, maxQueueSize: 10 });
+    queueManager.reloadFromConfig();
+
+    expect(queueManager.getDefaultQueue()).toBe(defaultQueue);
+
+    await new Promise(r => setTimeout(r, 200));
+    expect(defaultQueue.getStats().activeWorkers).toBe(2);
+    expect(defaultQueue.getStats().queueLength).toBe(0);
+
+    releaseTask1!();
+    await Promise.all([p1, p2]);
+    defaultQueue.shutdown();
+  });
+
+  it("disables the default queue when concurrency.enabled becomes false", () => {
+    const mock = createMockConfigManager({
+      concurrency: { enabled: true, maxWorkers: 2, maxQueueSize: 5 },
+    });
+
+    const queueManager = new QueueManager(mock.manager);
+    queueManager.setExecutor(() => Promise.resolve({ statusCode: 200, headers: {}, duration: 0 }));
+
+    expect(queueManager.getQueueForPath("/v1/messages")).not.toBeNull();
+
+    mock.setConcurrency(undefined);
+    queueManager.reloadFromConfig();
+
+    expect(queueManager.getQueueForPath("/v1/messages")).toBeNull();
+    expect(queueManager.getDefaultQueue()).toBeNull();
+  });
+
+  it("creates the default queue when concurrency becomes enabled", async () => {
+    const mock = createMockConfigManager({
+      concurrency: undefined,
+    });
+
+    const executor = vi.fn().mockResolvedValue({
+      statusCode: 200,
+      headers: {},
+      duration: 0,
+    } satisfies ProxyResult);
+    const queueManager = new QueueManager(mock.manager);
+    queueManager.setExecutor(executor);
+
+    expect(queueManager.getQueueForPath("/v1/messages")).toBeNull();
+
+    mock.setConcurrency({ enabled: true, maxWorkers: 1, maxQueueSize: 5 });
+    queueManager.reloadFromConfig();
+
+    const queueInfo = queueManager.getQueueForPath("/v1/messages");
+    expect(queueInfo).not.toBeNull();
+    await queueInfo!.queue.submit(createMockTask("task1"));
+    expect(executor).toHaveBeenCalledTimes(1);
+    queueInfo!.queue.shutdown();
+  });
+
+  it("syncs route queues on add, update, and remove", () => {
+    const route: RouteQueueConfig = {
+      pattern: "^/v1/messages/count_tokens$",
+      name: "count_tokens",
+      maxWorkers: 5,
+      maxQueueSize: 100,
+      compiledPattern: /^\/v1\/messages\/count_tokens$/,
+    };
+
+    const mock = createMockConfigManager({
+      concurrency: { enabled: true, maxWorkers: 1, maxQueueSize: 5 },
+      routeQueues: [route],
+    });
+
+    const queueManager = new QueueManager(mock.manager);
+    queueManager.setExecutor(() => Promise.resolve({ statusCode: 200, headers: {}, duration: 0 }));
+
+    const path = "/v1/messages/count_tokens";
+    const initial = queueManager.getQueueForPath(path);
+    expect(initial?.name).toBe("count_tokens");
+    expect(initial?.queue.getStats().maxWorkers).toBe(5);
+
+    mock.setRouteQueues([
+      {
+        ...route,
+        maxWorkers: 20,
+      },
+    ]);
+    queueManager.reloadFromConfig();
+
+    const updated = queueManager.getQueueForPath(path);
+    expect(updated?.queue).toBe(initial?.queue);
+    expect(updated?.queue.getStats().maxWorkers).toBe(20);
+
+    mock.setRouteQueues([]);
+    queueManager.reloadFromConfig();
+    expect(queueManager.getQueueForPath(path)?.name).toBe("default");
+    updated?.queue.shutdown();
+    queueManager.getDefaultQueue()?.shutdown();
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -181,6 +181,11 @@ export const api = {
       body: JSON.stringify({ clearAll: true }),
     }),
 
+  clearAllMetrics: (): Promise<void> =>
+    fetchAPI<void>("/stats", {
+      method: "DELETE",
+    }),
+
   // Stats
   getStats: (range?: StatsRange): Promise<LogStats> => {
     const params = range && range !== "all" ? `?range=${range}` : "";

--- a/web/src/features/dashboard/Dashboard.tsx
+++ b/web/src/features/dashboard/Dashboard.tsx
@@ -1,9 +1,19 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Loader2, RotateCw, Database } from "lucide-react";
+import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
+import { Loader2, RotateCw, Database, RotateCcw } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { api } from "@/api/client";
 import type { StatsRange, ServerStatus } from "@/types/api";
 import { cn } from "@/lib/utils";
@@ -59,6 +69,7 @@ export default function Dashboard() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [refreshing, setRefreshing] = useState(false);
+  const [showResetDialog, setShowResetDialog] = useState(false);
   const [range, setRange] = useState<StatsRange>("7d");
 
   const { data: status, isLoading: statusLoading } = useQuery({
@@ -85,6 +96,14 @@ export default function Dashboard() {
       setRefreshing(false);
     }
   };
+
+  const resetStatsMutation = useMutation({
+    mutationFn: () => api.clearAllMetrics(),
+    onSuccess: async () => {
+      setShowResetDialog(false);
+      await queryClient.invalidateQueries({ queryKey: ["stats"] });
+    },
+  });
 
   const provider = getProviderDisplay(status, t);
   const dbUnavailable = !statsLoading && stats?.dbAvailable === false;
@@ -117,6 +136,22 @@ export default function Dashboard() {
               </button>
             ))}
           </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7 text-xs gap-1 shrink-0"
+            onClick={() => setShowResetDialog(true)}
+            disabled={dbUnavailable || resetStatsMutation.isPending}
+            title={t("dashboard.resetStats.action")}
+          >
+            {resetStatsMutation.isPending ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <RotateCcw className="h-3 w-3" />
+            )}
+            <span className="hidden sm:inline">{t("dashboard.resetStats.action")}</span>
+          </Button>
           <Button
             type="button"
             size="sm"
@@ -421,6 +456,33 @@ export default function Dashboard() {
       )}
 
       <QueueStatus />
+
+      <AlertDialog open={showResetDialog} onOpenChange={setShowResetDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("dashboard.resetStats.title")}</AlertDialogTitle>
+            <AlertDialogDescription>{t("dashboard.resetStats.description")}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={resetStatsMutation.isPending}>
+              {t("common.cancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => resetStatsMutation.mutate()}
+              disabled={resetStatsMutation.isPending}
+            >
+              {resetStatsMutation.isPending ? (
+                <>
+                  <Loader2 className="h-3 w-3 animate-spin mr-1" />
+                  {t("dashboard.resetStats.resetting")}
+                </>
+              ) : (
+                t("dashboard.resetStats.confirm")
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/web/src/features/settings/Settings.tsx
+++ b/web/src/features/settings/Settings.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useId, useMemo, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ListFilter, Loader2, Plus, Trash2, X } from "lucide-react";
@@ -138,6 +138,8 @@ function cloneRouting(routing: RoutingSettings): RoutingSettings {
   });
 }
 
+const SAVED_MESSAGE_DURATION_MS = 5000;
+
 function SaveBar({
   mutation,
   onSave,
@@ -148,11 +150,22 @@ function SaveBar({
     error: unknown;
     isSuccess: boolean;
     data?: PatchConfigResponse;
+    reset: () => void;
   };
   onSave: () => void;
 }) {
   const { t } = useTranslation();
   const restartRequired = Boolean(mutation.isSuccess && mutation.data?.restartRequired);
+  const { isSuccess, reset } = mutation;
+
+  useEffect(() => {
+    if (!isSuccess || restartRequired) {
+      return;
+    }
+    const timer = setTimeout(() => reset(), SAVED_MESSAGE_DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [isSuccess, reset, restartRequired]);
+
   return (
     <div className="space-y-2 pt-2">
       <div className="flex items-center justify-end gap-2">
@@ -277,6 +290,16 @@ function LanguageSettingsSection({ locale }: { locale?: string }) {
       await queryClient.invalidateQueries({ queryKey: ["config"] });
     },
   });
+
+  const { isSuccess: localeSaved, reset: resetLocaleMutation } = localeMutation;
+
+  useEffect(() => {
+    if (!localeSaved) {
+      return;
+    }
+    const timer = setTimeout(() => resetLocaleMutation(), SAVED_MESSAGE_DURATION_MS);
+    return () => clearTimeout(timer);
+  }, [localeSaved, resetLocaleMutation]);
 
   const handleLocaleChange = (locale: string) => {
     const nextLocale = locale || undefined;
@@ -1317,18 +1340,8 @@ export default function Settings() {
         </Card>
       ) : data ? (
         <>
-          <LanguageSettingsSection
-            key={`locale:${data.server?.locale ?? ""}`}
-            locale={data.server?.locale}
-          />
-          <ServerSection
-            key={JSON.stringify({
-              port: data.server?.port,
-              host: data.server?.host,
-              autoStart: data.server?.autoStart,
-            })}
-            data={data.server}
-          />
+          <LanguageSettingsSection locale={data.server?.locale} />
+          <ServerSection data={data.server} />
           <RoutingSection
             key={JSON.stringify(data.routing)}
             routing={{
@@ -1338,8 +1351,8 @@ export default function Settings() {
             routingDefaults={data.routingDefaults}
             providerOptions={providerOptions}
           />
-          <ConcurrencySection key={JSON.stringify(data.concurrency)} data={data.concurrency} />
-          <LoggingSection key={JSON.stringify(data.logging)} data={data.logging} />
+          <ConcurrencySection data={data.concurrency} />
+          <LoggingSection data={data.logging} />
         </>
       ) : (
         <Card className="p-0">

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -89,6 +89,13 @@
       "30d": "30d",
       "all": "All"
     },
+    "resetStats": {
+      "action": "Reset stats",
+      "title": "Reset dashboard statistics",
+      "description": "Clear all token usage and performance metrics on the Dashboard. Request logs in the Logs tab are not affected.",
+      "confirm": "Reset statistics",
+      "resetting": "Resetting…"
+    },
     "dbUnavailable": {
       "title": "Statistics unavailable",
       "description": "The local database could not be opened. Token and performance metrics cannot be recorded or displayed. Install sqlite3 on your PATH, or use the Desktop app which includes a built-in database engine."
@@ -625,7 +632,7 @@
     },
     "clearDialog": {
       "title": "Clear All Logs",
-      "description": "Are you sure you want to clear all logs? This action cannot be undone.",
+      "description": "Delete all stored request and response bodies from the Logs tab. Dashboard token and performance statistics are not affected.",
       "clearing": "Clearing...",
       "action": "Clear All"
     }

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -89,6 +89,13 @@
       "30d": "30天",
       "all": "全部"
     },
+    "resetStats": {
+      "action": "复位统计",
+      "title": "复位仪表盘统计",
+      "description": "清空仪表盘上的 Token 用量与性能指标。Logs 页中的请求记录不受影响。",
+      "confirm": "确认复位",
+      "resetting": "复位中…"
+    },
     "dbUnavailable": {
       "title": "统计数据不可用",
       "description": "无法打开本地数据库，Token 与性能指标无法记录或展示。请在 PATH 中安装 sqlite3，或使用内置数据库引擎的 Desktop 版本。"
@@ -624,7 +631,7 @@
     },
     "clearDialog": {
       "title": "清空所有日志",
-      "description": "确定要清空所有日志吗？此操作无法撤销。",
+      "description": "删除 Logs 页中保存的全部请求与响应正文。仪表盘上的 Token 与性能统计不会受影响。",
       "clearing": "清空中...",
       "action": "清空全部"
     }


### PR DESCRIPTION
## Summary

- **Concurrency hot-reload**: Queue limits (default and per-route) apply immediately when concurrency settings change, without restarting the proxy. Added `ConcurrencyManager.applyConfig`, `QueueManager.reloadFromConfig`, and unit tests.
- **Settings UX**: Saved toast now appears on the first save and auto-hides after 5 seconds.
- **Logs vs metrics**: Clearing logs in the Logs tab removes only stored request/response bodies; dashboard token and performance metrics are preserved. A new **Reset stats** action on the Dashboard clears metrics via `DELETE /ccrelay/api/stats` without touching stored logs.

## Test plan

- [ ] Change concurrency `maxWorkers` / `maxQueueSize` in Settings, save, and confirm queue behavior updates without proxy restart
- [ ] Save Settings for the first time and confirm the success toast appears and disappears after ~5s
- [ ] Clear all logs on the Logs tab — dashboard stats should remain
- [ ] Use **Reset stats** on the Dashboard — token/performance metrics clear; stored request logs remain
- [ ] Run `npm test` for queue manager, concurrency manager, and API/database unit tests


Made with [Cursor](https://cursor.com)