### PR TITLE
fix: repair malformed tool-call arguments and outbound request normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Protocol/Conversion**
 
 - Strip unsupported reasoning parameters when forwarding to models that do not support them (e.g. effort on Claude Haiku), preventing client-injected fields from causing upstream errors.
+- Strip inline `system` role messages when forwarding to models that reject them (e.g. Claude Haiku), merging content into the top-level `system` field.
 
 ## [0.2.7] - 2026-06-28 (pre-release)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+**Protocol/Conversion**
+
+- Strip unsupported reasoning parameters when forwarding to models that do not support them (e.g. effort on Claude Haiku), preventing client-injected fields from causing upstream errors.
+
 ## [0.2.7] - 2026-06-28 (pre-release)
 
 Pre-release line for 0.2.7.

--- a/packages/core/src/converter/adapters/openai-chat-to-anthropic-request.ts
+++ b/packages/core/src/converter/adapters/openai-chat-to-anthropic-request.ts
@@ -17,6 +17,7 @@ import {
 } from "./anthropic-to-openai-chat-request";
 import { mapOpenAiWirePathToAnthropicUpstream } from "../paths";
 import { openAIHostedToolToAnthropicServerToolDef } from "../tool-schema-conversion";
+import { resolveModelMeta } from "../model-meta/registry";
 
 export interface OpenAIToAnthropicRequestResult {
   request: AnthropicMessageRequest;
@@ -68,15 +69,23 @@ export function convertOpenAIRequestToAnthropic(
     out.stop_sequences = Array.isArray(openai.stop) ? openai.stop : [openai.stop];
   }
   if (openai.reasoning_effort !== undefined) {
-    const effortStr =
-      typeof openai.reasoning_effort === "string" && openai.reasoning_effort.trim() !== ""
-        ? openai.reasoning_effort.toLowerCase()
-        : undefined;
-    if (effortStr === "none") {
-      out.thinking = { type: "disabled" };
-    } else {
-      out.thinking = { type: "adaptive" };
-      out.output_config = { effort: mapOpenAIEffortToAnthropic(effortStr) };
+    const rawEffort = openai.reasoning_effort;
+    let effortStr: string | undefined;
+    if (typeof rawEffort === "string" && rawEffort.trim() !== "") {
+      effortStr = rawEffort.toLowerCase();
+    } else if (typeof rawEffort === "string") {
+      effortStr = "";
+    }
+    const meta = resolveModelMeta(openai.model, { vendor: "anthropic" });
+    if (meta.reasoning.supportsReasoningEffort !== false) {
+      if (effortStr === "none" && meta.reasoning.supportsThinking) {
+        out.thinking = { type: "disabled" };
+      } else if (effortStr !== undefined && meta.reasoning.supportsAdaptiveThinking) {
+        out.thinking = { type: "adaptive" };
+        if (meta.reasoning.supportsEffort) {
+          out.output_config = { effort: mapOpenAIEffortToAnthropic(effortStr) };
+        }
+      }
     }
   }
 

--- a/packages/core/src/converter/adapters/openai-responses-to-chat.ts
+++ b/packages/core/src/converter/adapters/openai-responses-to-chat.ts
@@ -12,6 +12,7 @@ import type {
   OpenAIToolChoice,
 } from "./anthropic-to-openai-chat-request";
 import { assignOpenAiChatMaxOutput } from "../rules/openai-chat-model-rules";
+import { normalizeOpenAiToolCallArgumentsString } from "../rules/openai-tool-call-arguments";
 import { isOpenAIChatCompletionsRequest } from "./openai-chat-to-anthropic-request";
 
 /** Collect tools for Responses echo: `function` defs, nested `namespace` bundles (inner tools), and hosted tools (web_search, etc.). */
@@ -398,8 +399,9 @@ function appendInputItemsToMessages(items: unknown[], messages: OpenAIMessage[])
 
     if (typ === "function_call") {
       const name = String((o as { name?: string }).name ?? "");
-      const argStr =
+      const rawArgStr =
         typeof o.arguments === "string" ? o.arguments : JSON.stringify(o.arguments ?? {});
+      const argStr = normalizeOpenAiToolCallArgumentsString(rawArgStr);
       const rawId = o as { call_id?: unknown; id?: unknown };
       const callId =
         typeof rawId.call_id === "string"

--- a/packages/core/src/converter/anthropic-request-sanitize.ts
+++ b/packages/core/src/converter/anthropic-request-sanitize.ts
@@ -3,6 +3,8 @@
  * These volatile system blocks break prompt caching prefixes when cc_version/cch change.
  */
 
+import { sanitizeAnthropicRequestRecord } from "./model-meta/sanitize-anthropic";
+
 /** Entire block must be a `key=value;` sequence — no trailing real prompt content. */
 const BILLING_HEADER_FULL_RE = /^x-anthropic-billing-header:\s*(?:[a-z0-9_]+\s*=\s*[^;]*;\s*)+$/i;
 
@@ -80,4 +82,36 @@ export function stripBillingHeaderFromAnthropicBody(body: Buffer): Buffer {
   }
 
   return Buffer.from(JSON.stringify(data), "utf-8");
+}
+
+function sanitizeAnthropicRecordInPlace(data: Record<string, unknown>): boolean {
+  const before = JSON.stringify(data);
+  sanitizeAnthropicRequestRecord(data);
+  return JSON.stringify(data) !== before;
+}
+
+/**
+ * Billing-header strip + model-capability sanitize for outbound Anthropic Messages bodies.
+ * Returns the original buffer when nothing changes.
+ */
+export function sanitizeAnthropicOutboundBody(body: Buffer): Buffer {
+  let next = stripBillingHeaderFromAnthropicBody(body);
+  if (!next || next.length === 0) {
+    return next;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(next.toString("utf-8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return next;
+    }
+    const data = parsed as Record<string, unknown>;
+    if (sanitizeAnthropicRecordInPlace(data)) {
+      next = Buffer.from(JSON.stringify(data), "utf-8");
+    }
+  } catch {
+    return next;
+  }
+
+  return next;
 }

--- a/packages/core/src/converter/index.ts
+++ b/packages/core/src/converter/index.ts
@@ -184,6 +184,11 @@ export {
 } from "./rules/openai-chat-model-rules";
 
 export {
+  normalizeOpenAiToolCallArgumentsString,
+  sanitizeOpenAiChatToolArgumentsInMessages,
+} from "./rules/openai-tool-call-arguments";
+
+export {
   stripBillingHeaderFromAnthropicBody,
   isBillingHeaderBlock,
 } from "./anthropic-request-sanitize";

--- a/packages/core/src/converter/index.ts
+++ b/packages/core/src/converter/index.ts
@@ -190,5 +190,16 @@ export {
 
 export {
   stripBillingHeaderFromAnthropicBody,
+  sanitizeAnthropicOutboundBody,
   isBillingHeaderBlock,
 } from "./anthropic-request-sanitize";
+
+export {
+  resolveModelMeta,
+  listModelFamilies,
+  type ModelMeta,
+  type ModelVendor,
+  type ResolveModelMetaOptions,
+  sanitizeAnthropicRequestRecord,
+  sanitizeOpenAiChatRequestRecord,
+} from "./model-meta";

--- a/packages/core/src/converter/index.ts
+++ b/packages/core/src/converter/index.ts
@@ -198,6 +198,7 @@ export {
   resolveModelMeta,
   listModelFamilies,
   type ModelMeta,
+  type ModelAnthropicMeta,
   type ModelVendor,
   type ResolveModelMetaOptions,
   sanitizeAnthropicRequestRecord,

--- a/packages/core/src/converter/model-meta/defaults.ts
+++ b/packages/core/src/converter/model-meta/defaults.ts
@@ -29,6 +29,7 @@ export const VENDOR_DEFAULT_META: Readonly<Record<ModelVendor, ModelMeta>> = {
     vendor: "anthropic",
     reasoning: { ...REASONING_CAPABLE },
     vision: { enabled: true },
+    anthropic: { supportsSystemRoleInMessages: true },
   },
   openai: {
     id: "openai-default",
@@ -62,6 +63,7 @@ export function cloneModelMeta(meta: ModelMeta): ModelMeta {
     ...(meta.openaiChat ? { openaiChat: { ...meta.openaiChat } } : {}),
     ...(meta.gemini ? { gemini: { ...meta.gemini } } : {}),
     ...(meta.deepseek ? { deepseek: { ...meta.deepseek } } : {}),
+    ...(meta.anthropic ? { anthropic: { ...meta.anthropic } } : {}),
   };
 }
 

--- a/packages/core/src/converter/model-meta/defaults.ts
+++ b/packages/core/src/converter/model-meta/defaults.ts
@@ -1,0 +1,68 @@
+import type { ModelMeta, ModelVendor } from "./types";
+
+const REASONING_CAPABLE: ModelMeta["reasoning"] = {
+  enabled: true,
+  supportsEffort: true,
+  supportsThinking: true,
+  supportsAdaptiveThinking: true,
+  supportsReasoningEffort: true,
+};
+
+const NO_REASONING: ModelMeta["reasoning"] = {
+  enabled: false,
+  supportsEffort: false,
+  supportsThinking: false,
+  supportsAdaptiveThinking: false,
+  supportsReasoningEffort: false,
+};
+
+export const GLOBAL_UNKNOWN_MODEL_META: ModelMeta = {
+  id: "unknown",
+  vendor: "generic",
+  reasoning: { ...NO_REASONING },
+  vision: { enabled: false },
+};
+
+export const VENDOR_DEFAULT_META: Readonly<Record<ModelVendor, ModelMeta>> = {
+  anthropic: {
+    id: "anthropic-default",
+    vendor: "anthropic",
+    reasoning: { ...REASONING_CAPABLE },
+    vision: { enabled: true },
+  },
+  openai: {
+    id: "openai-default",
+    vendor: "openai",
+    reasoning: { enabled: false, supportsReasoningEffort: false },
+    vision: { enabled: false },
+    openaiChat: { usesMaxCompletionTokens: false },
+  },
+  gemini: {
+    id: "gemini-default",
+    vendor: "gemini",
+    reasoning: { enabled: true, supportsReasoningEffort: true },
+    vision: { enabled: true },
+    gemini: { canDisableThinking: true, is25Family: false },
+  },
+  deepseek: {
+    id: "deepseek-default",
+    vendor: "deepseek",
+    reasoning: { enabled: false, supportsReasoningEffort: true },
+    vision: { enabled: false },
+    deepseek: { isReasoner: false },
+  },
+  generic: GLOBAL_UNKNOWN_MODEL_META,
+};
+
+export function cloneModelMeta(meta: ModelMeta): ModelMeta {
+  return {
+    ...meta,
+    reasoning: { ...meta.reasoning },
+    vision: { ...meta.vision },
+    ...(meta.openaiChat ? { openaiChat: { ...meta.openaiChat } } : {}),
+    ...(meta.gemini ? { gemini: { ...meta.gemini } } : {}),
+    ...(meta.deepseek ? { deepseek: { ...meta.deepseek } } : {}),
+  };
+}
+
+export { REASONING_CAPABLE, NO_REASONING };

--- a/packages/core/src/converter/model-meta/families.anthropic.ts
+++ b/packages/core/src/converter/model-meta/families.anthropic.ts
@@ -1,0 +1,32 @@
+import { NO_REASONING, REASONING_CAPABLE } from "./defaults";
+import type { ModelFamilyEntry } from "./types";
+
+export const ANTHROPIC_MODEL_FAMILIES: readonly ModelFamilyEntry[] = [
+  {
+    id: "claude-haiku",
+    vendor: "anthropic",
+    match: "claude-haiku-*",
+    meta: {
+      reasoning: { ...NO_REASONING },
+      vision: { enabled: true },
+    },
+  },
+  {
+    id: "claude-sonnet",
+    vendor: "anthropic",
+    match: "claude-sonnet-*",
+    meta: {
+      reasoning: { ...REASONING_CAPABLE },
+      vision: { enabled: true },
+    },
+  },
+  {
+    id: "claude-opus",
+    vendor: "anthropic",
+    match: "claude-opus-*",
+    meta: {
+      reasoning: { ...REASONING_CAPABLE },
+      vision: { enabled: true },
+    },
+  },
+];

--- a/packages/core/src/converter/model-meta/families.anthropic.ts
+++ b/packages/core/src/converter/model-meta/families.anthropic.ts
@@ -9,6 +9,7 @@ export const ANTHROPIC_MODEL_FAMILIES: readonly ModelFamilyEntry[] = [
     meta: {
       reasoning: { ...NO_REASONING },
       vision: { enabled: true },
+      anthropic: { supportsSystemRoleInMessages: false },
     },
   },
   {

--- a/packages/core/src/converter/model-meta/families.deepseek.ts
+++ b/packages/core/src/converter/model-meta/families.deepseek.ts
@@ -1,0 +1,24 @@
+import type { ModelFamilyEntry } from "./types";
+
+export const DEEPSEEK_MODEL_FAMILIES: readonly ModelFamilyEntry[] = [
+  {
+    id: "deepseek-reasoner",
+    vendor: "deepseek",
+    match: ["deepseek-reasoner*", "deepseek-r1*"],
+    meta: {
+      reasoning: { enabled: true, supportsReasoningEffort: true },
+      vision: { enabled: false },
+      deepseek: { isReasoner: true },
+    },
+  },
+  {
+    id: "deepseek-chat",
+    vendor: "deepseek",
+    match: "deepseek-chat*",
+    meta: {
+      reasoning: { enabled: false, supportsReasoningEffort: true },
+      vision: { enabled: false },
+      deepseek: { isReasoner: false },
+    },
+  },
+];

--- a/packages/core/src/converter/model-meta/families.gemini.ts
+++ b/packages/core/src/converter/model-meta/families.gemini.ts
@@ -1,0 +1,35 @@
+import type { ModelFamilyEntry } from "./types";
+
+export const GEMINI_MODEL_FAMILIES: readonly ModelFamilyEntry[] = [
+  {
+    id: "gemini-2.5-flash",
+    vendor: "gemini",
+    match: ["*2.5*flash*", "gemini-2.5-flash*"],
+    meta: {
+      reasoning: { enabled: true, supportsReasoningEffort: true },
+      vision: { enabled: true },
+      gemini: { canDisableThinking: true, is25Family: true },
+    },
+  },
+  {
+    id: "gemini-2.5-pro",
+    vendor: "gemini",
+    match: ["*2.5*pro*", "gemini-2.5-pro*"],
+    meta: {
+      reasoning: { enabled: true, supportsReasoningEffort: true },
+      vision: { enabled: true },
+      gemini: { canDisableThinking: false, is25Family: true },
+    },
+  },
+  {
+    id: "gemini-3-plus",
+    vendor: "gemini",
+    match: [],
+    matchRegex: /^gemini-[3-9]/,
+    meta: {
+      reasoning: { enabled: true, supportsReasoningEffort: true },
+      vision: { enabled: true },
+      gemini: { canDisableThinking: false, is25Family: false },
+    },
+  },
+];

--- a/packages/core/src/converter/model-meta/families.openai.ts
+++ b/packages/core/src/converter/model-meta/families.openai.ts
@@ -1,0 +1,43 @@
+import type { ModelFamilyEntry } from "./types";
+
+const OPENAI_REASONING_EFFORTS = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
+
+export const OPENAI_MODEL_FAMILIES: readonly ModelFamilyEntry[] = [
+  {
+    id: "gpt-5",
+    vendor: "openai",
+    match: "gpt-5*",
+    meta: {
+      reasoning: { enabled: true, supportsReasoningEffort: true },
+      vision: { enabled: true },
+      openaiChat: {
+        usesMaxCompletionTokens: true,
+        validReasoningEfforts: OPENAI_REASONING_EFFORTS,
+      },
+    },
+  },
+  {
+    id: "o-series",
+    vendor: "openai",
+    match: [],
+    matchRegex: /^o\d/,
+    meta: {
+      reasoning: { enabled: true, supportsReasoningEffort: true },
+      vision: { enabled: true },
+      openaiChat: {
+        usesMaxCompletionTokens: true,
+        validReasoningEfforts: OPENAI_REASONING_EFFORTS,
+      },
+    },
+  },
+  {
+    id: "gpt-4o",
+    vendor: "openai",
+    match: "gpt-4o*",
+    meta: {
+      reasoning: { enabled: false, supportsReasoningEffort: false },
+      vision: { enabled: true },
+      openaiChat: { usesMaxCompletionTokens: false },
+    },
+  },
+];

--- a/packages/core/src/converter/model-meta/index.ts
+++ b/packages/core/src/converter/model-meta/index.ts
@@ -1,4 +1,5 @@
 export type {
+  ModelAnthropicMeta,
   ModelDeepSeekMeta,
   ModelFamilyEntry,
   ModelGeminiMeta,

--- a/packages/core/src/converter/model-meta/index.ts
+++ b/packages/core/src/converter/model-meta/index.ts
@@ -1,0 +1,34 @@
+export type {
+  ModelDeepSeekMeta,
+  ModelFamilyEntry,
+  ModelGeminiMeta,
+  ModelMeta,
+  ModelOpenAiChatMeta,
+  ModelReasoningMeta,
+  ModelVendor,
+  ModelVisionMeta,
+  ResolveModelMetaOptions,
+} from "./types";
+
+export { GLOBAL_UNKNOWN_MODEL_META, VENDOR_DEFAULT_META } from "./defaults";
+export { listModelFamilies, resolveModelMeta } from "./registry";
+export {
+  sanitizeAnthropicRequestByMeta,
+  sanitizeAnthropicRequestRecord,
+} from "./sanitize-anthropic";
+export {
+  sanitizeOpenAiChatRequestByMeta,
+  sanitizeOpenAiChatRequestRecord,
+} from "./sanitize-openai-chat";
+
+import { resolveModelMeta } from "./registry";
+
+/** Whether Gemini models accept `reasoning_effort: none` (thinking_budget 0). */
+export function canGeminiDisableThinking(model: string): boolean {
+  return resolveModelMeta(model, { vendor: "gemini" }).gemini?.canDisableThinking === true;
+}
+
+/** Whether the model id is in the Gemini 2.5 family (thinking_budget wire). */
+export function isGemini25Model(model: string): boolean {
+  return resolveModelMeta(model, { vendor: "gemini" }).gemini?.is25Family === true;
+}

--- a/packages/core/src/converter/model-meta/normalize-anthropic-system.ts
+++ b/packages/core/src/converter/model-meta/normalize-anthropic-system.ts
@@ -1,0 +1,128 @@
+/**
+ * Hoist inline `messages` system/developer entries into top-level `system` for models
+ * that reject `role: system` inside the messages array (e.g. Claude Haiku).
+ */
+
+/* eslint-disable @typescript-eslint/naming-convention -- Anthropic Messages API wire fields */
+
+type AnthropicSystemTextBlock = {
+  type: "text";
+  text: string;
+  cache_control?: { type: string; ttl?: string };
+};
+
+function isSystemRole(role: unknown): boolean {
+  return role === "system" || role === "developer";
+}
+
+function contentToSystemBlocks(content: unknown): AnthropicSystemTextBlock[] {
+  if (typeof content === "string" && content.length > 0) {
+    return [{ type: "text", text: content }];
+  }
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  const blocks: AnthropicSystemTextBlock[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== "object" || Array.isArray(part)) {
+      continue;
+    }
+    const p = part as Record<string, unknown>;
+    if (p.type !== "text" || typeof p.text !== "string" || p.text.length === 0) {
+      continue;
+    }
+    const block: AnthropicSystemTextBlock = { type: "text", text: p.text };
+    const cc = p.cache_control;
+    if (cc && typeof cc === "object" && !Array.isArray(cc)) {
+      const c = cc as Record<string, unknown>;
+      if (typeof c.type === "string") {
+        block.cache_control = {
+          type: c.type,
+          ...(typeof c.ttl === "string" ? { ttl: c.ttl } : {}),
+        };
+      }
+    }
+    blocks.push(block);
+  }
+  return blocks;
+}
+
+function existingSystemToBlocks(system: unknown): AnthropicSystemTextBlock[] {
+  if (typeof system === "string") {
+    return system.length > 0 ? [{ type: "text", text: system }] : [];
+  }
+  if (!Array.isArray(system)) {
+    return [];
+  }
+  const blocks: AnthropicSystemTextBlock[] = [];
+  for (const entry of system) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      continue;
+    }
+    const e = entry as Record<string, unknown>;
+    if (e.type !== "text" || typeof e.text !== "string" || e.text.length === 0) {
+      continue;
+    }
+    const block: AnthropicSystemTextBlock = { type: "text", text: e.text };
+    const cc = e.cache_control;
+    if (cc && typeof cc === "object" && !Array.isArray(cc)) {
+      const c = cc as Record<string, unknown>;
+      if (typeof c.type === "string") {
+        block.cache_control = {
+          type: c.type,
+          ...(typeof c.ttl === "string" ? { ttl: c.ttl } : {}),
+        };
+      }
+    }
+    blocks.push(block);
+  }
+  return blocks;
+}
+
+function blocksToSystemField(
+  blocks: AnthropicSystemTextBlock[]
+): string | AnthropicSystemTextBlock[] {
+  if (blocks.length === 0) {
+    return [];
+  }
+  if (blocks.length === 1 && !blocks[0].cache_control) {
+    return blocks[0].text;
+  }
+  return blocks;
+}
+
+/**
+ * Hoist `messages` entries with role system/developer into top-level `system`.
+ * Mutates `data` in place. Returns true when messages were changed.
+ */
+export function hoistInlineSystemMessagesToAnthropicSystem(data: Record<string, unknown>): boolean {
+  const messages = data.messages;
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return false;
+  }
+
+  const rest: unknown[] = [];
+  const hoistedBlocks: AnthropicSystemTextBlock[] = [];
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object" || Array.isArray(msg)) {
+      rest.push(msg);
+      continue;
+    }
+    const m = msg as Record<string, unknown>;
+    if (!isSystemRole(m.role)) {
+      rest.push(msg);
+      continue;
+    }
+    hoistedBlocks.push(...contentToSystemBlocks(m.content));
+  }
+
+  if (hoistedBlocks.length === 0) {
+    return false;
+  }
+
+  const merged = [...existingSystemToBlocks(data.system), ...hoistedBlocks];
+  data.system = blocksToSystemField(merged);
+  data.messages = rest;
+  return true;
+}

--- a/packages/core/src/converter/model-meta/registry.ts
+++ b/packages/core/src/converter/model-meta/registry.ts
@@ -1,0 +1,118 @@
+import { minimatch } from "../../utils/helpers";
+import { ScopedLogger } from "../../utils/logger";
+import { cloneModelMeta, GLOBAL_UNKNOWN_MODEL_META, VENDOR_DEFAULT_META } from "./defaults";
+import { ANTHROPIC_MODEL_FAMILIES } from "./families.anthropic";
+import { DEEPSEEK_MODEL_FAMILIES } from "./families.deepseek";
+import { GEMINI_MODEL_FAMILIES } from "./families.gemini";
+import { OPENAI_MODEL_FAMILIES } from "./families.openai";
+import type { ModelFamilyEntry, ModelMeta, ModelVendor, ResolveModelMetaOptions } from "./types";
+
+const log = new ScopedLogger("ModelMeta");
+
+const ALL_FAMILIES: readonly ModelFamilyEntry[] = [
+  ...ANTHROPIC_MODEL_FAMILIES,
+  ...OPENAI_MODEL_FAMILIES,
+  ...GEMINI_MODEL_FAMILIES,
+  ...DEEPSEEK_MODEL_FAMILIES,
+];
+
+function familyPatterns(entry: ModelFamilyEntry): readonly string[] {
+  const m = entry.match;
+  if (typeof m === "string") {
+    return m.length > 0 ? [m] : [];
+  }
+  return m;
+}
+
+function entryMatchesModel(entry: ModelFamilyEntry, modelId: string): boolean {
+  if (entry.matchRegex?.test(modelId)) {
+    return true;
+  }
+  for (const pattern of familyPatterns(entry)) {
+    if (minimatch(modelId, pattern)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function mergeMeta(base: ModelMeta, patch: Partial<Omit<ModelMeta, "id" | "vendor">>): ModelMeta {
+  const out = cloneModelMeta(base);
+  if (patch.reasoning) {
+    out.reasoning = { ...out.reasoning, ...patch.reasoning };
+  }
+  if (patch.vision) {
+    out.vision = { ...out.vision, ...patch.vision };
+  }
+  if (patch.openaiChat) {
+    out.openaiChat = { ...(out.openaiChat ?? {}), ...patch.openaiChat };
+  }
+  if (patch.gemini) {
+    out.gemini = { ...(out.gemini ?? {}), ...patch.gemini };
+  }
+  if (patch.deepseek) {
+    out.deepseek = { ...(out.deepseek ?? {}), ...patch.deepseek };
+  }
+  return out;
+}
+
+function familyToMeta(entry: ModelFamilyEntry, modelId: string): ModelMeta {
+  let meta = cloneModelMeta({
+    id: entry.id,
+    vendor: entry.vendor,
+    ...entry.meta,
+  });
+
+  if (entry.overrides) {
+    for (const override of entry.overrides) {
+      if (override.match.toLowerCase() === modelId) {
+        meta = mergeMeta(meta, override.patch);
+      }
+    }
+  }
+
+  return meta;
+}
+
+function resolveFromFamilies(modelId: string, vendor?: ModelVendor): ModelMeta | null {
+  const candidates = vendor ? ALL_FAMILIES.filter(f => f.vendor === vendor) : ALL_FAMILIES;
+
+  for (const entry of candidates) {
+    if (entryMatchesModel(entry, modelId)) {
+      return familyToMeta(entry, modelId);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve static capability metadata for a wire model id (after provider model mapping).
+ */
+export function resolveModelMeta(modelId: string, options?: ResolveModelMetaOptions): ModelMeta {
+  const normalized = modelId.trim().toLowerCase();
+  if (!normalized) {
+    log.warn("[model-meta] empty model id; using unknown fallback");
+    return cloneModelMeta(GLOBAL_UNKNOWN_MODEL_META);
+  }
+
+  const fromFamily = resolveFromFamilies(normalized, options?.vendor);
+  if (fromFamily) {
+    return fromFamily;
+  }
+
+  if (options?.vendor && options.vendor !== "generic") {
+    const vendorDefault = VENDOR_DEFAULT_META[options.vendor];
+    if (vendorDefault) {
+      return cloneModelMeta({ ...vendorDefault, id: `${options.vendor}-default` });
+    }
+  }
+
+  log.warn(`[model-meta] no family match for "${normalized}"; using conservative unknown fallback`);
+  return cloneModelMeta(GLOBAL_UNKNOWN_MODEL_META);
+}
+
+/** @internal Tests and registry introspection. */
+export function listModelFamilies(): readonly ModelFamilyEntry[] {
+  return ALL_FAMILIES;
+}

--- a/packages/core/src/converter/model-meta/registry.ts
+++ b/packages/core/src/converter/model-meta/registry.ts
@@ -53,6 +53,9 @@ function mergeMeta(base: ModelMeta, patch: Partial<Omit<ModelMeta, "id" | "vendo
   if (patch.deepseek) {
     out.deepseek = { ...(out.deepseek ?? {}), ...patch.deepseek };
   }
+  if (patch.anthropic) {
+    out.anthropic = { ...(out.anthropic ?? {}), ...patch.anthropic };
+  }
   return out;
 }
 

--- a/packages/core/src/converter/model-meta/sanitize-anthropic.ts
+++ b/packages/core/src/converter/model-meta/sanitize-anthropic.ts
@@ -1,0 +1,71 @@
+import { ScopedLogger } from "../../utils/logger";
+import { resolveModelMeta } from "./registry";
+import type { ModelMeta } from "./types";
+
+const log = new ScopedLogger("ModelMeta");
+
+function deleteOutputConfigEffort(data: Record<string, unknown>, stripped: string[]): void {
+  const oc = data.output_config;
+  if (!oc || typeof oc !== "object" || Array.isArray(oc)) {
+    return;
+  }
+  const out = oc as Record<string, unknown>;
+  if ("effort" in out) {
+    delete out.effort;
+    stripped.push("output_config.effort");
+  }
+  if (Object.keys(out).length === 0) {
+    delete data.output_config;
+    stripped.push("output_config");
+  }
+}
+
+/**
+ * Strip Anthropic Messages API fields unsupported by the resolved model meta.
+ * Mutates `data` in place; returns field paths removed for logging.
+ */
+export function sanitizeAnthropicRequestByMeta(
+  data: Record<string, unknown>,
+  meta: ModelMeta
+): string[] {
+  const stripped: string[] = [];
+  const reasoning = meta.reasoning;
+
+  if (!reasoning.supportsEffort) {
+    deleteOutputConfigEffort(data, stripped);
+  }
+
+  const thinking = data.thinking;
+  if (thinking && typeof thinking === "object" && !Array.isArray(thinking)) {
+    const t = thinking as Record<string, unknown>;
+    const type = typeof t.type === "string" ? t.type.toLowerCase() : "";
+
+    if (!reasoning.supportsThinking) {
+      delete data.thinking;
+      stripped.push("thinking");
+    } else if (!reasoning.supportsAdaptiveThinking && type === "adaptive") {
+      delete data.thinking;
+      stripped.push("thinking");
+    }
+  } else if (!reasoning.supportsThinking && data.thinking !== undefined) {
+    delete data.thinking;
+    stripped.push("thinking");
+  }
+
+  if (stripped.length > 0) {
+    const modelLabel = typeof data.model === "string" ? data.model : "?";
+    log.warn(
+      `[model-meta] stripped ${stripped.join(", ")} for ${modelLabel} ` +
+        `(family=${meta.id}, vendor=${meta.vendor})`
+    );
+  }
+
+  return stripped;
+}
+
+/** Resolve meta from `data.model` and sanitize in place. */
+export function sanitizeAnthropicRequestRecord(data: Record<string, unknown>): void {
+  const model = typeof data.model === "string" ? data.model : "";
+  const meta = resolveModelMeta(model, { vendor: "anthropic" });
+  sanitizeAnthropicRequestByMeta(data, meta);
+}

--- a/packages/core/src/converter/model-meta/sanitize-anthropic.ts
+++ b/packages/core/src/converter/model-meta/sanitize-anthropic.ts
@@ -1,10 +1,11 @@
 import { ScopedLogger } from "../../utils/logger";
+import { hoistInlineSystemMessagesToAnthropicSystem } from "./normalize-anthropic-system";
 import { resolveModelMeta } from "./registry";
 import type { ModelMeta } from "./types";
 
 const log = new ScopedLogger("ModelMeta");
 
-function deleteOutputConfigEffort(data: Record<string, unknown>, stripped: string[]): void {
+function deleteOutputConfigEffort(data: Record<string, unknown>, changes: string[]): void {
   const oc = data.output_config;
   if (!oc || typeof oc !== "object" || Array.isArray(oc)) {
     return;
@@ -12,11 +13,11 @@ function deleteOutputConfigEffort(data: Record<string, unknown>, stripped: strin
   const out = oc as Record<string, unknown>;
   if ("effort" in out) {
     delete out.effort;
-    stripped.push("output_config.effort");
+    changes.push("output_config.effort");
   }
   if (Object.keys(out).length === 0) {
     delete data.output_config;
-    stripped.push("output_config");
+    changes.push("output_config");
   }
 }
 
@@ -28,11 +29,11 @@ export function sanitizeAnthropicRequestByMeta(
   data: Record<string, unknown>,
   meta: ModelMeta
 ): string[] {
-  const stripped: string[] = [];
+  const changes: string[] = [];
   const reasoning = meta.reasoning;
 
   if (!reasoning.supportsEffort) {
-    deleteOutputConfigEffort(data, stripped);
+    deleteOutputConfigEffort(data, changes);
   }
 
   const thinking = data.thinking;
@@ -42,25 +43,31 @@ export function sanitizeAnthropicRequestByMeta(
 
     if (!reasoning.supportsThinking) {
       delete data.thinking;
-      stripped.push("thinking");
+      changes.push("thinking");
     } else if (!reasoning.supportsAdaptiveThinking && type === "adaptive") {
       delete data.thinking;
-      stripped.push("thinking");
+      changes.push("thinking");
     }
   } else if (!reasoning.supportsThinking && data.thinking !== undefined) {
     delete data.thinking;
-    stripped.push("thinking");
+    changes.push("thinking");
   }
 
-  if (stripped.length > 0) {
+  if (meta.anthropic?.supportsSystemRoleInMessages === false) {
+    if (hoistInlineSystemMessagesToAnthropicSystem(data)) {
+      changes.push("messages.system->system");
+    }
+  }
+
+  if (changes.length > 0) {
     const modelLabel = typeof data.model === "string" ? data.model : "?";
     log.warn(
-      `[model-meta] stripped ${stripped.join(", ")} for ${modelLabel} ` +
+      `[model-meta] sanitized ${changes.join(", ")} for ${modelLabel} ` +
         `(family=${meta.id}, vendor=${meta.vendor})`
     );
   }
 
-  return stripped;
+  return changes;
 }
 
 /** Resolve meta from `data.model` and sanitize in place. */

--- a/packages/core/src/converter/model-meta/sanitize-openai-chat.ts
+++ b/packages/core/src/converter/model-meta/sanitize-openai-chat.ts
@@ -1,0 +1,60 @@
+import { ScopedLogger } from "../../utils/logger";
+import { resolveModelMeta } from "./registry";
+import type { ModelMeta } from "./types";
+
+const log = new ScopedLogger("ModelMeta");
+
+/**
+ * Strip OpenAI Chat Completions fields unsupported by the resolved model meta.
+ */
+export function sanitizeOpenAiChatRequestByMeta(
+  data: Record<string, unknown>,
+  meta: ModelMeta
+): string[] {
+  const stripped: string[] = [];
+  const reasoning = meta.reasoning;
+  const openaiChat = meta.openaiChat;
+
+  if (!reasoning.supportsReasoningEffort && data.reasoning_effort !== undefined) {
+    delete data.reasoning_effort;
+    stripped.push("reasoning_effort");
+  } else if (
+    openaiChat?.validReasoningEfforts &&
+    typeof data.reasoning_effort === "string" &&
+    data.reasoning_effort.trim() !== ""
+  ) {
+    const effort = data.reasoning_effort.trim().toLowerCase();
+    const allowed = new Set(openaiChat.validReasoningEfforts.map(e => e.toLowerCase()));
+    if (!allowed.has(effort)) {
+      delete data.reasoning_effort;
+      stripped.push("reasoning_effort");
+    }
+  }
+
+  if (stripped.length > 0) {
+    const modelLabel = typeof data.model === "string" ? data.model : "?";
+    log.warn(
+      `[model-meta] stripped ${stripped.join(", ")} for ${modelLabel} ` +
+        `(family=${meta.id}, vendor=${meta.vendor})`
+    );
+  }
+
+  return stripped;
+}
+
+export function sanitizeOpenAiChatRequestRecord(data: Record<string, unknown>): void {
+  const model = typeof data.model === "string" ? data.model : "";
+  const meta = resolveModelMeta(model, { vendor: inferOpenAiVendor(model) });
+  sanitizeOpenAiChatRequestByMeta(data, meta);
+}
+
+function inferOpenAiVendor(model: string): ModelMeta["vendor"] {
+  const m = model.toLowerCase();
+  if (m.includes("gemini")) {
+    return "gemini";
+  }
+  if (m.includes("deepseek")) {
+    return "deepseek";
+  }
+  return "openai";
+}

--- a/packages/core/src/converter/model-meta/types.ts
+++ b/packages/core/src/converter/model-meta/types.ts
@@ -38,6 +38,11 @@ export interface ModelDeepSeekMeta {
   isReasoner?: boolean;
 }
 
+export interface ModelAnthropicMeta {
+  /** When false, hoist `messages` entries with role system/developer into top-level `system`. */
+  supportsSystemRoleInMessages?: boolean;
+}
+
 export interface ModelMeta {
   id: string;
   vendor: ModelVendor;
@@ -46,6 +51,7 @@ export interface ModelMeta {
   openaiChat?: ModelOpenAiChatMeta;
   gemini?: ModelGeminiMeta;
   deepseek?: ModelDeepSeekMeta;
+  anthropic?: ModelAnthropicMeta;
 }
 
 /** Declarative family row in the static registry. */

--- a/packages/core/src/converter/model-meta/types.ts
+++ b/packages/core/src/converter/model-meta/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Static model capability metadata for protocol sanitization and cross-protocol conversion.
+ */
+
+export type ModelVendor = "anthropic" | "openai" | "gemini" | "deepseek" | "generic";
+
+export interface ModelReasoningMeta {
+  /** Whether the model family supports extended / adaptive reasoning. */
+  enabled: boolean;
+  /** Anthropic `output_config.effort`. */
+  supportsEffort?: boolean;
+  /** Anthropic top-level `thinking`. */
+  supportsThinking?: boolean;
+  /** Anthropic `thinking.type = adaptive`. */
+  supportsAdaptiveThinking?: boolean;
+  /** OpenAI Chat `reasoning_effort`. */
+  supportsReasoningEffort?: boolean;
+}
+
+export interface ModelVisionMeta {
+  enabled: boolean;
+}
+
+export interface ModelOpenAiChatMeta {
+  usesMaxCompletionTokens?: boolean;
+  validReasoningEfforts?: readonly string[];
+}
+
+export interface ModelGeminiMeta {
+  /** Gemini 2.5 Flash-style models may set thinking_budget to 0. */
+  canDisableThinking?: boolean;
+  /** Uses `thinking_budget` instead of `thinking_level`. */
+  is25Family?: boolean;
+}
+
+export interface ModelDeepSeekMeta {
+  /** DeepSeek reasoner-style models use native thinking + effort normalization. */
+  isReasoner?: boolean;
+}
+
+export interface ModelMeta {
+  id: string;
+  vendor: ModelVendor;
+  reasoning: ModelReasoningMeta;
+  vision: ModelVisionMeta;
+  openaiChat?: ModelOpenAiChatMeta;
+  gemini?: ModelGeminiMeta;
+  deepseek?: ModelDeepSeekMeta;
+}
+
+/** Declarative family row in the static registry. */
+export interface ModelFamilyEntry {
+  id: string;
+  vendor: ModelVendor;
+  /** Glob patterns passed to {@link minimatch} (lowercase model id). */
+  match: string | readonly string[];
+  /** Optional regex when glob is insufficient (e.g. OpenAI o-series). */
+  matchRegex?: RegExp;
+  meta: Omit<ModelMeta, "id" | "vendor">;
+  /** Exact model id patches applied after family match. */
+  overrides?: readonly {
+    match: string;
+    patch: Partial<Omit<ModelMeta, "id" | "vendor">>;
+  }[];
+}
+
+export interface ResolveModelMetaOptions {
+  vendor?: ModelVendor;
+}

--- a/packages/core/src/converter/platform-transforms/deepseek/request-sanitize.ts
+++ b/packages/core/src/converter/platform-transforms/deepseek/request-sanitize.ts
@@ -4,6 +4,8 @@
  * penalties are ignored upstream; strip them for a smaller payload.
  */
 
+import { resolveModelMeta } from "../../model-meta/registry";
+
 /** Injected on outbound `/v1/chat/completions` bodies when upstream host is `api.deepseek.com`. */
 export function deepseekChatSanitize(body: Record<string, unknown>): void {
   const raw = body.reasoning_effort;
@@ -11,6 +13,13 @@ export function deepseekChatSanitize(body: Record<string, unknown>): void {
     typeof raw === "string" && raw.trim() !== "" ? raw.trim().toLowerCase() : undefined;
 
   if (effort === undefined) {
+    return;
+  }
+
+  const model = typeof body.model === "string" ? body.model : "";
+  const meta = resolveModelMeta(model, { vendor: "deepseek" });
+  if (!meta.reasoning.supportsReasoningEffort) {
+    delete body.reasoning_effort;
     return;
   }
 

--- a/packages/core/src/converter/platform-transforms/gemini/request-sanitize.ts
+++ b/packages/core/src/converter/platform-transforms/gemini/request-sanitize.ts
@@ -4,28 +4,11 @@
 
 /* eslint-disable @typescript-eslint/naming-convention -- Gemini OpenAI-compat wire uses snake_case */
 
+import { canGeminiDisableThinking, isGemini25Model } from "../../model-meta";
+
+export { canGeminiDisableThinking, isGemini25Model };
+
 const GEMINI_VALID_EFFORTS = new Set(["none", "minimal", "low", "medium", "high"]);
-
-/**
- * Whether `reasoning_effort: "none"` is valid for this Gemini model (2.5 Flash family).
- * 2.5 Pro and Gemini 3+ cannot disable thinking per Gemini docs.
- */
-export function canGeminiDisableThinking(model: string): boolean {
-  const m = model.toLowerCase();
-  if (m.includes("2.5-pro")) {
-    return false;
-  }
-  const major = m.match(/gemini-(\d+)/);
-  if (major && parseInt(major[1], 10) >= 3) {
-    return false;
-  }
-  return true;
-}
-
-/** Gemini 2.5 family uses `thinking_budget` in `thinking_config`. */
-export function isGemini25Model(model: string): boolean {
-  return model.toLowerCase().includes("2.5");
-}
 
 /**
  * Map OpenAI-style effort to a 2.5 `thinking_budget` (integers per Gemini docs).

--- a/packages/core/src/converter/rules/openai-chat-model-rules.ts
+++ b/packages/core/src/converter/rules/openai-chat-model-rules.ts
@@ -5,6 +5,8 @@
 
 /* eslint-disable @typescript-eslint/naming-convention -- OpenAI Chat Completions wire field names */
 
+import { resolveModelMeta } from "../model-meta/registry";
+
 /** Minimal body shape for max output field assignment */
 export interface OpenAiChatMaxOutputTarget {
   model: string;
@@ -16,12 +18,7 @@ export interface OpenAiChatMaxOutputTarget {
  * Models that expect completion budget under `max_completion_tokens` (not `max_tokens`).
  */
 export function openaiChatUsesMaxCompletionTokens(model: string): boolean {
-  const m = model.trim().toLowerCase();
-  if (m.startsWith("gpt-5")) {
-    return true;
-  }
-  // o-series reasoning/chat ids: o1, o3, o4, …
-  return /^o\d/.test(m);
+  return resolveModelMeta(model, { vendor: "openai" }).openaiChat?.usesMaxCompletionTokens === true;
 }
 
 /**

--- a/packages/core/src/converter/rules/openai-tool-call-arguments.ts
+++ b/packages/core/src/converter/rules/openai-tool-call-arguments.ts
@@ -1,0 +1,62 @@
+/**
+ * Normalize OpenAI Chat `tool_calls[].function.arguments` strings for upstream providers
+ * that JSON-parse arguments during prefill (e.g. MiMo).
+ */
+
+import type { OpenAIMessage } from "../adapters/anthropic-to-openai-chat-request";
+import { ScopedLogger } from "../../utils/logger";
+
+const log = new ScopedLogger("ToolCallArguments");
+
+/**
+ * Coerce a tool-call arguments string into parseable JSON object text.
+ * Truncated or non-JSON payloads are wrapped as `{ "raw": "..." }`.
+ */
+export function normalizeOpenAiToolCallArgumentsString(args: string): string {
+  const trimmed = typeof args === "string" ? args.trim() : "";
+  if (trimmed.length === 0) {
+    return "{}";
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return trimmed;
+    }
+    return JSON.stringify({ value: parsed });
+  } catch {
+    return JSON.stringify({ raw: args });
+  }
+}
+
+/** Repair malformed `tool_calls[].function.arguments` on assistant messages in place. */
+export function sanitizeOpenAiChatToolArgumentsInMessages(messages: unknown): number {
+  if (!Array.isArray(messages)) {
+    return 0;
+  }
+  let repairedCount = 0;
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      continue;
+    }
+    const m = msg as OpenAIMessage;
+    if (m.role !== "assistant" || !Array.isArray(m.tool_calls)) {
+      continue;
+    }
+    for (const tc of m.tool_calls) {
+      const fn = tc?.function;
+      if (!fn || typeof fn.arguments !== "string") {
+        continue;
+      }
+      const normalized = normalizeOpenAiToolCallArgumentsString(fn.arguments);
+      if (normalized !== fn.arguments) {
+        log.warn(
+          `[tool-args] repaired malformed arguments for ${fn.name || "(unnamed)"} ` +
+            `(len=${fn.arguments.length}, preview=${JSON.stringify(fn.arguments.slice(0, 48))})`
+        );
+        fn.arguments = normalized;
+        repairedCount++;
+      }
+    }
+  }
+  return repairedCount;
+}

--- a/packages/core/src/converter/streaming/openai-chat-stream-to-responses.ts
+++ b/packages/core/src/converter/streaming/openai-chat-stream-to-responses.ts
@@ -38,6 +38,8 @@ export interface StreamingConversionState {
   toolCalls: ToolCallState[];
   currentToolIndex: number;
   outputIndex: number;
+  /** Tool calls received finish_reason; close on [DONE] after trailing arg deltas. */
+  toolsPendingClose: boolean;
   /** Original Responses request fields to echo back in response shells */
   echo?: ResponsesRequestEcho;
   usage?: {
@@ -69,6 +71,7 @@ export function createStreamingState(opts?: {
     toolCalls: [],
     currentToolIndex: 0,
     outputIndex: 0,
+    toolsPendingClose: false,
     ...(opts?.echo !== undefined ? { echo: opts.echo } : {}),
   };
 }
@@ -237,12 +240,8 @@ export function processStreamingChunk(state: StreamingConversionState, line: str
       events.push(...emitOutputItemDone(state, "message"));
       state.outputIndex++;
     } else if (state.phase === "tool") {
-      // Close any unclosed tool calls
-      for (let i = 0; i < state.toolCalls.length; i++) {
-        events.push(...emitFunctionCallArgDone(state, i));
-        events.push(...emitOutputItemDone(state, "function_call", i));
-        state.outputIndex++;
-      }
+      // Defer tool close until [DONE] so trailing argument deltas after finish_reason are included.
+      state.toolsPendingClose = true;
     } else if (state.phase === "initial") {
       events.push(...emitResponseCreated(state));
     }
@@ -610,6 +609,16 @@ function emitFunctionCallArgDone(state: StreamingConversionState, toolIndex: num
   ];
 }
 
+function emitPendingToolCallCloseEvents(state: StreamingConversionState): string[] {
+  const events: string[] = [];
+  for (let i = 0; i < state.toolCalls.length; i++) {
+    events.push(...emitFunctionCallArgDone(state, i));
+    events.push(...emitOutputItemDone(state, "function_call", i));
+    state.outputIndex++;
+  }
+  return events;
+}
+
 function emitResponseCompleted(state: StreamingConversionState): string[] {
   const output: unknown[] = [];
 
@@ -675,11 +684,16 @@ function flushCompletion(state: StreamingConversionState): string[] {
     return []; // Already completed — avoid duplicate [DONE]
   }
 
-  // finish_reason already finalized output items — wait for upstream usage, then complete.
+  // finish_reason received; close deferred tool items, then complete.
   if (state.phase === "finished") {
-    const out = [...emitResponseCompleted(state), sseLine("data: [DONE]")];
+    const events: string[] = [];
+    if (state.toolsPendingClose) {
+      events.push(...emitPendingToolCallCloseEvents(state));
+      state.toolsPendingClose = false;
+    }
+    events.push(...emitResponseCompleted(state), sseLine("data: [DONE]"));
     state.phase = "done";
-    return out;
+    return events;
   }
 
   const events: string[] = [];
@@ -700,11 +714,7 @@ function flushCompletion(state: StreamingConversionState): string[] {
     state.outputIndex++;
     events.push(...emitResponseCompleted(state));
   } else if (state.phase === "tool") {
-    for (let i = 0; i < state.toolCalls.length; i++) {
-      events.push(...emitFunctionCallArgDone(state, i));
-      events.push(...emitOutputItemDone(state, "function_call", i));
-      state.outputIndex++;
-    }
+    events.push(...emitPendingToolCallCloseEvents(state));
     events.push(...emitResponseCompleted(state));
   }
 

--- a/packages/core/src/server/handler.ts
+++ b/packages/core/src/server/handler.ts
@@ -35,6 +35,7 @@ import { ResponseLogger } from "./responseLogger";
 import { RequestHandler } from "./request";
 import { ModelCatalog } from "./smartRouting/modelCatalog";
 import { InterceptorRegistry } from "./interceptor";
+import { AvailabilityProbeInterceptor } from "../services/availability-probe";
 import { WebSearchInterceptor } from "../services/web-search";
 import { WsBroadcaster, WsFollowerClient } from "./websocket";
 import {
@@ -108,6 +109,7 @@ export class ProxyServer {
     this.queueManager = new QueueManager(config);
 
     this.interceptorRegistry = new InterceptorRegistry();
+    this.interceptorRegistry.register(new AvailabilityProbeInterceptor());
     this.interceptorRegistry.register(new WebSearchInterceptor(() => this.config.webSearchConfig));
 
     // Listen to Router's provider changes - this is the single source of truth

--- a/packages/core/src/server/interceptor/registry.ts
+++ b/packages/core/src/server/interceptor/registry.ts
@@ -14,9 +14,11 @@ export class InterceptorRegistry {
   async tryIntercept(
     rawBody: Buffer,
     clientSurface: ApiSurface,
-    providerId: string
+    providerId: string,
+    method: string,
+    path: string
   ): Promise<InterceptResult | null> {
-    const ctx: ServiceInterceptorContext = { rawBody, clientSurface, providerId };
+    const ctx: ServiceInterceptorContext = { rawBody, clientSurface, providerId, method, path };
     for (const interceptor of this.interceptors) {
       if (interceptor.shouldIntercept(ctx)) {
         return await interceptor.execute(ctx);

--- a/packages/core/src/server/interceptor/types.ts
+++ b/packages/core/src/server/interceptor/types.ts
@@ -27,6 +27,8 @@ export interface ServiceInterceptorContext {
   rawBody: Buffer;
   clientSurface: ApiSurface;
   providerId: string;
+  method: string;
+  path: string;
 }
 
 export interface ServiceInterceptor {

--- a/packages/core/src/server/request/bodyProcessor.ts
+++ b/packages/core/src/server/request/bodyProcessor.ts
@@ -14,6 +14,7 @@ import {
   mapAnthropicWirePathToOpenAiUpstream,
   mapOpenAiWirePathToAnthropicUpstream,
   stripBillingHeaderFromAnthropicBody,
+  sanitizeAnthropicOutboundBody,
   type ResponsesRequestEcho,
 } from "../../converter";
 import type { OpenAIMessage } from "../../converter/adapters/anthropic-to-openai-chat-request";
@@ -22,6 +23,7 @@ import {
   ensureOpenAiChatStreamUsageIncluded,
 } from "../../converter/rules/openai-chat-model-rules";
 import { sanitizeOpenAiChatToolArgumentsInMessages } from "../../converter/rules/openai-tool-call-arguments";
+import { sanitizeOpenAiChatRequestRecord } from "../../converter/model-meta/sanitize-openai-chat";
 import {
   normalizeToolsForProvider,
   applyPlatformMessageTransforms,
@@ -40,6 +42,24 @@ const log = new ScopedLogger("BodyProcessor");
 /** OpenAI Chat outbound: path after routing targets `/chat/completions`. */
 function isOpenAiChatCompletionsTargetPath(targetPath: string): boolean {
   return targetPath.toLowerCase().includes("chat/completions");
+}
+
+function isAnthropicMessagesTargetPath(targetPath: string, method: string): boolean {
+  return method === "POST" && targetPath === "/v1/messages";
+}
+
+function applyAnthropicOutboundSanitizeIfNeeded(
+  body: Buffer,
+  routing: RoutingContext,
+  upstreamWire: ApiSurface
+): Buffer {
+  if (upstreamWire !== "anthropic") {
+    return body;
+  }
+  if (!isAnthropicMessagesTargetPath(routing.targetPath, routing.method) || !body.length) {
+    return body;
+  }
+  return sanitizeAnthropicOutboundBody(body);
 }
 
 function applyHostedToolsToOpenAiChatRecord(data: Record<string, unknown>, baseUrl: string): void {
@@ -89,6 +109,7 @@ function applyPlatformTransformsToOpenAiChatBody(
     applyPlatformMessagesToOpenAiChatRecord(data, baseUrl);
     applyPlatformRequestSanitize(data, baseUrl);
     sanitizeOpenAiChatToolArgumentsInMessages(data.messages);
+    sanitizeOpenAiChatRequestRecord(data);
     return Buffer.from(JSON.stringify(data), "utf-8");
   } catch {
     return body;
@@ -365,6 +386,8 @@ export class BodyProcessor {
         hasHostedWebSearchFlag = false;
       }
     }
+
+    body = applyAnthropicOutboundSanitizeIfNeeded(body, routing, upstreamWire);
 
     return {
       body,

--- a/packages/core/src/server/request/bodyProcessor.ts
+++ b/packages/core/src/server/request/bodyProcessor.ts
@@ -21,6 +21,7 @@ import {
   normalizeOpenAiChatMaxOutputFields,
   ensureOpenAiChatStreamUsageIncluded,
 } from "../../converter/rules/openai-chat-model-rules";
+import { sanitizeOpenAiChatToolArgumentsInMessages } from "../../converter/rules/openai-tool-call-arguments";
 import {
   normalizeToolsForProvider,
   applyPlatformMessageTransforms,
@@ -87,6 +88,7 @@ function applyPlatformTransformsToOpenAiChatBody(
     openaiChatStrictToolsSanitize(data, baseUrl);
     applyPlatformMessagesToOpenAiChatRecord(data, baseUrl);
     applyPlatformRequestSanitize(data, baseUrl);
+    sanitizeOpenAiChatToolArgumentsInMessages(data.messages);
     return Buffer.from(JSON.stringify(data), "utf-8");
   } catch {
     return body;

--- a/packages/core/src/server/request/index.ts
+++ b/packages/core/src/server/request/index.ts
@@ -148,7 +148,9 @@ export class RequestHandler {
             const intercepted = await this.interceptorRegistry.tryIntercept(
               rawBody,
               routing.clientSurface,
-              routing.provider.id
+              routing.provider.id,
+              routing.method,
+              routing.path
             );
             if (intercepted) {
               if (res.writableEnded) {

--- a/packages/core/src/services/availability-probe/detector.ts
+++ b/packages/core/src/services/availability-probe/detector.ts
@@ -1,0 +1,69 @@
+import type { ApiSurface } from "../../types";
+import { detectApiSurface } from "../../server/request/apiSurfaceDetector";
+import { isOpenAIChatCompletionsWirePath, pathOnly } from "../../converter/paths";
+import type { AvailabilityProbeDetection } from "./types";
+
+const OPENAI_RESPONSES_PATHS = new Set(["/responses", "/v1/responses", "/openai/responses"]);
+
+const ANTHROPIC_MESSAGES_PATHS = new Set(["/v1/messages", "/anthropic/v1/messages"]);
+
+function isProbeTokenLimit(value: unknown): boolean {
+  return value === 1;
+}
+
+function hasProbeTokenLimit(body: Record<string, unknown>): boolean {
+  return isProbeTokenLimit(body.max_tokens) || isProbeTokenLimit(body.max_completion_tokens);
+}
+
+function resolveProbeResponseSurface(
+  method: string,
+  path: string,
+  clientSurface: ApiSurface
+): ApiSurface {
+  const p = pathOnly(path);
+  if (isOpenAIChatCompletionsWirePath(p) || p === "/openai/chat/completions") {
+    return "openai";
+  }
+  if (OPENAI_RESPONSES_PATHS.has(p)) {
+    return "openai_responses";
+  }
+  if (ANTHROPIC_MESSAGES_PATHS.has(p)) {
+    return "anthropic";
+  }
+  return detectApiSurface(method, path) ?? clientSurface;
+}
+
+/**
+ * Detect one-token availability probes used to validate endpoint reachability.
+ * Returns null when the body is not a probe request.
+ */
+export function detectAvailabilityProbe(
+  rawBody: Buffer,
+  method: string,
+  path: string,
+  clientSurface: ApiSurface
+): AvailabilityProbeDetection | null {
+  if (rawBody.length === 0) {
+    return null;
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(rawBody.toString("utf-8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  if (!hasProbeTokenLimit(parsed)) {
+    return null;
+  }
+
+  const model = typeof parsed.model === "string" ? parsed.model : "";
+  const stream = parsed.stream === true;
+
+  return {
+    model,
+    stream,
+    responseSurface: resolveProbeResponseSurface(method, path, clientSurface),
+  };
+}

--- a/packages/core/src/services/availability-probe/formatter.ts
+++ b/packages/core/src/services/availability-probe/formatter.ts
@@ -1,0 +1,186 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { randomUUID } from "crypto";
+import type { OpenAIChatCompletionResponse } from "../../converter/adapters/openai-chat-to-anthropic-response";
+import { convertChatCompletionToResponses } from "../../converter/adapters/openai-chat-to-responses";
+import {
+  formatOpenAIChatCompletionsSse,
+  formatOpenAIResponsesSse,
+} from "../../converter/streaming/sse-formatters";
+import type { AvailabilityProbeDetection } from "./types";
+
+const PROBE_TEXT = "1";
+
+function buildOpenAiChatResponse(model: string): OpenAIChatCompletionResponse {
+  const created = Math.floor(Date.now() / 1000);
+  return {
+    id: `chatcmpl-${randomUUID().replace(/-/g, "")}`,
+    object: "chat.completion",
+    created,
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: PROBE_TEXT },
+        finish_reason: "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: 1,
+      completion_tokens: 1,
+      total_tokens: 2,
+    },
+  };
+}
+
+function buildAnthropicJsonResponse(model: string): string {
+  return JSON.stringify({
+    type: "message",
+    id: `msg_${randomUUID().replace(/-/g, "").slice(0, 24)}`,
+    role: "assistant",
+    model,
+    content: [{ type: "text", text: PROBE_TEXT }],
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: { input_tokens: 1, output_tokens: 1 },
+  });
+}
+
+function buildAnthropicSseResponse(model: string): string {
+  const msgId = `msg_${randomUUID().replace(/-/g, "").slice(0, 24)}`;
+  const events: { eventName?: string; data: Record<string, unknown> }[] = [
+    {
+      eventName: "message_start",
+      data: {
+        type: "message_start",
+        message: {
+          id: msgId,
+          type: "message",
+          role: "assistant",
+          model,
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 0 },
+        },
+      },
+    },
+    {
+      eventName: "content_block_start",
+      data: {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      },
+    },
+    {
+      eventName: "content_block_delta",
+      data: {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: PROBE_TEXT },
+      },
+    },
+    {
+      eventName: "content_block_stop",
+      data: { type: "content_block_stop", index: 0 },
+    },
+    {
+      eventName: "message_delta",
+      data: {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 1 },
+      },
+    },
+    { eventName: "message_stop", data: { type: "message_stop" } },
+  ];
+
+  return events
+    .map(event => {
+      const payload = JSON.stringify(event.data);
+      return event.eventName
+        ? `event: ${event.eventName}\ndata: ${payload}\n\n`
+        : `data: ${payload}\n\n`;
+    })
+    .join("");
+}
+
+export interface AvailabilityProbeResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+  tokens: { inputTokens: number; outputTokens: number };
+}
+
+export function formatAvailabilityProbeResponse(
+  detection: AvailabilityProbeDetection
+): AvailabilityProbeResponse {
+  const model = detection.model || "ccrelay-probe";
+  const tokens = { inputTokens: 1, outputTokens: 1 };
+
+  if (detection.responseSurface === "anthropic") {
+    if (detection.stream) {
+      return {
+        statusCode: 200,
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+        body: buildAnthropicSseResponse(model),
+        tokens,
+      };
+    }
+    return {
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: buildAnthropicJsonResponse(model),
+      tokens,
+    };
+  }
+
+  const chat = buildOpenAiChatResponse(model);
+
+  if (detection.responseSurface === "openai_responses") {
+    const response = convertChatCompletionToResponses(chat, model);
+    if (detection.stream) {
+      return {
+        statusCode: 200,
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+        body: formatOpenAIResponsesSse(response),
+        tokens,
+      };
+    }
+    return {
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(response),
+      tokens,
+    };
+  }
+
+  if (detection.stream) {
+    return {
+      statusCode: 200,
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+      body: formatOpenAIChatCompletionsSse(chat),
+      tokens,
+    };
+  }
+
+  return {
+    statusCode: 200,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(chat),
+    tokens,
+  };
+}

--- a/packages/core/src/services/availability-probe/index.ts
+++ b/packages/core/src/services/availability-probe/index.ts
@@ -1,0 +1,4 @@
+export { detectAvailabilityProbe } from "./detector";
+export { formatAvailabilityProbeResponse } from "./formatter";
+export type { AvailabilityProbeDetection } from "./types";
+export { AvailabilityProbeInterceptor } from "./interceptor";

--- a/packages/core/src/services/availability-probe/interceptor.ts
+++ b/packages/core/src/services/availability-probe/interceptor.ts
@@ -1,0 +1,45 @@
+import type {
+  InterceptResult,
+  ServiceInterceptor,
+  ServiceInterceptorContext,
+} from "../../server/interceptor";
+import { detectAvailabilityProbe } from "./detector";
+import { formatAvailabilityProbeResponse } from "./formatter";
+import type { AvailabilityProbeDetection } from "./types";
+
+/**
+ * Short-circuits one-token availability probes (max_tokens / max_completion_tokens === 1)
+ * so validation requests never hit upstream providers.
+ */
+export class AvailabilityProbeInterceptor implements ServiceInterceptor {
+  readonly name = "availability-probe";
+
+  private readonly detectionCache = new WeakMap<Buffer, AvailabilityProbeDetection>();
+
+  shouldIntercept(ctx: ServiceInterceptorContext): boolean {
+    const detection = detectAvailabilityProbe(ctx.rawBody, ctx.method, ctx.path, ctx.clientSurface);
+    if (!detection) {
+      return false;
+    }
+    this.detectionCache.set(ctx.rawBody, detection);
+    return true;
+  }
+
+  execute(ctx: ServiceInterceptorContext): Promise<InterceptResult> {
+    const detection = this.detectionCache.get(ctx.rawBody);
+    if (!detection) {
+      return Promise.reject(
+        new Error("[availability-probe] execute called without cached detection (registry bug?)")
+      );
+    }
+    const out = formatAvailabilityProbeResponse(detection);
+    return Promise.resolve({
+      handled: true,
+      statusCode: out.statusCode,
+      headers: out.headers,
+      body: out.body,
+      routeType: "service",
+      tokens: out.tokens,
+    });
+  }
+}

--- a/packages/core/src/services/availability-probe/types.ts
+++ b/packages/core/src/services/availability-probe/types.ts
@@ -1,0 +1,8 @@
+import type { ApiSurface } from "../../types";
+
+/** Parsed availability probe request (max_tokens or max_completion_tokens === 1). */
+export interface AvailabilityProbeDetection {
+  model: string;
+  stream: boolean;
+  responseSurface: ApiSurface;
+}

--- a/tests/unit/converter/adapters/openai-chat-to-anthropic-request.test.ts
+++ b/tests/unit/converter/adapters/openai-chat-to-anthropic-request.test.ts
@@ -281,6 +281,20 @@ describe("convertOpenAIRequestToAnthropic", () => {
       expect(request.thinking).toEqual({ type: "adaptive" });
       expect(request.output_config).toEqual({ effort: "high" });
     });
+
+    it("does not inject thinking or output_config for haiku with reasoning_effort", () => {
+      const { request } = convertOpenAIRequestToAnthropic(
+        {
+          model: "claude-haiku-4-5",
+          max_tokens: 1024,
+          messages: [{ role: "user", content: "Hi" }],
+          reasoning_effort: "medium",
+        },
+        "/v1/chat/completions"
+      );
+      expect(request.thinking).toBeUndefined();
+      expect(request.output_config).toBeUndefined();
+    });
   });
 
   it("omits tool_choice when there are no tools (even if tool_choice was set)", () => {

--- a/tests/unit/converter/adapters/openai-responses-to-chat.test.ts
+++ b/tests/unit/converter/adapters/openai-responses-to-chat.test.ts
@@ -111,6 +111,26 @@ describe("convertResponsesRequestToChatCompletions", () => {
     expect(tools[1].tool_call_id).toBe("call_b");
   });
 
+  it("repairs truncated function_call arguments for upstream prefill", () => {
+    const truncated = '{"target_file":"/Users/dzhsurf/Documents/code';
+    const { request } = convertResponsesRequestToChatCompletions(
+      {
+        model: "gpt-4o",
+        input: [
+          {
+            type: "function_call",
+            name: "Read",
+            arguments: truncated,
+            call_id: "call_x",
+          },
+        ],
+      },
+      "/v1/responses"
+    );
+    const tc = request.messages.find(m => m.role === "assistant")?.tool_calls?.[0];
+    expect(JSON.parse(tc!.function.arguments)).toEqual({ raw: truncated });
+  });
+
   it("does not merge function_call after a tool message (new assistant turn)", () => {
     const { request } = convertResponsesRequestToChatCompletions(
       {

--- a/tests/unit/converter/anthropic-request-sanitize.test.ts
+++ b/tests/unit/converter/anthropic-request-sanitize.test.ts
@@ -183,5 +183,26 @@ describe("converter: anthropic-request-sanitize", () => {
       expect(parsed.thinking).toEqual({ type: "adaptive" });
       expect(parsed.output_config).toEqual({ effort: "medium" });
     });
+
+    it("hoists inline system messages for haiku with billing strip", () => {
+      const input = {
+        model: "claude-haiku-4-5",
+        max_tokens: 1024,
+        messages: [
+          { role: "user", content: "hi" },
+          { role: "system", content: "Skills: godot" },
+        ],
+        system: [{ type: "text", text: BILLING_TEXT }],
+      };
+      const body = Buffer.from(JSON.stringify(input), "utf-8");
+      const out = sanitizeAnthropicOutboundBody(body);
+      const parsed = JSON.parse(out.toString("utf-8")) as {
+        system?: { type: string; text: string }[];
+        messages: { role: string }[];
+      };
+
+      expect(parsed.system).toBe("Skills: godot");
+      expect(parsed.messages.every(m => m.role !== "system")).toBe(true);
+    });
   });
 });

--- a/tests/unit/converter/anthropic-request-sanitize.test.ts
+++ b/tests/unit/converter/anthropic-request-sanitize.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   stripBillingHeaderFromAnthropicBody,
+  sanitizeAnthropicOutboundBody,
   isBillingHeaderBlock,
 } from "@/converter/anthropic-request-sanitize";
 
@@ -145,6 +146,42 @@ describe("converter: anthropic-request-sanitize", () => {
       };
       const body = Buffer.from(JSON.stringify(input), "utf-8");
       expect(stripBillingHeaderFromAnthropicBody(body)).toBe(body);
+    });
+  });
+
+  describe("sanitizeAnthropicOutboundBody", () => {
+    it("strips billing header and unsupported reasoning fields for haiku", () => {
+      const input = {
+        model: "claude-haiku-4-5",
+        max_tokens: 1024,
+        messages: [{ role: "user", content: "hi" }],
+        system: [{ type: "text", text: BILLING_TEXT }],
+        thinking: { type: "enabled", budget_tokens: 1024 },
+        output_config: { effort: "medium" },
+      };
+      const body = Buffer.from(JSON.stringify(input), "utf-8");
+      const out = sanitizeAnthropicOutboundBody(body);
+      const parsed = JSON.parse(out.toString("utf-8")) as Record<string, unknown>;
+
+      expect(parsed.system).toBeUndefined();
+      expect(parsed.thinking).toBeUndefined();
+      expect(parsed.output_config).toBeUndefined();
+    });
+
+    it("preserves reasoning fields for sonnet", () => {
+      const input = {
+        model: "claude-sonnet-4-20250514",
+        max_tokens: 1024,
+        messages: [{ role: "user", content: "hi" }],
+        thinking: { type: "adaptive" },
+        output_config: { effort: "medium" },
+      };
+      const body = Buffer.from(JSON.stringify(input), "utf-8");
+      const out = sanitizeAnthropicOutboundBody(body);
+      const parsed = JSON.parse(out.toString("utf-8")) as Record<string, unknown>;
+
+      expect(parsed.thinking).toEqual({ type: "adaptive" });
+      expect(parsed.output_config).toEqual({ effort: "medium" });
     });
   });
 });

--- a/tests/unit/converter/model-meta/normalize-anthropic-system.test.ts
+++ b/tests/unit/converter/model-meta/normalize-anthropic-system.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { hoistInlineSystemMessagesToAnthropicSystem } from "@/converter/model-meta/normalize-anthropic-system";
+
+/* eslint-disable @typescript-eslint/naming-convention -- Anthropic API bodies use snake_case */
+
+describe("hoistInlineSystemMessagesToAnthropicSystem", () => {
+  it("hoists string system message into top-level system", () => {
+    const data: Record<string, unknown> = {
+      messages: [
+        { role: "user", content: "hi" },
+        { role: "system", content: "Skills list" },
+      ],
+    };
+    expect(hoistInlineSystemMessagesToAnthropicSystem(data)).toBe(true);
+    expect(data.system).toBe("Skills list");
+    expect(data.messages).toEqual([{ role: "user", content: "hi" }]);
+  });
+
+  it("appends hoisted content after existing system blocks", () => {
+    const data: Record<string, unknown> = {
+      system: [
+        {
+          type: "text",
+          text: "You are Claude Code.",
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [
+        { role: "user", content: "task" },
+        { role: "system", content: "Available skills: godot, pdf" },
+      ],
+    };
+    expect(hoistInlineSystemMessagesToAnthropicSystem(data)).toBe(true);
+    expect(data.system).toEqual([
+      {
+        type: "text",
+        text: "You are Claude Code.",
+        cache_control: { type: "ephemeral" },
+      },
+      { type: "text", text: "Available skills: godot, pdf" },
+    ]);
+    expect(data.messages).toEqual([{ role: "user", content: "task" }]);
+  });
+
+  it("hoists developer role and preserves cache_control on array content", () => {
+    const data: Record<string, unknown> = {
+      messages: [
+        {
+          role: "developer",
+          content: [
+            {
+              type: "text",
+              text: "Dev instructions",
+              cache_control: { type: "ephemeral", ttl: "1h" },
+            },
+          ],
+        },
+        { role: "user", content: "go" },
+      ],
+    };
+    expect(hoistInlineSystemMessagesToAnthropicSystem(data)).toBe(true);
+    expect(data.system).toEqual([
+      {
+        type: "text",
+        text: "Dev instructions",
+        cache_control: { type: "ephemeral", ttl: "1h" },
+      },
+    ]);
+    expect(data.messages).toEqual([{ role: "user", content: "go" }]);
+  });
+
+  it("merges string existing system with hoisted string via block array", () => {
+    const data: Record<string, unknown> = {
+      system: "Prefix prompt.",
+      messages: [{ role: "system", content: "Suffix skills." }],
+    };
+    expect(hoistInlineSystemMessagesToAnthropicSystem(data)).toBe(true);
+    expect(data.system).toEqual([
+      { type: "text", text: "Prefix prompt." },
+      { type: "text", text: "Suffix skills." },
+    ]);
+  });
+
+  it("returns false when no inline system messages exist", () => {
+    const data: Record<string, unknown> = {
+      messages: [{ role: "user", content: "hi" }],
+    };
+    expect(hoistInlineSystemMessagesToAnthropicSystem(data)).toBe(false);
+    expect(data.system).toBeUndefined();
+  });
+});

--- a/tests/unit/converter/model-meta/resolve.test.ts
+++ b/tests/unit/converter/model-meta/resolve.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { resolveModelMeta, listModelFamilies } from "@/converter/model-meta/registry";
+import { GLOBAL_UNKNOWN_MODEL_META } from "@/converter/model-meta/defaults";
+
+describe("resolveModelMeta", () => {
+  it("matches claude-haiku family with reasoning disabled", () => {
+    const meta = resolveModelMeta("claude-haiku-4-5", { vendor: "anthropic" });
+    expect(meta.id).toBe("claude-haiku");
+    expect(meta.reasoning.supportsEffort).toBe(false);
+    expect(meta.reasoning.supportsThinking).toBe(false);
+    expect(meta.vision.enabled).toBe(true);
+  });
+
+  it("matches claude-sonnet family with reasoning enabled", () => {
+    const meta = resolveModelMeta("claude-sonnet-4-20250514", { vendor: "anthropic" });
+    expect(meta.id).toBe("claude-sonnet");
+    expect(meta.reasoning.supportsEffort).toBe(true);
+    expect(meta.reasoning.supportsAdaptiveThinking).toBe(true);
+  });
+
+  it("matches gpt-5 max_completion_tokens family", () => {
+    const meta = resolveModelMeta("gpt-5.2", { vendor: "openai" });
+    expect(meta.id).toBe("gpt-5");
+    expect(meta.openaiChat?.usesMaxCompletionTokens).toBe(true);
+  });
+
+  it("matches o-series via regex", () => {
+    expect(resolveModelMeta("o3-mini", { vendor: "openai" }).id).toBe("o-series");
+    expect(resolveModelMeta("o4-mini", { vendor: "openai" }).id).toBe("o-series");
+  });
+
+  it("matches gemini 2.5 flash disable thinking", () => {
+    const meta = resolveModelMeta("gemini-2.5-flash", { vendor: "gemini" });
+    expect(meta.gemini?.canDisableThinking).toBe(true);
+    expect(meta.gemini?.is25Family).toBe(true);
+  });
+
+  it("matches gemini 2.5 pro without disable thinking", () => {
+    const meta = resolveModelMeta("gemini-2.5-pro", { vendor: "gemini" });
+    expect(meta.gemini?.canDisableThinking).toBe(false);
+  });
+
+  it("matches gemini 3+ without disable thinking", () => {
+    const meta = resolveModelMeta("gemini-3-flash-preview", { vendor: "gemini" });
+    expect(meta.id).toBe("gemini-3-plus");
+    expect(meta.gemini?.canDisableThinking).toBe(false);
+  });
+
+  it("matches deepseek reasoner", () => {
+    const meta = resolveModelMeta("deepseek-reasoner", { vendor: "deepseek" });
+    expect(meta.deepseek?.isReasoner).toBe(true);
+  });
+
+  it("uses conservative unknown fallback for unrecognized ids", () => {
+    const meta = resolveModelMeta("totally-unknown-model-xyz");
+    expect(meta.id).toBe(GLOBAL_UNKNOWN_MODEL_META.id);
+    expect(meta.reasoning.supportsEffort).toBe(false);
+    expect(meta.reasoning.supportsThinking).toBe(false);
+  });
+
+  it("uses vendor default when family missing but vendor hint provided", () => {
+    const meta = resolveModelMeta("custom-deployment-name", { vendor: "anthropic" });
+    expect(meta.vendor).toBe("anthropic");
+    expect(meta.reasoning.supportsEffort).toBe(true);
+  });
+
+  it("lists all registered families", () => {
+    expect(listModelFamilies().length).toBeGreaterThan(5);
+  });
+});

--- a/tests/unit/converter/model-meta/resolve.test.ts
+++ b/tests/unit/converter/model-meta/resolve.test.ts
@@ -8,6 +8,7 @@ describe("resolveModelMeta", () => {
     expect(meta.id).toBe("claude-haiku");
     expect(meta.reasoning.supportsEffort).toBe(false);
     expect(meta.reasoning.supportsThinking).toBe(false);
+    expect(meta.anthropic?.supportsSystemRoleInMessages).toBe(false);
     expect(meta.vision.enabled).toBe(true);
   });
 
@@ -16,6 +17,7 @@ describe("resolveModelMeta", () => {
     expect(meta.id).toBe("claude-sonnet");
     expect(meta.reasoning.supportsEffort).toBe(true);
     expect(meta.reasoning.supportsAdaptiveThinking).toBe(true);
+    expect(meta.anthropic?.supportsSystemRoleInMessages).not.toBe(false);
   });
 
   it("matches gpt-5 max_completion_tokens family", () => {
@@ -62,6 +64,7 @@ describe("resolveModelMeta", () => {
     const meta = resolveModelMeta("custom-deployment-name", { vendor: "anthropic" });
     expect(meta.vendor).toBe("anthropic");
     expect(meta.reasoning.supportsEffort).toBe(true);
+    expect(meta.anthropic?.supportsSystemRoleInMessages).toBe(true);
   });
 
   it("lists all registered families", () => {

--- a/tests/unit/converter/model-meta/sanitize-anthropic.test.ts
+++ b/tests/unit/converter/model-meta/sanitize-anthropic.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { resolveModelMeta } from "@/converter/model-meta/registry";
+import { sanitizeAnthropicRequestByMeta } from "@/converter/model-meta/sanitize-anthropic";
+
+/* eslint-disable @typescript-eslint/naming-convention -- Anthropic API bodies use snake_case */
+
+describe("sanitizeAnthropicRequestByMeta", () => {
+  it("strips effort and thinking for claude-haiku (Cowork-style payload)", () => {
+    const data: Record<string, unknown> = {
+      model: "claude-haiku-4-5",
+      max_tokens: 32000,
+      thinking: { type: "enabled", budget_tokens: 31999 },
+      output_config: { effort: "medium" },
+      messages: [{ role: "user", content: "hi" }],
+    };
+    const meta = resolveModelMeta("claude-haiku-4-5", { vendor: "anthropic" });
+    const stripped = sanitizeAnthropicRequestByMeta(data, meta);
+
+    expect(stripped).toContain("output_config.effort");
+    expect(stripped).toContain("thinking");
+    expect(data.thinking).toBeUndefined();
+    expect(data.output_config).toBeUndefined();
+  });
+
+  it("preserves effort and thinking for claude-sonnet", () => {
+    const data: Record<string, unknown> = {
+      model: "claude-sonnet-4-20250514",
+      thinking: { type: "adaptive" },
+      output_config: { effort: "medium" },
+      messages: [{ role: "user", content: "hi" }],
+    };
+    const meta = resolveModelMeta("claude-sonnet-4-20250514", { vendor: "anthropic" });
+    const stripped = sanitizeAnthropicRequestByMeta(data, meta);
+
+    expect(stripped).toHaveLength(0);
+    expect(data.output_config).toEqual({ effort: "medium" });
+    expect(data.thinking).toEqual({ type: "adaptive" });
+  });
+
+  it("removes only effort when output_config has other keys", () => {
+    const data: Record<string, unknown> = {
+      model: "claude-haiku-4-5",
+      output_config: { effort: "medium", format: { type: "text" } },
+      messages: [],
+    };
+    const meta = resolveModelMeta("claude-haiku-4-5", { vendor: "anthropic" });
+    sanitizeAnthropicRequestByMeta(data, meta);
+
+    expect(data.output_config).toEqual({ format: { type: "text" } });
+  });
+});

--- a/tests/unit/converter/model-meta/sanitize-anthropic.test.ts
+++ b/tests/unit/converter/model-meta/sanitize-anthropic.test.ts
@@ -48,4 +48,39 @@ describe("sanitizeAnthropicRequestByMeta", () => {
 
     expect(data.output_config).toEqual({ format: { type: "text" } });
   });
+
+  it("hoists inline system messages for haiku Cowork-style payload", () => {
+    const data: Record<string, unknown> = {
+      model: "claude-haiku-4-5",
+      max_tokens: 32000,
+      thinking: { type: "adaptive" },
+      output_config: { effort: "xhigh" },
+      system: [
+        {
+          type: "text",
+          text: "You are Claude Code.",
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [
+        { role: "user", content: "Review the project." },
+        { role: "system", content: "Available skills: godot, pdf" },
+      ],
+    };
+    const meta = resolveModelMeta("claude-haiku-4-5", { vendor: "anthropic" });
+    const changes = sanitizeAnthropicRequestByMeta(data, meta);
+
+    expect(changes).toContain("messages.system->system");
+    expect(changes).toContain("thinking");
+    expect(changes).toContain("output_config.effort");
+    expect(data.messages).toEqual([{ role: "user", content: "Review the project." }]);
+    expect(data.system).toEqual([
+      {
+        type: "text",
+        text: "You are Claude Code.",
+        cache_control: { type: "ephemeral" },
+      },
+      { type: "text", text: "Available skills: godot, pdf" },
+    ]);
+  });
 });

--- a/tests/unit/converter/rules/openai-tool-call-arguments.test.ts
+++ b/tests/unit/converter/rules/openai-tool-call-arguments.test.ts
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/naming-convention -- OpenAI wire field names */
+import { describe, it, expect } from "vitest";
+import type { OpenAIMessage } from "@/converter/adapters/anthropic-to-openai-chat-request";
+import {
+  normalizeOpenAiToolCallArgumentsString,
+  sanitizeOpenAiChatToolArgumentsInMessages,
+} from "@/converter/rules/openai-tool-call-arguments";
+
+describe("normalizeOpenAiToolCallArgumentsString", () => {
+  it("returns {} for empty input", () => {
+    expect(normalizeOpenAiToolCallArgumentsString("")).toBe("{}");
+    expect(normalizeOpenAiToolCallArgumentsString("   ")).toBe("{}");
+  });
+
+  it("passes through valid object JSON", () => {
+    expect(normalizeOpenAiToolCallArgumentsString('{"query":"test"}')).toBe('{"query":"test"}');
+  });
+
+  it("wraps truncated JSON as raw", () => {
+    const truncated = '{"target_file":"/Users/dzhsurf/Documents/code';
+    const out = normalizeOpenAiToolCallArgumentsString(truncated);
+    expect(JSON.parse(out)).toEqual({ raw: truncated });
+  });
+
+  it("wraps non-object JSON values", () => {
+    expect(JSON.parse(normalizeOpenAiToolCallArgumentsString('"hello"'))).toEqual({
+      value: "hello",
+    });
+    expect(JSON.parse(normalizeOpenAiToolCallArgumentsString("[1,2]"))).toEqual({
+      value: [1, 2],
+    });
+  });
+});
+
+describe("sanitizeOpenAiChatToolArgumentsInMessages", () => {
+  it("repairs assistant tool_calls in place", () => {
+    const messages: OpenAIMessage[] = [
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call_1",
+            type: "function",
+            function: { name: "Read", arguments: '{"path":"/tmp' },
+          },
+        ],
+      },
+    ];
+    expect(sanitizeOpenAiChatToolArgumentsInMessages(messages)).toBe(1);
+    const args = messages[0].tool_calls?.[0].function.arguments ?? "";
+    expect(JSON.parse(args)).toEqual({ raw: '{"path":"/tmp' });
+  });
+});

--- a/tests/unit/converter/streaming/openai-chat-stream-to-responses.test.ts
+++ b/tests/unit/converter/streaming/openai-chat-stream-to-responses.test.ts
@@ -408,13 +408,16 @@ describe("processStreamingChunk", () => {
     );
     expect(state.toolCalls[0].arguments).toBe('{"query":"test"}');
 
-    // Finish
+    // Finish — tool close events are deferred until [DONE]
     const eFinish = processStreamingChunk(state, chunk({}, "stop"));
     const finishTypes = extractTypes(eFinish);
-    expect(finishTypes).toContain("response.function_call_arguments.done");
-    expect(finishTypes).toContain("response.output_item.done");
+    expect(finishTypes).not.toContain("response.function_call_arguments.done");
+    expect(finishTypes).not.toContain("response.output_item.done");
     expect(finishTypes).not.toContain("response.completed");
-    expect(extractTypes(processStreamingChunk(state, "[DONE]"))).toContain("response.completed");
+    const doneTypes = extractTypes(processStreamingChunk(state, "[DONE]"));
+    expect(doneTypes).toContain("response.function_call_arguments.done");
+    expect(doneTypes).toContain("response.output_item.done");
+    expect(doneTypes).toContain("response.completed");
   });
 
   it("handles multiple tool calls", () => {
@@ -457,14 +460,58 @@ describe("processStreamingChunk", () => {
     expect(state.toolCalls[0].name).toBe("fn_a");
     expect(state.toolCalls[1].name).toBe("fn_b");
 
-    // Finish
+    // Finish — tool close events are deferred until [DONE]
     const eFinish = processStreamingChunk(state, chunk({}, "tool_calls"));
-    // Should close both tool calls
     const finishTypes = extractTypes(eFinish);
-    const doneItems = finishTypes.filter(t => t === "response.output_item.done");
-    expect(doneItems.length).toBe(2);
+    expect(finishTypes).not.toContain("response.output_item.done");
     expect(finishTypes).not.toContain("response.completed");
-    expect(extractTypes(processStreamingChunk(state, "[DONE]"))).toContain("response.completed");
+    const doneTypes = extractTypes(processStreamingChunk(state, "[DONE]"));
+    expect(doneTypes.filter(t => t === "response.output_item.done").length).toBe(2);
+    expect(doneTypes).toContain("response.completed");
+  });
+
+  it("includes argument deltas that arrive after finish_reason before [DONE]", () => {
+    const state = createStreamingState();
+    processStreamingChunk(state, chunk({ role: "assistant", content: "" }));
+    processStreamingChunk(
+      state,
+      chunk({
+        tool_calls: [
+          {
+            index: 0,
+            id: "call_late",
+            type: "function",
+            function: { name: "search", arguments: "" },
+          },
+        ],
+      })
+    );
+    processStreamingChunk(
+      state,
+      chunk({
+        tool_calls: [{ index: 0, function: { arguments: '{"q":"' } }],
+      })
+    );
+
+    processStreamingChunk(state, chunk({}, "tool_calls"));
+    expect(state.toolsPendingClose).toBe(true);
+    expect(state.toolCalls[0].arguments).toBe('{"q":"');
+
+    processStreamingChunk(
+      state,
+      chunk({
+        tool_calls: [{ index: 0, function: { arguments: 'x"}' } }],
+      })
+    );
+    expect(state.toolCalls[0].arguments).toBe('{"q":"x"}');
+
+    const doneEvents = processStreamingChunk(state, "[DONE]");
+    const argDone = doneEvents.find(e => e.includes("response.function_call_arguments.done"));
+    expect(argDone).toContain('"arguments":"{\\"q\\":\\"x\\"}"');
+    const itemDone = doneEvents.find(
+      e => e.includes("response.output_item.done") && e.includes("function_call")
+    );
+    expect(itemDone).toContain('\\"q\\":\\"x\\"');
   });
 
   it("handles [DONE] sentinel", () => {

--- a/tests/unit/services/availability-probe/probe.test.ts
+++ b/tests/unit/services/availability-probe/probe.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { detectAvailabilityProbe } from "@/services/availability-probe/detector";
+import { formatAvailabilityProbeResponse } from "@/services/availability-probe/formatter";
+
+/* eslint-disable @typescript-eslint/naming-convention -- OpenAI/Anthropic wire keys in fixtures */
+
+describe("availability-probe detector", () => {
+  it("detects max_completion_tokens=1 on /chat/completions", () => {
+    const body = Buffer.from(
+      JSON.stringify({
+        model: "gpt-5.4",
+        messages: [{ role: "user", content: "." }],
+        max_completion_tokens: 1,
+      })
+    );
+    const detection = detectAvailabilityProbe(body, "POST", "/chat/completions", "anthropic");
+    expect(detection).toEqual({
+      model: "gpt-5.4",
+      stream: false,
+      responseSurface: "openai",
+    });
+  });
+
+  it("detects max_tokens=1 on Anthropic /v1/messages", () => {
+    const body = Buffer.from(
+      JSON.stringify({
+        model: "claude-sonnet-4-20250514",
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 1,
+      })
+    );
+    const detection = detectAvailabilityProbe(body, "POST", "/v1/messages", "anthropic");
+    expect(detection?.responseSurface).toBe("anthropic");
+    expect(detection?.stream).toBe(false);
+  });
+
+  it("ignores normal token limits", () => {
+    const body = Buffer.from(
+      JSON.stringify({
+        model: "gpt-4",
+        messages: [{ role: "user", content: "hello" }],
+        max_tokens: 1024,
+      })
+    );
+    expect(detectAvailabilityProbe(body, "POST", "/chat/completions", "openai")).toBeNull();
+  });
+});
+
+describe("availability-probe formatter", () => {
+  it("returns OpenAI chat completion JSON with content '1'", () => {
+    const out = formatAvailabilityProbeResponse({
+      model: "gpt-5.4",
+      stream: false,
+      responseSurface: "openai",
+    });
+    expect(out.statusCode).toBe(200);
+    expect(out.headers["Content-Type"]).toBe("application/json");
+    const parsed = JSON.parse(out.body) as {
+      choices: Array<{ message: { content: string } }>;
+    };
+    expect(parsed.choices[0]?.message.content).toBe("1");
+    expect(out.tokens.outputTokens).toBe(1);
+  });
+
+  it("returns Anthropic message JSON with one text block", () => {
+    const out = formatAvailabilityProbeResponse({
+      model: "claude-sonnet-4-20250514",
+      stream: false,
+      responseSurface: "anthropic",
+    });
+    const parsed = JSON.parse(out.body) as {
+      content: Array<{ type: string; text: string }>;
+    };
+    expect(parsed.content[0]).toEqual({ type: "text", text: "1" });
+  });
+
+  it("returns SSE for streaming OpenAI chat probes", () => {
+    const out = formatAvailabilityProbeResponse({
+      model: "gpt-5.4",
+      stream: true,
+      responseSurface: "openai",
+    });
+    expect(out.headers["Content-Type"]).toBe("text/event-stream");
+    expect(out.body).toContain("chat.completion.chunk");
+    expect(out.body).toContain('"content":"1"');
+    expect(out.body).toContain("[DONE]");
+  });
+});

--- a/tests/unit/web/wizard-engine.test.ts
+++ b/tests/unit/web/wizard-engine.test.ts
@@ -7,6 +7,7 @@ import {
   helperRowsSeedFromCustomModelsText,
   initSelections,
   parseCustomModelLineForUi,
+  slugifyProviderId,
 } from "../../../web/src/features/providers/wizard/engine";
 import {
   defaultModelIdsAsText,
@@ -354,5 +355,107 @@ describe("generateProviders", () => {
     expect(out[0].useCustomModelsList).toBe(false);
     expect(out[0].customModelsList).toBeUndefined();
     expect(out[0].modelMap).toEqual([]);
+  });
+
+  it("derives provider id from customized display name", () => {
+    const preset = getPresetById("generic-openai-chat");
+    if (!preset) {
+      throw new Error("preset generic-openai-chat");
+    }
+    const out = generateProviders(preset, {
+      selections: {},
+      apiKey: "k",
+      userBaseUrl: "https://gateway.example/v1",
+      nameBase: "Work OpenAI",
+      modelIds: ["gpt-4o"],
+      claudeSupport: true,
+      useCustomModels: true,
+    });
+    expect(out[0].id).toBe("work-openai-upstream");
+    expect(out[0].name).toBe("Work OpenAI");
+  });
+
+  it("keeps preset id when display name matches default", () => {
+    const preset = getPresetById("generic-anthropic");
+    if (!preset) {
+      throw new Error("preset generic-anthropic");
+    }
+    const out = generateProviders(preset, {
+      selections: {},
+      apiKey: "k",
+      userBaseUrl: "https://api.anthropic.com",
+      nameBase: "Anthropic",
+      modelIds: ["claude-sonnet-4-20250514"],
+      claudeSupport: false,
+      useCustomModels: true,
+    });
+    expect(out[0].id).toBe("anthropic-upstream");
+  });
+
+  it("suffixes provider id when it collides with an existing provider", () => {
+    const preset = getPresetById("generic-openai-chat");
+    if (!preset) {
+      throw new Error("preset generic-openai-chat");
+    }
+    const out = generateProviders(preset, {
+      selections: {},
+      apiKey: "k",
+      userBaseUrl: "https://gateway.example/v1",
+      nameBase: "Work OpenAI",
+      modelIds: ["gpt-4o"],
+      claudeSupport: true,
+      useCustomModels: true,
+      existingProviderIds: ["work-openai-upstream"],
+    });
+    expect(out[0].id).toBe("work-openai-upstream-2");
+  });
+
+  it("suffixes default preset id when adding a second provider without renaming", () => {
+    const preset = getPresetById("generic-openai-chat");
+    if (!preset) {
+      throw new Error("preset generic-openai-chat");
+    }
+    const out = generateProviders(preset, {
+      selections: {},
+      apiKey: "k",
+      userBaseUrl: "https://gateway.example/v1",
+      nameBase: "OpenAI-Chat",
+      modelIds: ["gpt-4o"],
+      claudeSupport: true,
+      useCustomModels: true,
+      existingProviderIds: ["openai-chat-upstream"],
+    });
+    expect(out[0].id).toBe("openai-chat-upstream-2");
+  });
+
+  it("keeps distinct ids for multi-variant presets with customized display name", () => {
+    const preset = getPresetById("glm");
+    if (!preset) {
+      throw new Error("preset glm");
+    }
+    const out = generateProviders(preset, {
+      selections: initSelections(preset),
+      apiKey: "k",
+      nameBase: "Company GLM",
+      modelIds: ["glm-5.1"],
+      claudeSupport: true,
+      useCustomModels: true,
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0].id).toBe("company-glm-intl-anthropic");
+    expect(out[1].id).toBe("company-glm-intl-openai");
+    expect(new Set(out.map(p => p.id)).size).toBe(2);
+  });
+});
+
+describe("slugifyProviderId", () => {
+  it("lowercases and hyphenates display names", () => {
+    expect(slugifyProviderId("Work OpenAI")).toBe("work-openai");
+    expect(slugifyProviderId("  My_Company-GLM  ")).toBe("my_company-glm");
+  });
+
+  it("returns empty string for blank input", () => {
+    expect(slugifyProviderId("   ")).toBe("");
+    expect(slugifyProviderId("---")).toBe("");
   });
 });

--- a/web/src/features/providers/Providers.tsx
+++ b/web/src/features/providers/Providers.tsx
@@ -984,6 +984,7 @@ export default function Providers() {
         open={showWizard}
         onOpenChange={setShowWizard}
         aliasPrefix={aliasPrefix}
+        existingProviderIds={(providersData?.providers ?? []).map(p => p.id)}
         onCustom={() => {
           setShowWizard(false);
           openLegacyAddModal();

--- a/web/src/features/providers/Providers.tsx
+++ b/web/src/features/providers/Providers.tsx
@@ -43,7 +43,6 @@ import { rebuildCoworkModelMap } from "@ccrelay/shared/coworkModelMap";
 import type { AliasHashProtocol } from "@ccrelay/shared/aliasHash";
 import { api } from "@/api/client";
 import type { AddProviderRequest, Provider, ModelMapEntry } from "@/types/api";
-import { providerVendorSortRank } from "./providerSortOrder";
 import { WizardDialog } from "./wizard/WizardDialog";
 import { CoworkAliasHelper } from "./CoworkAliasHelper";
 
@@ -590,18 +589,9 @@ export default function Providers() {
       }
       return p.enabled ? 1 : 2;
     };
-    const ga = sortGroup(a);
-    const gb = sortGroup(b);
-    if (ga !== gb) {
-      return ga - gb;
-    }
-    const rankDiff = providerVendorSortRank(a) - providerVendorSortRank(b);
-    if (rankDiff !== 0) {
-      return rankDiff;
-    }
-    const byName = a.name.localeCompare(b.name, "en", { sensitivity: "base", numeric: true });
-    if (byName !== 0) {
-      return byName;
+    const groupDiff = sortGroup(a) - sortGroup(b);
+    if (groupDiff !== 0) {
+      return groupDiff;
     }
     return a.id.localeCompare(b.id, "en", { sensitivity: "base", numeric: true });
   });

--- a/web/src/features/providers/providerSortOrder.ts
+++ b/web/src/features/providers/providerSortOrder.ts
@@ -1,5 +1,5 @@
 /**
- * Display order for partner vendors (wizard “合作商” / Partners) and provider list grouping.
+ * Display order for partner vendors (wizard “合作商” / Partners).
  */
 
 /** Partner preset ids in preferred UI order. */
@@ -19,53 +19,4 @@ export function partnerPresetSortIndex(presetId: string): number {
     presetId as (typeof PARTNER_PRESET_DISPLAY_ORDER)[number]
   );
   return i === -1 ? PARTNER_PRESET_DISPLAY_ORDER.length : i;
-}
-
-/** Lower rank sorts earlier (after `official` and enabled-state groups). */
-export function providerVendorSortRank(provider: { id: string; name: string }): number {
-  const id = provider.id.toLowerCase();
-  const name = provider.name.toLowerCase();
-
-  const matches = (needles: readonly string[]): boolean =>
-    needles.some(
-      n =>
-        id === n ||
-        id.startsWith(`${n}-`) ||
-        id.startsWith(`${n}_`) ||
-        id.includes(`-${n}-`) ||
-        id.includes(`-${n}_`) ||
-        name.includes(n)
-    );
-
-  if (provider.id === "official") {
-    return 0;
-  }
-  if (matches(["glm", "z.ai", "bigmodel", "智谱"])) {
-    return 10;
-  }
-  if (matches(["mimo", "xiaomi", "xiaomimimo", "小米"])) {
-    return 20;
-  }
-  if (matches(["deepseek"])) {
-    return 30;
-  }
-  if (matches(["minimax", "minimaxi"])) {
-    return 40;
-  }
-  if (matches(["azure"])) {
-    return 50;
-  }
-  if (matches(["openai"]) && !matches(["azure"])) {
-    return 60;
-  }
-  if (matches(["gemini", "generativelanguage"])) {
-    return 70;
-  }
-  if (matches(["astraflow", "umodelverse", "modelverse"])) {
-    return 80;
-  }
-  if (matches(["tuning-engines", "tuningengines"])) {
-    return 90;
-  }
-  return 1000;
 }

--- a/web/src/features/providers/wizard/WizardDialog.tsx
+++ b/web/src/features/providers/wizard/WizardDialog.tsx
@@ -33,6 +33,7 @@ export interface WizardDialogProps {
   onCustom: () => void;
   onComplete: () => void;
   aliasPrefix?: string;
+  existingProviderIds?: readonly string[];
   addMutation: {
     mutateAsync: (data: AddProviderRequest) => Promise<unknown>;
   };
@@ -58,6 +59,7 @@ export function WizardDialog({
   onCustom,
   onComplete,
   aliasPrefix = "claude-",
+  existingProviderIds = [],
   addMutation,
 }: WizardDialogProps) {
   const { t } = useTranslation();
@@ -177,6 +179,7 @@ export function WizardDialog({
       claudeSupport,
       useCustomModels,
       aliasPrefix,
+      existingProviderIds,
     };
     try {
       return { ok: true, preview: generateProviders(preset, wi) };
@@ -193,6 +196,7 @@ export function WizardDialog({
     claudeSupport,
     useCustomModels,
     aliasPrefix,
+    existingProviderIds,
   ]);
 
   const credentialFields: WizardCredentialsFields = useMemo(

--- a/web/src/features/providers/wizard/engine.ts
+++ b/web/src/features/providers/wizard/engine.ts
@@ -232,6 +232,46 @@ export function buildModelConfig(input: BuildModelConfigInput):
   };
 }
 
+/** Convert a display name into a provider ID segment (lowercase `[a-z0-9_-]`). */
+export function slugifyProviderId(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-+/g, "-");
+}
+
+function resolveProviderIdBase(
+  preset: PartnerPreset,
+  nameRoot: string,
+  idSuffix: string,
+  nameCustomized: boolean
+): string {
+  if (!nameCustomized) {
+    return [preset.idPrefix, idSuffix].filter(s => s.length > 0).join("-");
+  }
+  const slug = slugifyProviderId(nameRoot);
+  if (!slug) {
+    return [preset.idPrefix, idSuffix].filter(s => s.length > 0).join("-");
+  }
+  return [slug, idSuffix].filter(s => s.length > 0).join("-");
+}
+
+function ensureUniqueProviderId(baseId: string, reserved: Set<string>): string {
+  if (!reserved.has(baseId)) {
+    reserved.add(baseId);
+    return baseId;
+  }
+  let n = 2;
+  while (reserved.has(`${baseId}-${n}`)) {
+    n++;
+  }
+  const unique = `${baseId}-${n}`;
+  reserved.add(unique);
+  return unique;
+}
+
 function resolveAuthHeader(
   preset: PartnerPreset,
   selections: Record<string, string | boolean>
@@ -258,14 +298,18 @@ export function generateProviders(preset: PartnerPreset, input: WizardInput): Ad
   const templateValues = buildTemplateValues(preset, input.selections, input.userBaseUrl);
   const aliasPrefix = input.aliasPrefix ?? "claude-";
   const authHeader = resolveAuthHeader(preset, input.selections);
-  const nameRoot = input.nameBase?.trim() || preset.namePrefix;
+  const trimmedNameBase = input.nameBase?.trim();
+  const nameRoot = trimmedNameBase || preset.namePrefix;
+  const nameCustomized = Boolean(trimmedNameBase && trimmedNameBase !== preset.namePrefix);
+  const reservedIds = new Set(input.existingProviderIds ?? []);
 
   return preset.variants.map(variant => {
     const baseUrl = resolveTemplate(variant.urlTemplate, templateValues);
     const idSuffix = resolveTemplate(variant.idSuffix, templateValues);
     const nameSuffix = resolveTemplate(variant.nameSuffix, templateValues);
 
-    const id = [preset.idPrefix, idSuffix].filter(s => s.length > 0).join("-");
+    const idBase = resolveProviderIdBase(preset, nameRoot, idSuffix, nameCustomized);
+    const id = ensureUniqueProviderId(idBase, reservedIds);
     const nameParts = [nameRoot, nameSuffix].filter(s => s.length > 0);
     const name = nameParts.join("-");
 

--- a/web/src/features/providers/wizard/types.ts
+++ b/web/src/features/providers/wizard/types.ts
@@ -73,4 +73,6 @@ export interface WizardInput extends WizardModelInput {
   useCustomModels: boolean;
   /** Smart routing alias prefix; defaults to `claude-` when omitted */
   aliasPrefix?: string;
+  /** Existing provider IDs — used to avoid collisions when deriving IDs from display names */
+  existingProviderIds?: readonly string[];
 }


### PR DESCRIPTION
## Summary

- Repair truncated or invalid OpenAI `tool_calls[].function.arguments` before upstream prefill (e.g. MiMo), preventing 400 errors like `unexpected end of data: line 1 column 155` when conversation history contains incomplete tool calls from a prior stream.
- Defer Responses stream tool-close events until `[DONE]` so late `function_call_arguments.delta` chunks are not dropped.
- Normalize OpenAI chat outbound requests (`max_tokens` → `max_completion_tokens`, `stream_options.include_usage`) and improve log header redaction.
- Add model capability registry to strip unsupported reasoning params and hoist inline `system` messages for models like Claude Haiku.
- Short-circuit one-token availability probes locally instead of forwarding to upstream.
- Provider UI: derive wizard IDs from display names; sort providers alphabetically by id within groups.

## Test plan

- [ ] Reproduce MiMo Responses→Chat flow with a truncated `update_plan` tool call in history; confirm upstream request wraps arguments as `{"raw":"..."}` and no longer returns 400.
- [ ] Verify streaming Responses conversion emits `function_call_arguments.done` only after all deltas are received.
- [ ] Confirm Claude Haiku outbound requests hoist inline `system` messages and strip unsupported `reasoning` fields.
- [ ] Run `npm run test` and `npm run lint`.
- [ ] Smoke-test provider wizard: adding multiple providers with custom display names yields unique IDs.


Made with [Cursor](https://cursor.com)