### PR TITLE
chore: release 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2026-06-26
+
+Request logs now capture request and response headers with sensitive auth values masked. Dashboard token and performance metrics are stored separately from request bodies, so clearing logs or resetting stats affects only the intended data. Relays from Claude or Cowork strip volatile billing metadata from system prompts so upstream prompt caching is not invalidated on every request.
+
 ### Added
 
 **Logging**
@@ -30,10 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Protocol/Conversion**
 
 - Relaying requests from Claude or Cowork now removes volatile billing metadata injected into the system prompt, so prompt caching on upstream Anthropic-compatible providers is not invalidated on every request.
-
-## [0.2.6] - 2026-06-16 (pre-release)
-
-Pre-release line for 0.2.6.
 
 ## [0.2.5] - 2026-06-02
 


### PR DESCRIPTION
## Summary

- Finalize `CHANGELOG.md` for **0.2.6**: move `[Unreleased]` entries into the release section, add a version summary, and set the release date to 2026-06-26.
- Remove the pre-release placeholder for 0.2.6 so the changelog is ready for the official GitHub Release.

This PR is the last step before tagging `v0.2.6`. All feature and fix work for this line was already merged via #90–#94.

## Test plan

- [ ] Review `CHANGELOG.md` `[0.2.6]` section for accuracy and user-facing wording
- [ ] After merge, create GitHub Release `v0.2.6` with the changelog body
- [ ] Confirm CI attaches VSIX and desktop installers to the release


Made with [Cursor](https://cursor.com)