### PR TITLE
0.2.7 pre-release: OpenAI chat normalization and token metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7] - 2026-06-28 (pre-release)
+
+Pre-release line for 0.2.7.
+
 ## [0.2.6] - 2026-06-26
 
 Request logs now capture request and response headers with sensitive auth values masked. Dashboard token and performance metrics are stored separately from request bodies, so clearing logs or resetting stats affects only the intended data. Relays from Claude or Cowork strip volatile billing metadata from system prompts so upstream prompt caching is not invalidated on every request.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccrelay-monorepo",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccrelay-monorepo",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -10347,7 +10347,7 @@
     },
     "packages/core": {
       "name": "@ccrelay/core",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.1",
@@ -10405,7 +10405,7 @@
     },
     "packages/desktop": {
       "name": "ccrelay-desktop",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -10421,7 +10421,7 @@
     },
     "packages/desktop-tauri": {
       "name": "@ccrelay/desktop-tauri",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasInstallScript": true,
       "dependencies": {
         "@ccrelay/core": "*",
@@ -11117,7 +11117,7 @@
     },
     "packages/vscode": {
       "name": "ccrelay-vscode",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "MIT",
       "dependencies": {
         "@ccrelay/core": "*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "ccrelay-monorepo",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "license": "MIT",
   "packageManager": "npm@10.9.4",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ccrelay/core",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "description": "CCRelay proxy server core (Node.js)",
   "license": "MIT",

--- a/packages/core/src/converter/index.ts
+++ b/packages/core/src/converter/index.ts
@@ -176,7 +176,10 @@ export {
 
 export {
   assignOpenAiChatMaxOutput,
+  ensureOpenAiChatStreamUsageIncluded,
+  normalizeOpenAiChatMaxOutputFields,
   openaiChatUsesMaxCompletionTokens,
+  resolveOpenAiChatUsesMaxCompletionTokens,
   type OpenAiChatMaxOutputTarget,
 } from "./rules/openai-chat-model-rules";
 

--- a/packages/core/src/converter/rules/openai-chat-model-rules.ts
+++ b/packages/core/src/converter/rules/openai-chat-model-rules.ts
@@ -24,13 +24,91 @@ export function openaiChatUsesMaxCompletionTokens(model: string): boolean {
   return /^o\d/.test(m);
 }
 
+/**
+ * Whether the outbound body should use `max_completion_tokens`, using upstream `model`
+ * and optionally the client wire model (e.g. before Azure deployment name mapping).
+ */
+export function resolveOpenAiChatUsesMaxCompletionTokens(
+  upstreamModel: string,
+  clientModelHint?: string
+): boolean {
+  if (openaiChatUsesMaxCompletionTokens(upstreamModel)) {
+    return true;
+  }
+  if (clientModelHint !== undefined && openaiChatUsesMaxCompletionTokens(clientModelHint)) {
+    return true;
+  }
+  return false;
+}
+
 /** Set exactly one of max_tokens / max_completion_tokens on the outbound Chat Completions body. */
-export function assignOpenAiChatMaxOutput(openai: OpenAiChatMaxOutputTarget, value: number): void {
+export function assignOpenAiChatMaxOutput(
+  openai: OpenAiChatMaxOutputTarget,
+  value: number,
+  clientModelHint?: string
+): void {
   delete openai.max_tokens;
   delete openai.max_completion_tokens;
-  if (openaiChatUsesMaxCompletionTokens(openai.model)) {
+  if (resolveOpenAiChatUsesMaxCompletionTokens(openai.model, clientModelHint)) {
     openai.max_completion_tokens = value;
   } else {
     openai.max_tokens = value;
   }
+}
+
+/**
+ * Normalize whichever max-output field the client sent to the single field the upstream model expects.
+ * No-op when neither field is present.
+ */
+export function normalizeOpenAiChatMaxOutputFields(
+  body: Record<string, unknown>,
+  clientModelHint?: string
+): void {
+  const model = typeof body.model === "string" ? body.model : "";
+  const maxTokens = typeof body.max_tokens === "number" ? body.max_tokens : undefined;
+  const maxCompletion =
+    typeof body.max_completion_tokens === "number" ? body.max_completion_tokens : undefined;
+  const value = maxCompletion ?? maxTokens;
+  if (value === undefined) {
+    return;
+  }
+
+  delete body.max_tokens;
+  delete body.max_completion_tokens;
+  if (resolveOpenAiChatUsesMaxCompletionTokens(model, clientModelHint)) {
+    body.max_completion_tokens = value;
+  } else {
+    body.max_tokens = value;
+  }
+}
+
+function isStreamEnabled(value: unknown): boolean {
+  return value === true || value === "true";
+}
+
+/**
+ * OpenAI Chat Completions streaming omits `usage` unless `stream_options.include_usage` is true.
+ * Inject it on outbound bodies so relay metrics can record token counts.
+ */
+export function ensureOpenAiChatStreamUsageIncluded(body: Record<string, unknown>): void {
+  if (!isStreamEnabled(body.stream)) {
+    return;
+  }
+
+  const existing = body.stream_options;
+  if (
+    existing !== undefined &&
+    existing !== null &&
+    typeof existing === "object" &&
+    !Array.isArray(existing)
+  ) {
+    const opts = existing as Record<string, unknown>;
+    if (opts.include_usage === true) {
+      return;
+    }
+    opts.include_usage = true;
+    return;
+  }
+
+  body.stream_options = { include_usage: true };
 }

--- a/packages/core/src/server/headerMask.ts
+++ b/packages/core/src/server/headerMask.ts
@@ -12,6 +12,7 @@ export const SENSITIVE_HEADER_NAMES = new Set([
   "authorization",
   "x-api-key",
   "proxy-authorization",
+  "acl-token",
 ]);
 
 /** Fully masked placeholder for secrets too short to safely show first/last 4. */

--- a/packages/core/src/server/request/bodyProcessor.ts
+++ b/packages/core/src/server/request/bodyProcessor.ts
@@ -18,6 +18,10 @@ import {
 } from "../../converter";
 import type { OpenAIMessage } from "../../converter/adapters/anthropic-to-openai-chat-request";
 import {
+  normalizeOpenAiChatMaxOutputFields,
+  ensureOpenAiChatStreamUsageIncluded,
+} from "../../converter/rules/openai-chat-model-rules";
+import {
   normalizeToolsForProvider,
   applyPlatformMessageTransforms,
   applyPlatformQueryPolicy,
@@ -64,7 +68,11 @@ function applyPlatformMessagesToOpenAiChatRecord(
   data.messages = applyPlatformMessageTransforms(messages as OpenAIMessage[], baseUrl);
 }
 
-function applyPlatformTransformsToOpenAiChatBody(body: Buffer, baseUrl: string): Buffer {
+function applyPlatformTransformsToOpenAiChatBody(
+  body: Buffer,
+  baseUrl: string,
+  clientModelHint?: string
+): Buffer {
   if (!body.length) {
     return body;
   }
@@ -73,6 +81,8 @@ function applyPlatformTransformsToOpenAiChatBody(body: Buffer, baseUrl: string):
     if (!isOpenAIChatCompletionsRequest(data)) {
       return body;
     }
+    normalizeOpenAiChatMaxOutputFields(data, clientModelHint);
+    ensureOpenAiChatStreamUsageIncluded(data);
     applyHostedToolsToOpenAiChatRecord(data, baseUrl);
     openaiChatStrictToolsSanitize(data, baseUrl);
     applyPlatformMessagesToOpenAiChatRecord(data, baseUrl);
@@ -322,7 +332,11 @@ export class BodyProcessor {
     }
 
     if (isOpenAiChatCompletionsTargetPath(routing.targetPath)) {
-      body = applyPlatformTransformsToOpenAiChatBody(body, routing.provider.baseUrl);
+      body = applyPlatformTransformsToOpenAiChatBody(
+        body,
+        routing.provider.baseUrl,
+        clientWireModel
+      );
     }
 
     if (databaseEnabled && body && body.length > 0) {

--- a/packages/desktop-tauri/package.json
+++ b/packages/desktop-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ccrelay/desktop-tauri",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "description": "CCRelay desktop app (Tauri)",
   "scripts": {

--- a/packages/desktop-tauri/src-tauri/Cargo.lock
+++ b/packages/desktop-tauri/src-tauri/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "ccrelay"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "open",
  "serde",

--- a/packages/desktop-tauri/src-tauri/Cargo.toml
+++ b/packages/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccrelay"
-version = "0.2.6"
+version = "0.2.7"
 description = "CCRelay desktop app"
 authors = ["Inflab"]
 edition = "2021"

--- a/packages/desktop-tauri/src-tauri/tauri.conf.json
+++ b/packages/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CCRelay",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "identifier": "org.inflab.ccrelay",
   "build": {
     "frontendDist": "../web",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccrelay-desktop",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "description": "CCRelay desktop tray app",
   "license": "MIT",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "CCRelay",
   "icon": "assets/icon-128.png",
   "description": "VSCode extension with built-in API proxy server - switch between AI providers seamlessly",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "publisher": "inflab",
   "license": "MIT",
   "repository": {

--- a/tests/unit/converter/rules/openai-chat-model-rules.test.ts
+++ b/tests/unit/converter/rules/openai-chat-model-rules.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   openaiChatUsesMaxCompletionTokens,
+  resolveOpenAiChatUsesMaxCompletionTokens,
   assignOpenAiChatMaxOutput,
+  normalizeOpenAiChatMaxOutputFields,
+  ensureOpenAiChatStreamUsageIncluded,
 } from "@/converter/rules/openai-chat-model-rules";
 import type { OpenAIMessageRequest } from "@/converter/adapters/anthropic-to-openai-chat-request";
+
+/* eslint-disable @typescript-eslint/naming-convention -- OpenAI wire field names in test fixtures */
 
 describe("openaiChatUsesMaxCompletionTokens", () => {
   it("is true for gpt-5 family", () => {
@@ -31,28 +36,135 @@ describe("openaiChatUsesMaxCompletionTokens", () => {
 
 describe("assignOpenAiChatMaxOutput", () => {
   it("sets max_completion_tokens and clears max_tokens for gpt-5", () => {
-    /* eslint-disable @typescript-eslint/naming-convention -- OpenAI wire fields */
     const req: OpenAIMessageRequest = {
       model: "gpt-5",
       messages: [],
       max_tokens: 99,
     };
-    /* eslint-enable @typescript-eslint/naming-convention */
     assignOpenAiChatMaxOutput(req, 1234);
     expect(req.max_completion_tokens).toBe(1234);
     expect(req.max_tokens).toBeUndefined();
   });
 
   it("sets max_tokens and clears max_completion_tokens for gpt-4o", () => {
-    /* eslint-disable @typescript-eslint/naming-convention -- OpenAI wire fields */
     const req: OpenAIMessageRequest = {
       model: "gpt-4o",
       messages: [],
       max_completion_tokens: 99,
     };
-    /* eslint-enable @typescript-eslint/naming-convention */
     assignOpenAiChatMaxOutput(req, 2000);
     expect(req.max_tokens).toBe(2000);
     expect(req.max_completion_tokens).toBeUndefined();
   });
+
+  it("uses client model hint when upstream model is an Azure deployment name", () => {
+    const req: OpenAIMessageRequest = {
+      model: "my-gpt5-prod",
+      messages: [],
+    };
+    assignOpenAiChatMaxOutput(req, 8000, "gpt-5.4");
+    expect(req.max_completion_tokens).toBe(8000);
+    expect(req.max_tokens).toBeUndefined();
+  });
+});
+
+describe("resolveOpenAiChatUsesMaxCompletionTokens", () => {
+  it("falls back to client model hint for deployment names", () => {
+    expect(resolveOpenAiChatUsesMaxCompletionTokens("my-deploy", "gpt-5-mini")).toBe(true);
+    expect(resolveOpenAiChatUsesMaxCompletionTokens("my-deploy", "gpt-4o")).toBe(false);
+  });
+});
+
+describe("normalizeOpenAiChatMaxOutputFields", () => {
+  it("maps max_tokens to max_completion_tokens for gpt-5 passthrough bodies", () => {
+    const body: Record<string, unknown> = {
+      model: "gpt-5.4",
+      messages: [],
+      max_tokens: 4096,
+    };
+    normalizeOpenAiChatMaxOutputFields(body);
+    expect(body.max_completion_tokens).toBe(4096);
+    expect(body.max_tokens).toBeUndefined();
+  });
+
+  it("maps max_tokens using client hint when model is an Azure deployment", () => {
+    const body: Record<string, unknown> = {
+      model: "prod-gpt5-eastus",
+      messages: [],
+      max_tokens: 8192,
+    };
+    normalizeOpenAiChatMaxOutputFields(body, "gpt-5.4-mini");
+    expect(body.max_completion_tokens).toBe(8192);
+    expect(body.max_tokens).toBeUndefined();
+  });
+
+  it("keeps max_tokens for gpt-4o", () => {
+    const body: Record<string, unknown> = {
+      model: "gpt-4o",
+      messages: [],
+      max_tokens: 2048,
+    };
+    normalizeOpenAiChatMaxOutputFields(body);
+    expect(body.max_tokens).toBe(2048);
+    expect(body.max_completion_tokens).toBeUndefined();
+  });
+
+  it("prefers max_completion_tokens when both are present", () => {
+    const body: Record<string, unknown> = {
+      model: "gpt-5",
+      messages: [],
+      max_tokens: 100,
+      max_completion_tokens: 500,
+    };
+    normalizeOpenAiChatMaxOutputFields(body);
+    expect(body.max_completion_tokens).toBe(500);
+    expect(body.max_tokens).toBeUndefined();
+  });
+});
+/* eslint-enable @typescript-eslint/naming-convention */
+
+describe("ensureOpenAiChatStreamUsageIncluded", () => {
+  /* eslint-disable @typescript-eslint/naming-convention -- OpenAI wire field names in test fixtures */
+  it("adds stream_options.include_usage when stream is true", () => {
+    const body: Record<string, unknown> = {
+      model: "gpt-5.4",
+      stream: true,
+      messages: [],
+    };
+    ensureOpenAiChatStreamUsageIncluded(body);
+    expect(body.stream_options).toEqual({ include_usage: true });
+  });
+
+  it("sets include_usage on existing stream_options", () => {
+    const body: Record<string, unknown> = {
+      model: "gpt-5.4",
+      stream: true,
+      stream_options: { include_obfuscation: false },
+      messages: [],
+    };
+    ensureOpenAiChatStreamUsageIncluded(body);
+    expect(body.stream_options).toEqual({ include_obfuscation: false, include_usage: true });
+  });
+
+  it("leaves body unchanged when include_usage is already true", () => {
+    const body: Record<string, unknown> = {
+      model: "gpt-5.4",
+      stream: true,
+      stream_options: { include_usage: true },
+      messages: [],
+    };
+    ensureOpenAiChatStreamUsageIncluded(body);
+    expect(body.stream_options).toEqual({ include_usage: true });
+  });
+
+  it("no-op when stream is false", () => {
+    const body: Record<string, unknown> = {
+      model: "gpt-5.4",
+      stream: false,
+      messages: [],
+    };
+    ensureOpenAiChatStreamUsageIncluded(body);
+    expect(body.stream_options).toBeUndefined();
+  });
+  /* eslint-enable @typescript-eslint/naming-convention */
 });

--- a/tests/unit/server/headerMask.test.ts
+++ b/tests/unit/server/headerMask.test.ts
@@ -72,11 +72,22 @@ describe("server: headerMask", () => {
       expect(parsed["set-cookie"]).toEqual(["s=1; Path=/", "t=2"]);
     });
 
-    it("treats authorization, x-api-key, and proxy-authorization as sensitive", () => {
+    it("treats authorization, x-api-key, proxy-authorization, and acl-token as sensitive", () => {
       expect(SENSITIVE_HEADER_NAMES.has("authorization")).toBe(true);
       expect(SENSITIVE_HEADER_NAMES.has("x-api-key")).toBe(true);
       expect(SENSITIVE_HEADER_NAMES.has("proxy-authorization")).toBe(true);
+      expect(SENSITIVE_HEADER_NAMES.has("acl-token")).toBe(true);
       expect(SENSITIVE_HEADER_NAMES.has("content-type")).toBe(false);
+    });
+
+    it("masks acl-token header values", () => {
+      const out = maskHeadersForLog({
+        "acl-token": "acl-secret-token-value-12345",
+        "content-type": "application/json",
+      });
+      const parsed = JSON.parse(out!) as Record<string, string>;
+      expect(parsed["acl-token"]).toBe("acl-***2345");
+      expect(parsed["content-type"]).toBe("application/json");
     });
   });
 });

--- a/tests/unit/server/request/bodyProcessor.azureMaxTokens.test.ts
+++ b/tests/unit/server/request/bodyProcessor.azureMaxTokens.test.ts
@@ -1,0 +1,86 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { describe, expect, it } from "vitest";
+import { BodyProcessor } from "@/server/request/bodyProcessor";
+import type { RoutingContext } from "@/server/request/context";
+import type { Provider } from "@/types";
+
+describe("BodyProcessor Azure OpenAI max_tokens normalization", () => {
+  const azureOpenAi: Provider = {
+    id: "azure-gpt",
+    name: "Azure",
+    baseUrl: "https://example.cognitiveservices.azure.com/openai/v1",
+    mode: "passthrough",
+    providerType: "openai",
+    apiKey: "sk",
+    modelMap: [{ pattern: "gpt-5.4", model: "prod-gpt5-eastus" }],
+  };
+
+  function makeRouting(overrides: Partial<RoutingContext>): RoutingContext {
+    return {
+      blocked: false,
+      method: "POST",
+      path: "/openai/v1/chat/completions",
+      provider: azureOpenAi,
+      clientHeaders: {},
+      headers: {},
+      targetUrl: "https://example.cognitiveservices.azure.com/openai/v1/chat/completions",
+      targetPath: "/chat/completions",
+      targetQuery: "",
+      isRouted: false,
+      isOpenAIProvider: true,
+      clientSurface: "openai",
+      ...overrides,
+    };
+  }
+
+  it("maps max_tokens to max_completion_tokens on OpenAI passthrough to Azure gpt-5", () => {
+    const body = Buffer.from(
+      JSON.stringify({
+        model: "gpt-5.4",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 4096,
+      })
+    );
+    const out = new BodyProcessor().process(body, makeRouting({}), false);
+    const parsed = JSON.parse(out.body.toString("utf-8")) as Record<string, unknown>;
+    expect(parsed.max_completion_tokens).toBe(4096);
+    expect(parsed.max_tokens).toBeUndefined();
+  });
+
+  it("uses client model hint after deployment mapping for Anthropic inbound", () => {
+    const body = Buffer.from(
+      JSON.stringify({
+        model: "gpt-5.4",
+        max_tokens: 8192,
+        messages: [{ role: "user", content: "hi" }],
+      })
+    );
+    const out = new BodyProcessor().process(
+      body,
+      makeRouting({
+        path: "/anthropic/v1/messages",
+        clientSurface: "anthropic",
+        targetPath: "/chat/completions",
+      }),
+      false
+    );
+    const parsed = JSON.parse(out.body.toString("utf-8")) as Record<string, unknown>;
+    expect(parsed.model).toBe("prod-gpt5-eastus");
+    expect(parsed.max_completion_tokens).toBe(8192);
+    expect(parsed.max_tokens).toBeUndefined();
+  });
+
+  it("injects stream_options.include_usage for streaming OpenAI passthrough", () => {
+    const body = Buffer.from(
+      JSON.stringify({
+        model: "gpt-5.4",
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      })
+    );
+    const out = new BodyProcessor().process(body, makeRouting({}), false);
+    const parsed = JSON.parse(out.body.toString("utf-8")) as Record<string, unknown>;
+    expect(parsed.stream_options).toEqual({ include_usage: true });
+  });
+});


### PR DESCRIPTION
## Summary

- Normalize outbound OpenAI Chat Completions requests: map `max_tokens` to `max_completion_tokens` for gpt-5/o-series models (including Azure deployment names via client model hint), and inject `stream_options.include_usage` for streaming requests so dashboard token metrics are recorded.
- Mask `acl-token` in request/response header logs alongside existing sensitive auth headers.
- Bump monorepo version to **0.2.7** (pre-release).

## Test plan

- [x] Unit tests: `openai-chat-model-rules`, `bodyProcessor.azureMaxTokens`, `headerMask`
- [ ] OpenAI streaming `/chat/completions` through CCRelay → verify upstream request includes `stream_options.include_usage: true` and dashboard shows token counts
- [ ] Azure OpenAI gpt-5 with deployment model mapping → verify outbound body uses `max_completion_tokens`, not `max_tokens`
- [ ] Check Logs detail panel: `acl-token` header values are masked


Made with [Cursor](https://cursor.com)