### PR TITLE
feat: phase timing metrics, token stats fixes, and LongCat SSE normalization

### DIFF
--- a/packages/core/src/api/stats.ts
+++ b/packages/core/src/api/stats.ts
@@ -44,6 +44,7 @@ export async function handleStats(
       avgTtfb: 0,
       outputTps: 0,
       outputTpsSampleCount: 0,
+      avgQueueWaitMs: 0,
       p50Duration: 0,
       p90Duration: 0,
       providerBreakdown: [],

--- a/packages/core/src/converter/platform-transforms/index.ts
+++ b/packages/core/src/converter/platform-transforms/index.ts
@@ -93,6 +93,7 @@ export {
   transformGlmAnthropicSearchSseRows,
   glmWebSearchServerToolName,
 } from "./glm/anthropic-sse";
+export { transformLongcatAnthropicSseRows } from "./longcat/anthropic-sse";
 
 /** Routing slice used to strip outbound query per platform rule (no server-layer import). */
 export interface PlatformOutboundQueryRouting {

--- a/packages/core/src/converter/platform-transforms/longcat/anthropic-sse.ts
+++ b/packages/core/src/converter/platform-transforms/longcat/anthropic-sse.ts
@@ -1,0 +1,49 @@
+/**
+ * LongCat Anthropic Messages SSE: `message_start` often ships `usage: {}` while strict
+ * clients require numeric `input_tokens` / `output_tokens` (final counts arrive on `message_delta`).
+ */
+
+/* eslint-disable @typescript-eslint/naming-convention -- Anthropic SSE wire payloads */
+
+import type { AnthropicSseEventRow } from "../glm/anthropic-sse-emitter";
+
+function defaultUsageNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function normalizeMessageStartUsage(row: AnthropicSseEventRow): AnthropicSseEventRow {
+  if (row.data.type !== "message_start") {
+    return row;
+  }
+
+  const message = row.data.message;
+  if (!message || typeof message !== "object" || Array.isArray(message)) {
+    return row;
+  }
+
+  const msg = message as Record<string, unknown>;
+  const usageRaw = msg.usage;
+  const usage =
+    usageRaw && typeof usageRaw === "object" && !Array.isArray(usageRaw)
+      ? (usageRaw as Record<string, unknown>)
+      : {};
+
+  const data = structuredClone(row.data);
+  const normalizedMessage = { ...(data.message as Record<string, unknown>) };
+  normalizedMessage.usage = {
+    input_tokens: defaultUsageNumber(usage.input_tokens),
+    output_tokens: defaultUsageNumber(usage.output_tokens),
+    cache_read_input_tokens: defaultUsageNumber(usage.cache_read_input_tokens),
+    cache_creation_input_tokens: defaultUsageNumber(usage.cache_creation_input_tokens),
+  };
+  data.message = normalizedMessage;
+
+  return { eventName: row.eventName, data };
+}
+
+/** Fill missing numeric usage fields on `message_start` for strict Anthropic SSE clients. */
+export function transformLongcatAnthropicSseRows(
+  rows: AnthropicSseEventRow[]
+): AnthropicSseEventRow[] {
+  return rows.map(normalizeMessageStartUsage);
+}

--- a/packages/core/src/converter/platform-transforms/registries.ts
+++ b/packages/core/src/converter/platform-transforms/registries.ts
@@ -10,6 +10,7 @@ import type { AnthropicSseEventRow } from "./glm/anthropic-sse-emitter";
 import { azureWebSearchRequestOverride } from "./azure-openai/request-override";
 import { azureResponsesWebSearchResponseTransform } from "./azure-openai/responses-web-search";
 import { transformGlmAnthropicSearchSseRows } from "./glm/anthropic-sse";
+import { transformLongcatAnthropicSseRows } from "./longcat/anthropic-sse";
 import { glmWebSearchEnvelopeTransform } from "./glm/tools";
 import { glmFlattenContentTransform } from "./glm/messages";
 import { glmWebSearchResponseTransform } from "./glm/responses";
@@ -74,6 +75,7 @@ export const ANTHROPIC_SSE_TRANSFORM_REGISTRY: Readonly<
   Record<string, PlatformAnthropicSseTransform>
 > = {
   "glm-web-search-prime-normalize": transformGlmAnthropicSearchSseRows,
+  "longcat-message-start-usage": transformLongcatAnthropicSseRows,
 };
 
 export const REQUEST_SANITIZE_REGISTRY: Readonly<Record<string, PlatformRequestSanitizeTransform>> =

--- a/packages/core/src/converter/platform-transforms/rules.ts
+++ b/packages/core/src/converter/platform-transforms/rules.ts
@@ -23,6 +23,11 @@ export interface PlatformTransformRule {
   /** Anthropic Messages SSE buffered rewrite (hosted search normalization). Registry key. */
   anthropicSse?: string;
   /**
+   * When true, same-protocol Anthropic SSE applies `anthropicSse` per event while streaming
+   * (for row-local fixes). When false, transform runs only on the buffered hosted-search path.
+   */
+  anthropicSseStream?: boolean;
+  /**
    * After generic cross-protocol conversion to OpenAI Chat JSON: optional rewrite of body + path
    * (e.g. hosted web_search → Responses API on Azure).
    */
@@ -107,5 +112,11 @@ export const PLATFORM_TRANSFORM_RULES: readonly PlatformTransformRule[] = [
     domains: ["api.deepseek.com"],
     requestSanitize: "deepseek-chat-sanitize",
     strictTools: true,
+  },
+  {
+    provider: "longcat",
+    domains: ["api.longcat.chat"],
+    anthropicSse: "longcat-message-start-usage",
+    anthropicSseStream: true,
   },
 ];

--- a/packages/core/src/database/drivers/postgres/driver.ts
+++ b/packages/core/src/database/drivers/postgres/driver.ts
@@ -12,7 +12,11 @@ import {
   shouldTrackMetrics,
   POSTGRES_UPDATE_METRICS_COMPLETED,
   POSTGRES_UPDATE_METRICS_STATUS,
+  STREAM_GEN_SQL_COND,
+  UPSTREAM_TTFB_SQL_COND,
+  TOTAL_MS_SQL_COND,
 } from "../../metrics-sql";
+import { POSTGRES_UPDATE_LOG_COMPLETED } from "../../logs-sql";
 import type {
   DatabaseDriver,
   PostgresDriverConfig,
@@ -20,6 +24,7 @@ import type {
   LogFilter,
   LogQueryResult,
   DatabaseStats,
+  LogResponseTiming,
   ProviderStatRow,
   RequestStatus,
   StatsQuery,
@@ -31,7 +36,6 @@ import {
   dbRowToLogWithoutBody,
   filterProviderBreakdownByTokenUsage,
 } from "../../shared-utils";
-import { STREAM_PERF_SQL_COND } from "../../stream-metrics";
 
 /**
  * PostgreSQL driver implementation
@@ -130,8 +134,9 @@ export class PostgresDriver implements DatabaseDriver {
         timestamp, provider_id, provider_name, method, path, target_url,
         request_body, response_body, original_request_body, original_response_body,
         status_code, duration, success, error_message, client_id, status, route_type,
+        input_tokens, output_tokens, cache_tokens, ttfb,
         request_headers, response_headers
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)`,
         [
           log.timestamp,
           log.providerId,
@@ -150,6 +155,10 @@ export class PostgresDriver implements DatabaseDriver {
           log.clientId ?? null,
           "completed",
           log.routeType ?? null,
+          log.inputTokens ?? null,
+          log.outputTokens ?? null,
+          log.cacheTokens ?? null,
+          log.ttfb ?? null,
           log.requestHeaders ?? null,
           null,
         ]
@@ -276,7 +285,8 @@ export class PostgresDriver implements DatabaseDriver {
     outputTokens?: number,
     cacheTokens?: number,
     ttfb?: number,
-    responseHeadersMasked?: string
+    responseHeadersMasked?: string,
+    timing?: LogResponseTiming
   ): void {
     if (!this.isEnabled) {
       return;
@@ -285,28 +295,24 @@ export class PostgresDriver implements DatabaseDriver {
     Promise.all([
       ...(this._logsEnabled
         ? [
-            this.pool!.query(
-              `UPDATE ${TABLE}
-         SET status_code = $1,
-             response_body = $2,
-             original_response_body = $3,
-             duration = $4,
-             success = $5,
-             error_message = $6,
-             response_headers = $7,
-             status = 'completed'
-         WHERE client_id = $8`,
-              [
-                statusCode,
-                utf8StringToBlob(responseBody),
-                utf8StringToBlob(originalResponseBody),
-                duration,
-                success,
-                utf8StringToBlob(errorMessage),
-                responseHeadersMasked ?? null,
-                clientId,
-              ]
-            ),
+            this.pool!.query(POSTGRES_UPDATE_LOG_COMPLETED, [
+              statusCode,
+              utf8StringToBlob(responseBody),
+              utf8StringToBlob(originalResponseBody),
+              duration,
+              success,
+              utf8StringToBlob(errorMessage),
+              responseHeadersMasked ?? null,
+              inputTokens ?? null,
+              outputTokens ?? null,
+              cacheTokens ?? null,
+              ttfb ?? null,
+              timing?.queueWaitMs ?? null,
+              timing?.upstreamTtfbMs ?? null,
+              timing?.genMs ?? null,
+              timing?.totalMs ?? null,
+              clientId,
+            ]),
           ]
         : []),
       this.pool!.query(POSTGRES_UPDATE_METRICS_COMPLETED, [
@@ -315,6 +321,10 @@ export class PostgresDriver implements DatabaseDriver {
         cacheTokens ?? null,
         ttfb ?? null,
         duration,
+        timing?.queueWaitMs ?? null,
+        timing?.upstreamTtfbMs ?? null,
+        timing?.genMs ?? null,
+        timing?.totalMs ?? null,
         success,
         statusCode,
         clientId,
@@ -378,8 +388,9 @@ export class PostgresDriver implements DatabaseDriver {
             timestamp, provider_id, provider_name, method, path, target_url,
             request_body, response_body, original_request_body, original_response_body,
             status_code, duration, success, error_message, client_id, status, route_type,
+            input_tokens, output_tokens, cache_tokens, ttfb,
             request_headers, response_headers
-          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23)`,
             [
               log.timestamp,
               log.providerId,
@@ -398,6 +409,10 @@ export class PostgresDriver implements DatabaseDriver {
               log.clientId ?? null,
               "completed",
               log.routeType ?? null,
+              log.inputTokens ?? null,
+              log.outputTokens ?? null,
+              log.cacheTokens ?? null,
+              log.ttfb ?? null,
               log.requestHeaders ?? null,
               null,
             ]
@@ -481,7 +496,12 @@ export class PostgresDriver implements DatabaseDriver {
     const offset = filter.offset || 0;
 
     const rowsResult = await this.pool.query(
-      `SELECT v.*, m.input_tokens, m.output_tokens, m.cache_tokens, m.ttfb, m.model as metrics_model
+      `SELECT v.id, v.timestamp, v.provider_id, v.provider_name, v.method, v.path,
+              v.status_code, v.duration, v.success, v.error_message, v.client_id,
+              v.status, v.route_type,
+              v.input_tokens, v.output_tokens, v.cache_tokens, v.ttfb,
+              v.queue_wait_ms, v.upstream_ttfb_ms, v.gen_ms, v.total_ms,
+              m.model as metrics_model
        FROM ${TABLE} v
        LEFT JOIN ${METRICS_TABLE} m ON m.client_id = v.client_id
        ${whereClause} ORDER BY v.timestamp DESC LIMIT $${paramIndex++} OFFSET $${paramIndex}`,
@@ -502,7 +522,13 @@ export class PostgresDriver implements DatabaseDriver {
     }
 
     const result = await this.pool.query(
-      `SELECT v.*, m.input_tokens, m.output_tokens, m.cache_tokens, m.ttfb
+      `SELECT v.id, v.timestamp, v.provider_id, v.provider_name, v.method, v.path, v.target_url,
+              v.request_body, v.response_body, v.original_request_body, v.original_response_body,
+              v.request_headers, v.response_headers,
+              v.status_code, v.duration, v.success, v.error_message, v.client_id, v.status, v.route_type,
+              v.input_tokens, v.output_tokens, v.cache_tokens, v.ttfb,
+              v.queue_wait_ms, v.upstream_ttfb_ms, v.gen_ms, v.total_ms,
+              m.model as metrics_model
        FROM ${TABLE} v
        LEFT JOIN ${METRICS_TABLE} m ON m.client_id = v.client_id
        WHERE v.id = $1`,
@@ -578,6 +604,7 @@ export class PostgresDriver implements DatabaseDriver {
       avgTtfb: 0,
       outputTps: 0,
       outputTpsSampleCount: 0,
+      avgQueueWaitMs: 0,
       p50Duration: 0,
       p90Duration: 0,
       providerBreakdown: [],
@@ -600,9 +627,12 @@ export class PostgresDriver implements DatabaseDriver {
               COALESCE(SUM(input_tokens), 0) as "totalInputTokens",
               COALESCE(SUM(output_tokens), 0) as "totalOutputTokens",
               COALESCE(SUM(cache_tokens), 0) as "totalCacheTokens",
-              AVG(CASE WHEN ${STREAM_PERF_SQL_COND} THEN ttfb END) as "avgTtfb",
-              percentile_cont(0.5) WITHIN GROUP (ORDER BY duration) as "p50Duration",
-              percentile_cont(0.9) WITHIN GROUP (ORDER BY duration) as "p90Duration"
+              AVG(upstream_ttfb_ms) FILTER (WHERE ${UPSTREAM_TTFB_SQL_COND}) as "avgTtfb",
+              AVG(queue_wait_ms) FILTER (WHERE queue_wait_ms IS NOT NULL) as "avgQueueWaitMs",
+              percentile_cont(0.5) WITHIN GROUP (ORDER BY total_ms)
+                FILTER (WHERE ${TOTAL_MS_SQL_COND}) as "p50Duration",
+              percentile_cont(0.9) WITHIN GROUP (ORDER BY total_ms)
+                FILTER (WHERE ${TOTAL_MS_SQL_COND}) as "p90Duration"
        FROM ${METRICS_TABLE}
        WHERE ${timeFilter}`,
       timeParams
@@ -615,17 +645,16 @@ export class PostgresDriver implements DatabaseDriver {
     const totalInput = num(base.totalInputTokens);
     const totalOutput = num(base.totalOutputTokens);
     const totalCache = num(base.totalCacheTokens);
-    const denominator = totalInput + totalCache;
     const totalLogs = num(base.totalLogs);
 
     // 2. Filtered TPS
     const tpsResult = await this.pool.query(
       `SELECT COALESCE(SUM(output_tokens), 0) as "filteredTokens",
-              COALESCE(SUM(duration - ttfb), 0) as "filteredGenTime",
+              COALESCE(SUM(gen_ms), 0) as "filteredGenTime",
               COUNT(*) as "filteredCount"
        FROM ${METRICS_TABLE}
        WHERE ${timeFilter}
-         AND ${STREAM_PERF_SQL_COND}
+         AND ${STREAM_GEN_SQL_COND}
          AND output_tokens IS NOT NULL
          AND output_tokens > 0`,
       timeParams
@@ -657,7 +686,6 @@ export class PostgresDriver implements DatabaseDriver {
       byProvider[pid] = count;
       const inputTokens = num(row.totalInputTokens);
       const cacheTokens = num(row.totalCacheTokens);
-      const denom = inputTokens + cacheTokens;
       providerBreakdown.push({
         providerId: pid,
         providerName: String(row.provider_name ?? pid),
@@ -665,7 +693,7 @@ export class PostgresDriver implements DatabaseDriver {
         totalInputTokens: inputTokens,
         totalOutputTokens: num(row.totalOutputTokens),
         totalCacheTokens: cacheTokens,
-        cacheHitRate: denom > 0 ? Math.round((cacheTokens / denom) * 100) : 0,
+        cacheHitRate: inputTokens > 0 ? Math.round((cacheTokens / inputTokens) * 100) : 0,
       });
     }
 
@@ -678,10 +706,11 @@ export class PostgresDriver implements DatabaseDriver {
       totalInputTokens: totalInput,
       totalOutputTokens: totalOutput,
       totalCacheTokens: totalCache,
-      cacheHitRate: denominator > 0 ? Math.round((totalCache / denominator) * 100) : 0,
+      cacheHitRate: totalInput > 0 ? Math.round((totalCache / totalInput) * 100) : 0,
       avgTtfb: Math.round(fnum(base.avgTtfb)),
       outputTps: Math.round(outputTps * 10) / 10,
       outputTpsSampleCount: filteredCount,
+      avgQueueWaitMs: Math.round(fnum(base.avgQueueWaitMs)),
       p50Duration: Math.round(fnum(base.p50Duration)),
       p90Duration: Math.round(fnum(base.p90Duration)),
       providerBreakdown: filterProviderBreakdownByTokenUsage(providerBreakdown),

--- a/packages/core/src/database/drivers/sqlite/cli.ts
+++ b/packages/core/src/database/drivers/sqlite/cli.ts
@@ -17,7 +17,11 @@ import {
   buildMetricsCompletedInsertSql,
   SQLITE_UPDATE_METRICS_COMPLETED,
   SQLITE_UPDATE_METRICS_STATUS,
+  STREAM_GEN_SQL_COND,
+  UPSTREAM_TTFB_SQL_COND,
+  TOTAL_MS_SQL_COND,
 } from "../../metrics-sql";
+import { SQLITE_UPDATE_LOG_COMPLETED } from "../../logs-sql";
 import { SQLITE_MIN_VERSION, isSqliteVersionAtLeast } from "../../sqlite-version";
 import type {
   DatabaseDriver,
@@ -26,6 +30,7 @@ import type {
   LogFilter,
   LogQueryResult,
   DatabaseStats,
+  LogResponseTiming,
   ProviderStatRow,
   RequestStatus,
   StatsQuery,
@@ -47,7 +52,6 @@ import {
   type SqlInsertParam,
 } from "./utils";
 import { sqlLiteralForBlob } from "./cli-wire";
-import { STREAM_PERF_SQL_COND } from "../../stream-metrics";
 
 /** Thrown when the `sqlite3` executable is absent; callers may degrade to disabled log storage. */
 export const SQLITE_CLI_NOT_FOUND_MESSAGE = "sqlite3 CLI not found. Please install SQLite3.";
@@ -1088,7 +1092,8 @@ export class SqliteCliDriver implements DatabaseDriver {
     outputTokens?: number,
     cacheTokens?: number,
     ttfb?: number,
-    responseHeadersMasked?: string
+    responseHeadersMasked?: string,
+    timing?: LogResponseTiming
   ): void {
     if (!this.isEnabled || !this.writeConn?.started) {
       return;
@@ -1097,28 +1102,24 @@ export class SqliteCliDriver implements DatabaseDriver {
     const updates: Promise<void>[] = [];
     if (this._logsEnabled) {
       updates.push(
-        this.writeConn.exec(
-          `UPDATE ${TABLE}
-       SET status_code = ?,
-           response_body = ?,
-           original_response_body = ?,
-           duration = ?,
-           success = ?,
-           error_message = ?,
-           response_headers = ?,
-           status = 'completed'
-       WHERE client_id = ?`,
-          [
-            statusCode,
-            utf8StringToBlob(responseBody),
-            utf8StringToBlob(originalResponseBody),
-            duration,
-            success ? 1 : 0,
-            errorMessage ?? null,
-            responseHeadersMasked ?? null,
-            clientId,
-          ]
-        )
+        this.writeConn.exec(SQLITE_UPDATE_LOG_COMPLETED, [
+          statusCode,
+          utf8StringToBlob(responseBody),
+          utf8StringToBlob(originalResponseBody),
+          duration,
+          success ? 1 : 0,
+          errorMessage ?? null,
+          responseHeadersMasked ?? null,
+          inputTokens ?? null,
+          outputTokens ?? null,
+          cacheTokens ?? null,
+          ttfb ?? null,
+          timing?.queueWaitMs ?? null,
+          timing?.upstreamTtfbMs ?? null,
+          timing?.genMs ?? null,
+          timing?.totalMs ?? null,
+          clientId,
+        ])
       );
     }
     updates.push(
@@ -1128,6 +1129,10 @@ export class SqliteCliDriver implements DatabaseDriver {
         cacheTokens ?? null,
         ttfb ?? null,
         duration,
+        timing?.queueWaitMs ?? null,
+        timing?.upstreamTtfbMs ?? null,
+        timing?.genMs ?? null,
+        timing?.totalMs ?? null,
         success ? 1 : 0,
         statusCode,
         clientId,
@@ -1299,7 +1304,8 @@ export class SqliteCliDriver implements DatabaseDriver {
       `SELECT v.id, v.timestamp, v.provider_id, v.provider_name, v.method, v.path,
               v.status_code, v.duration, v.success, v.error_message, v.client_id,
               v.status, v.route_type,
-              m.input_tokens, m.output_tokens, m.cache_tokens, m.ttfb,
+              v.input_tokens, v.output_tokens, v.cache_tokens, v.ttfb,
+              v.queue_wait_ms, v.upstream_ttfb_ms, v.gen_ms, v.total_ms,
               m.model as metrics_model,
               ${CLI_BODY_PREVIEW_HEX}
        FROM ${TABLE} v
@@ -1326,7 +1332,9 @@ export class SqliteCliDriver implements DatabaseDriver {
               hex(v.original_response_body) as original_response_body,
               v.request_headers, v.response_headers,
               v.status_code, v.duration, v.success, v.error_message, v.client_id, v.status, v.route_type,
-              m.input_tokens, m.output_tokens, m.cache_tokens, m.ttfb
+              v.input_tokens, v.output_tokens, v.cache_tokens, v.ttfb,
+              v.queue_wait_ms, v.upstream_ttfb_ms, v.gen_ms, v.total_ms,
+              m.model as metrics_model
        FROM ${TABLE} v
        LEFT JOIN ${METRICS_TABLE} m ON m.client_id = v.client_id
        WHERE v.id = ?`,
@@ -1354,6 +1362,7 @@ export class SqliteCliDriver implements DatabaseDriver {
       avgTtfb: 0,
       outputTps: 0,
       outputTpsSampleCount: 0,
+      avgQueueWaitMs: 0,
       p50Duration: 0,
       p90Duration: 0,
       providerBreakdown: [],
@@ -1377,7 +1386,8 @@ export class SqliteCliDriver implements DatabaseDriver {
               COALESCE(SUM(input_tokens), 0) as totalInputTokens,
               COALESCE(SUM(output_tokens), 0) as totalOutputTokens,
               COALESCE(SUM(cache_tokens), 0) as totalCacheTokens,
-              AVG(CASE WHEN ${STREAM_PERF_SQL_COND} THEN ttfb END) as avgTtfb
+              AVG(CASE WHEN ${UPSTREAM_TTFB_SQL_COND} THEN upstream_ttfb_ms END) as avgTtfb,
+              AVG(CASE WHEN queue_wait_ms IS NOT NULL THEN queue_wait_ms END) as avgQueueWaitMs
        FROM ${METRICS_TABLE}
        WHERE ${timeFilter}`,
       timeParams
@@ -1386,16 +1396,15 @@ export class SqliteCliDriver implements DatabaseDriver {
     const totalInput = (base.totalInputTokens as number) ?? 0;
     const totalOutput = (base.totalOutputTokens as number) ?? 0;
     const totalCache = (base.totalCacheTokens as number) ?? 0;
-    const denominator = totalInput + totalCache;
 
-    // 2. Filtered TPS (only genuinely streamed: genTime > 500ms)
+    // 2. Filtered TPS (only genuinely streamed: gen_ms > 500ms)
     const tpsRows = await this.readConn.query(
       `SELECT COALESCE(SUM(output_tokens), 0) as filteredTokens,
-              COALESCE(SUM(duration - ttfb), 0) as filteredGenTime,
+              COALESCE(SUM(gen_ms), 0) as filteredGenTime,
               COUNT(*) as filteredCount
        FROM ${METRICS_TABLE}
        WHERE ${timeFilter}
-         AND ${STREAM_PERF_SQL_COND}
+         AND ${STREAM_GEN_SQL_COND}
          AND output_tokens IS NOT NULL
          AND output_tokens > 0`,
       timeParams
@@ -1406,25 +1415,29 @@ export class SqliteCliDriver implements DatabaseDriver {
     const filteredCount = (tps.filteredCount as number) ?? 0;
     const outputTps = filteredGenTime > 0 ? (filteredTokens / filteredGenTime) * 1000 : 0;
 
-    // 3. Percentiles via LIMIT/OFFSET
+    // 3. Percentiles via LIMIT/OFFSET on total_ms
     let p50Duration = 0;
     let p90Duration = 0;
-    const totalLogs = (base.totalLogs as number) ?? 0;
-    if (totalLogs > 0) {
-      const p50Offset = Math.floor(0.5 * (totalLogs - 1));
-      const p90Offset = Math.floor(0.9 * (totalLogs - 1));
+    const totalMsCountRows = await this.readConn.query(
+      `SELECT COUNT(*) as c FROM ${METRICS_TABLE} WHERE ${timeFilter} AND ${TOTAL_MS_SQL_COND}`,
+      timeParams
+    );
+    const totalMsRows = (totalMsCountRows[0]?.c as number) ?? 0;
+    if (totalMsRows > 0) {
+      const p50Offset = Math.floor(0.5 * (totalMsRows - 1));
+      const p90Offset = Math.floor(0.9 * (totalMsRows - 1));
       const [p50Rows, p90Rows] = await Promise.all([
         this.readConn.query(
-          `SELECT duration FROM ${METRICS_TABLE} WHERE ${timeFilter} ORDER BY duration ASC LIMIT 1 OFFSET ?`,
+          `SELECT total_ms FROM ${METRICS_TABLE} WHERE ${timeFilter} AND ${TOTAL_MS_SQL_COND} ORDER BY total_ms ASC LIMIT 1 OFFSET ?`,
           [...timeParams, p50Offset]
         ),
         this.readConn.query(
-          `SELECT duration FROM ${METRICS_TABLE} WHERE ${timeFilter} ORDER BY duration ASC LIMIT 1 OFFSET ?`,
+          `SELECT total_ms FROM ${METRICS_TABLE} WHERE ${timeFilter} AND ${TOTAL_MS_SQL_COND} ORDER BY total_ms ASC LIMIT 1 OFFSET ?`,
           [...timeParams, p90Offset]
         ),
       ]);
-      p50Duration = Math.round((p50Rows[0]?.duration as number) ?? 0);
-      p90Duration = Math.round((p90Rows[0]?.duration as number) ?? 0);
+      p50Duration = Math.round((p50Rows[0]?.total_ms as number) ?? 0);
+      p90Duration = Math.round((p90Rows[0]?.total_ms as number) ?? 0);
     }
 
     // 4. Provider breakdown
@@ -1445,7 +1458,6 @@ export class SqliteCliDriver implements DatabaseDriver {
       byProvider[r.provider_id as string] = r.count as number;
       const inputTokens = (r.totalInputTokens as number) ?? 0;
       const cacheTokens = (r.totalCacheTokens as number) ?? 0;
-      const denom = inputTokens + cacheTokens;
       providerBreakdown.push({
         providerId: r.provider_id as string,
         providerName: (r.provider_name as string) || (r.provider_id as string),
@@ -1453,12 +1465,12 @@ export class SqliteCliDriver implements DatabaseDriver {
         totalInputTokens: inputTokens,
         totalOutputTokens: (r.totalOutputTokens as number) ?? 0,
         totalCacheTokens: cacheTokens,
-        cacheHitRate: denom > 0 ? Math.round((cacheTokens / denom) * 100) : 0,
+        cacheHitRate: inputTokens > 0 ? Math.round((cacheTokens / inputTokens) * 100) : 0,
       });
     }
 
     return {
-      totalLogs,
+      totalLogs: (base.totalLogs as number) ?? 0,
       successCount: (base.successCount as number) ?? 0,
       errorCount: (base.errorCount as number) ?? 0,
       avgDuration: Math.round((base.avgDuration as number) ?? 0),
@@ -1466,10 +1478,11 @@ export class SqliteCliDriver implements DatabaseDriver {
       totalInputTokens: totalInput,
       totalOutputTokens: totalOutput,
       totalCacheTokens: totalCache,
-      cacheHitRate: denominator > 0 ? Math.round((totalCache / denominator) * 100) : 0,
+      cacheHitRate: totalInput > 0 ? Math.round((totalCache / totalInput) * 100) : 0,
       avgTtfb: Math.round((base.avgTtfb as number) ?? 0),
       outputTps: Math.round(outputTps * 10) / 10,
       outputTpsSampleCount: filteredCount,
+      avgQueueWaitMs: Math.round((base.avgQueueWaitMs as number) ?? 0),
       p50Duration,
       p90Duration,
       providerBreakdown: filterProviderBreakdownByTokenUsage(providerBreakdown),

--- a/packages/core/src/database/drivers/sqlite/native.ts
+++ b/packages/core/src/database/drivers/sqlite/native.ts
@@ -17,7 +17,11 @@ import {
   buildMetricsCompletedInsertSql,
   SQLITE_UPDATE_METRICS_COMPLETED,
   SQLITE_UPDATE_METRICS_STATUS,
+  STREAM_GEN_SQL_COND,
+  UPSTREAM_TTFB_SQL_COND,
+  TOTAL_MS_SQL_COND,
 } from "../../metrics-sql";
+import { SQLITE_UPDATE_LOG_COMPLETED } from "../../logs-sql";
 import { SQLITE_MIN_VERSION, isSqliteVersionAtLeast } from "../../sqlite-version";
 import { SQLITE_CLI_NOT_FOUND_MESSAGE } from "./cli";
 import type {
@@ -27,6 +31,7 @@ import type {
   LogFilter,
   LogQueryResult,
   DatabaseStats,
+  LogResponseTiming,
   ProviderStatRow,
   RequestStatus,
   StatsQuery,
@@ -42,7 +47,6 @@ import {
   filterProviderBreakdownByTokenUsage,
 } from "../../shared-utils";
 import { buildInsertSql } from "./utils";
-import { STREAM_PERF_SQL_COND } from "../../stream-metrics";
 
 export class SqliteNativeDriver implements DatabaseDriver {
   private readonly config: SqliteDriverConfig;
@@ -186,35 +190,34 @@ export class SqliteNativeDriver implements DatabaseDriver {
     outputTokens?: number,
     cacheTokens?: number,
     ttfb?: number,
-    responseHeadersMasked?: string
+    responseHeadersMasked?: string,
+    timing?: LogResponseTiming
   ): void {
     if (!this.isEnabled) {
       return;
     }
     try {
       if (this._logsEnabled) {
-        const stmt = this.d.prepare(`
-        UPDATE ${TABLE}
-        SET status_code = ?,
-            response_body = ?,
-            original_response_body = ?,
-            duration = ?,
-            success = ?,
-            error_message = ?,
-            response_headers = ?,
-            status = 'completed'
-        WHERE client_id = ?
-      `);
-        stmt.run(
-          statusCode,
-          utf8StringToBlob(responseBody),
-          utf8StringToBlob(originalResponseBody),
-          duration,
-          success ? 1 : 0,
-          errorMessage ?? null,
-          responseHeadersMasked ?? null,
-          clientId
-        );
+        this.d
+          .prepare(SQLITE_UPDATE_LOG_COMPLETED)
+          .run(
+            statusCode,
+            utf8StringToBlob(responseBody),
+            utf8StringToBlob(originalResponseBody),
+            duration,
+            success ? 1 : 0,
+            errorMessage ?? null,
+            responseHeadersMasked ?? null,
+            inputTokens ?? null,
+            outputTokens ?? null,
+            cacheTokens ?? null,
+            ttfb ?? null,
+            timing?.queueWaitMs ?? null,
+            timing?.upstreamTtfbMs ?? null,
+            timing?.genMs ?? null,
+            timing?.totalMs ?? null,
+            clientId
+          );
       }
       this.d
         .prepare(SQLITE_UPDATE_METRICS_COMPLETED)
@@ -224,6 +227,10 @@ export class SqliteNativeDriver implements DatabaseDriver {
           cacheTokens ?? null,
           ttfb ?? null,
           duration,
+          timing?.queueWaitMs ?? null,
+          timing?.upstreamTtfbMs ?? null,
+          timing?.genMs ?? null,
+          timing?.totalMs ?? null,
           success ? 1 : 0,
           statusCode,
           clientId
@@ -379,7 +386,8 @@ export class SqliteNativeDriver implements DatabaseDriver {
         `SELECT v.id, v.timestamp, v.provider_id, v.provider_name, v.method, v.path,
                 v.status_code, v.duration, v.success, v.error_message, v.client_id,
                 v.status, v.route_type,
-                m.input_tokens, m.output_tokens, m.cache_tokens, m.ttfb,
+                v.input_tokens, v.output_tokens, v.cache_tokens, v.ttfb,
+                v.queue_wait_ms, v.upstream_ttfb_ms, v.gen_ms, v.total_ms,
                 m.model as metrics_model,
                 ${sqliteListBodyPreviewColumns("v")}
          FROM ${TABLE} v
@@ -397,7 +405,7 @@ export class SqliteNativeDriver implements DatabaseDriver {
     }
     const row = this.d
       .prepare(
-        `SELECT v.*, m.input_tokens, m.output_tokens, m.cache_tokens, m.ttfb
+        `SELECT v.*, m.model as metrics_model
          FROM ${TABLE} v
          LEFT JOIN ${METRICS_TABLE} m ON m.client_id = v.client_id
          WHERE v.id = ?`
@@ -420,6 +428,7 @@ export class SqliteNativeDriver implements DatabaseDriver {
       avgTtfb: 0,
       outputTps: 0,
       outputTpsSampleCount: 0,
+      avgQueueWaitMs: 0,
       p50Duration: 0,
       p90Duration: 0,
       providerBreakdown: [],
@@ -443,7 +452,8 @@ export class SqliteNativeDriver implements DatabaseDriver {
                 COALESCE(SUM(input_tokens), 0) as totalInputTokens,
                 COALESCE(SUM(output_tokens), 0) as totalOutputTokens,
                 COALESCE(SUM(cache_tokens), 0) as totalCacheTokens,
-                AVG(CASE WHEN ${STREAM_PERF_SQL_COND} THEN ttfb END) as avgTtfb
+                AVG(CASE WHEN ${UPSTREAM_TTFB_SQL_COND} THEN upstream_ttfb_ms END) as avgTtfb,
+                AVG(CASE WHEN queue_wait_ms IS NOT NULL THEN queue_wait_ms END) as avgQueueWaitMs
          FROM ${METRICS_TABLE}
          WHERE ${timeFilter}`
       )
@@ -452,16 +462,15 @@ export class SqliteNativeDriver implements DatabaseDriver {
     const totalInput = (base.totalInputTokens as number) ?? 0;
     const totalOutput = (base.totalOutputTokens as number) ?? 0;
     const totalCache = (base.totalCacheTokens as number) ?? 0;
-    const denominator = totalInput + totalCache;
 
     const tps = this.d
       .prepare(
         `SELECT COALESCE(SUM(output_tokens), 0) as filteredTokens,
-                COALESCE(SUM(duration - ttfb), 0) as filteredGenTime,
+                COALESCE(SUM(gen_ms), 0) as filteredGenTime,
                 COUNT(*) as filteredCount
          FROM ${METRICS_TABLE}
          WHERE ${timeFilter}
-           AND ${STREAM_PERF_SQL_COND}
+           AND ${STREAM_GEN_SQL_COND}
            AND output_tokens IS NOT NULL
            AND output_tokens > 0`
       )
@@ -474,22 +483,27 @@ export class SqliteNativeDriver implements DatabaseDriver {
 
     let p50Duration = 0;
     let p90Duration = 0;
-    const totalLogs = (base.totalLogs as number) ?? 0;
-    if (totalLogs > 0) {
-      const p50Offset = Math.floor(0.5 * (totalLogs - 1));
-      const p90Offset = Math.floor(0.9 * (totalLogs - 1));
+    const totalMsCount = this.d
+      .prepare(
+        `SELECT COUNT(*) as c FROM ${METRICS_TABLE} WHERE ${timeFilter} AND ${TOTAL_MS_SQL_COND}`
+      )
+      .get(...timeParams) as Record<string, unknown>;
+    const totalMsRows = (totalMsCount?.c as number) ?? 0;
+    if (totalMsRows > 0) {
+      const p50Offset = Math.floor(0.5 * (totalMsRows - 1));
+      const p90Offset = Math.floor(0.9 * (totalMsRows - 1));
       const p50Row = this.d
         .prepare(
-          `SELECT duration FROM ${METRICS_TABLE} WHERE ${timeFilter} ORDER BY duration ASC LIMIT 1 OFFSET ?`
+          `SELECT total_ms FROM ${METRICS_TABLE} WHERE ${timeFilter} AND ${TOTAL_MS_SQL_COND} ORDER BY total_ms ASC LIMIT 1 OFFSET ?`
         )
         .get(...timeParams, p50Offset) as Record<string, unknown> | undefined;
       const p90Row = this.d
         .prepare(
-          `SELECT duration FROM ${METRICS_TABLE} WHERE ${timeFilter} ORDER BY duration ASC LIMIT 1 OFFSET ?`
+          `SELECT total_ms FROM ${METRICS_TABLE} WHERE ${timeFilter} AND ${TOTAL_MS_SQL_COND} ORDER BY total_ms ASC LIMIT 1 OFFSET ?`
         )
         .get(...timeParams, p90Offset) as Record<string, unknown> | undefined;
-      p50Duration = Math.round((p50Row?.duration as number) ?? 0);
-      p90Duration = Math.round((p90Row?.duration as number) ?? 0);
+      p50Duration = Math.round((p50Row?.total_ms as number) ?? 0);
+      p90Duration = Math.round((p90Row?.total_ms as number) ?? 0);
     }
 
     const providerRows = this.d
@@ -510,7 +524,6 @@ export class SqliteNativeDriver implements DatabaseDriver {
       byProvider[r.provider_id as string] = r.count as number;
       const inputTokens = (r.totalInputTokens as number) ?? 0;
       const cacheTokens = (r.totalCacheTokens as number) ?? 0;
-      const denom = inputTokens + cacheTokens;
       providerBreakdown.push({
         providerId: r.provider_id as string,
         providerName: (r.provider_name as string) || (r.provider_id as string),
@@ -518,12 +531,12 @@ export class SqliteNativeDriver implements DatabaseDriver {
         totalInputTokens: inputTokens,
         totalOutputTokens: (r.totalOutputTokens as number) ?? 0,
         totalCacheTokens: cacheTokens,
-        cacheHitRate: denom > 0 ? Math.round((cacheTokens / denom) * 100) : 0,
+        cacheHitRate: inputTokens > 0 ? Math.round((cacheTokens / inputTokens) * 100) : 0,
       });
     }
 
     return {
-      totalLogs,
+      totalLogs: (base.totalLogs as number) ?? 0,
       successCount: (base.successCount as number) ?? 0,
       errorCount: (base.errorCount as number) ?? 0,
       avgDuration: Math.round((base.avgDuration as number) ?? 0),
@@ -531,10 +544,11 @@ export class SqliteNativeDriver implements DatabaseDriver {
       totalInputTokens: totalInput,
       totalOutputTokens: totalOutput,
       totalCacheTokens: totalCache,
-      cacheHitRate: denominator > 0 ? Math.round((totalCache / denominator) * 100) : 0,
+      cacheHitRate: totalInput > 0 ? Math.round((totalCache / totalInput) * 100) : 0,
       avgTtfb: Math.round((base.avgTtfb as number) ?? 0),
       outputTps: Math.round(outputTps * 10) / 10,
       outputTpsSampleCount: filteredCount,
+      avgQueueWaitMs: Math.round((base.avgQueueWaitMs as number) ?? 0),
       p50Duration,
       p90Duration,
       providerBreakdown: filterProviderBreakdownByTokenUsage(providerBreakdown),

--- a/packages/core/src/database/drivers/sqlite/utils.ts
+++ b/packages/core/src/database/drivers/sqlite/utils.ts
@@ -28,8 +28,9 @@ export function buildInsertSql(
       timestamp, provider_id, provider_name, method, path, target_url,
       request_body, response_body, original_request_body, original_response_body,
       status_code, duration, success, error_message, client_id, status, route_type,
+      input_tokens, output_tokens, cache_tokens, ttfb,
       request_headers, response_headers
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     params: [
       log.timestamp,
       log.providerId,
@@ -48,6 +49,10 @@ export function buildInsertSql(
       log.clientId ?? null,
       status,
       log.routeType ?? null,
+      log.inputTokens ?? null,
+      log.outputTokens ?? null,
+      log.cacheTokens ?? null,
+      log.ttfb ?? null,
       log.requestHeaders ?? null,
       null,
     ],

--- a/packages/core/src/database/index.ts
+++ b/packages/core/src/database/index.ts
@@ -199,6 +199,7 @@ export class LogDatabase {
         avgTtfb: 0,
         outputTps: 0,
         outputTpsSampleCount: 0,
+        avgQueueWaitMs: 0,
         p50Duration: 0,
         p90Duration: 0,
         providerBreakdown: [],

--- a/packages/core/src/database/logs-sql.ts
+++ b/packages/core/src/database/logs-sql.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared SQL for request_logs_v2 token redundancy (SQLite + Postgres drivers).
+ */
+
+import { TABLE } from "./schema";
+
+export const SQLITE_UPDATE_LOG_COMPLETED = `UPDATE ${TABLE}
+  SET status_code = ?,
+      response_body = ?,
+      original_response_body = ?,
+      duration = ?,
+      success = ?,
+      error_message = ?,
+      response_headers = ?,
+      input_tokens = ?,
+      output_tokens = ?,
+      cache_tokens = ?,
+      ttfb = ?,
+      queue_wait_ms = ?,
+      upstream_ttfb_ms = ?,
+      gen_ms = ?,
+      total_ms = ?,
+      status = 'completed'
+  WHERE client_id = ?`;
+
+export const POSTGRES_UPDATE_LOG_COMPLETED = `UPDATE ${TABLE}
+  SET status_code = $1,
+      response_body = $2,
+      original_response_body = $3,
+      duration = $4,
+      success = $5,
+      error_message = $6,
+      response_headers = $7,
+      input_tokens = $8,
+      output_tokens = $9,
+      cache_tokens = $10,
+      ttfb = $11,
+      queue_wait_ms = $12,
+      upstream_ttfb_ms = $13,
+      gen_ms = $14,
+      total_ms = $15,
+      status = 'completed'
+  WHERE client_id = $16`;

--- a/packages/core/src/database/metrics-sql.ts
+++ b/packages/core/src/database/metrics-sql.ts
@@ -3,12 +3,17 @@
  */
 
 import { METRICS_TABLE } from "./schema";
-import { STREAM_PERF_SQL_COND } from "./stream-metrics";
+import {
+  STREAM_GEN_SQL_COND,
+  STREAM_PERF_SQL_COND,
+  TOTAL_MS_SQL_COND,
+  UPSTREAM_TTFB_SQL_COND,
+} from "./stream-metrics";
 import type { RequestLog } from "./types";
 import { isTokenUsageRequestPath } from "../converter/paths";
 
 /** Re-export for drivers building stats queries. */
-export { STREAM_PERF_SQL_COND };
+export { STREAM_PERF_SQL_COND, STREAM_GEN_SQL_COND, UPSTREAM_TTFB_SQL_COND, TOTAL_MS_SQL_COND };
 
 export function shouldTrackMetrics(log: Pick<RequestLog, "method" | "path">): boolean {
   return isTokenUsageRequestPath(log.method, log.path);
@@ -22,8 +27,10 @@ export function buildMetricsPendingInsertSql(log: RequestLog): {
   return {
     sql: `INSERT INTO ${METRICS_TABLE} (
       timestamp, provider_id, provider_name, model, client_id,
-      input_tokens, output_tokens, cache_tokens, ttfb, duration, success, status_code
-    ) VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, NULL, NULL)`,
+      input_tokens, output_tokens, cache_tokens, ttfb, duration,
+      queue_wait_ms, upstream_ttfb_ms, gen_ms, total_ms,
+      success, status_code
+    ) VALUES (?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)`,
     params: [
       log.timestamp,
       log.providerId,
@@ -42,14 +49,20 @@ export function buildMetricsCompletedInsertSql(log: RequestLog): {
   return {
     sql: `INSERT INTO ${METRICS_TABLE} (
       timestamp, provider_id, provider_name, model, client_id,
-      input_tokens, output_tokens, cache_tokens, ttfb, duration, success, status_code
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      input_tokens, output_tokens, cache_tokens, ttfb, duration,
+      queue_wait_ms, upstream_ttfb_ms, gen_ms, total_ms,
+      success, status_code
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(client_id) DO UPDATE SET
       input_tokens=excluded.input_tokens,
       output_tokens=excluded.output_tokens,
       cache_tokens=excluded.cache_tokens,
       ttfb=excluded.ttfb,
       duration=excluded.duration,
+      queue_wait_ms=excluded.queue_wait_ms,
+      upstream_ttfb_ms=excluded.upstream_ttfb_ms,
+      gen_ms=excluded.gen_ms,
+      total_ms=excluded.total_ms,
       success=excluded.success,
       status_code=excluded.status_code`,
     params: [
@@ -63,6 +76,10 @@ export function buildMetricsCompletedInsertSql(log: RequestLog): {
       log.cacheTokens ?? null,
       log.ttfb ?? null,
       log.duration,
+      log.queueWaitMs ?? null,
+      log.upstreamTtfbMs ?? null,
+      log.genMs ?? null,
+      log.totalMs ?? null,
       log.success ? 1 : 0,
       log.statusCode ?? null,
     ],
@@ -75,6 +92,10 @@ export const SQLITE_UPDATE_METRICS_COMPLETED = `UPDATE ${METRICS_TABLE}
       cache_tokens = ?,
       ttfb = ?,
       duration = ?,
+      queue_wait_ms = ?,
+      upstream_ttfb_ms = ?,
+      gen_ms = ?,
+      total_ms = ?,
       success = ?,
       status_code = ?
   WHERE client_id = ?`;
@@ -92,9 +113,13 @@ export const POSTGRES_UPDATE_METRICS_COMPLETED = `UPDATE ${METRICS_TABLE}
       cache_tokens = $3,
       ttfb = $4,
       duration = $5,
-      success = $6,
-      status_code = $7
-  WHERE client_id = $8`;
+      queue_wait_ms = $6,
+      upstream_ttfb_ms = $7,
+      gen_ms = $8,
+      total_ms = $9,
+      success = $10,
+      status_code = $11
+  WHERE client_id = $12`;
 
 export const POSTGRES_UPDATE_METRICS_STATUS = `UPDATE ${METRICS_TABLE}
   SET duration = $1,

--- a/packages/core/src/database/migration.ts
+++ b/packages/core/src/database/migration.ts
@@ -13,6 +13,8 @@ import {
   SQLITE_CREATE_TABLE_METRICS,
   SQLITE_INDEXES_METRICS,
   V2_TOKEN_COLUMNS,
+  V2_TIMING_COLUMNS,
+  METRICS_TIMING_COLUMNS,
   POSTGRES_CREATE_TABLE_V2,
   POSTGRES_INDEXES_V2,
   POSTGRES_CREATE_SCHEMA_MIGRATIONS,
@@ -317,6 +319,91 @@ async function runMigrationV2SplitMetricsPostgres(ctx: PostgresMigrationContext)
   }
 }
 
+function runMigrationV4LogTokenRedundancySqlite(ctx: SqliteMigrationContext): void {
+  for (const col of V2_TOKEN_COLUMNS) {
+    if (!sqliteColumnExists(ctx.queryScalar, TABLE, col)) {
+      ctx.exec(`ALTER TABLE ${TABLE} ADD COLUMN ${col} INTEGER`);
+    }
+  }
+}
+
+async function runMigrationV4LogTokenRedundancySqliteAsync(ctx: {
+  exec: (sql: string) => void | Promise<void>;
+  queryScalar: (sql: string) => number | null | undefined | Promise<number | null | undefined>;
+}): Promise<void> {
+  for (const col of V2_TOKEN_COLUMNS) {
+    const exists =
+      (await Promise.resolve(
+        ctx.queryScalar(
+          `SELECT COUNT(*) as c FROM pragma_table_info('${TABLE}') WHERE name='${col}'`
+        )
+      )) ?? 0;
+    if (exists === 0) {
+      await ctx.exec(`ALTER TABLE ${TABLE} ADD COLUMN ${col} INTEGER`);
+    }
+  }
+}
+
+async function runMigrationV4LogTokenRedundancyPostgres(
+  query: (sql: string, params?: unknown[]) => Promise<unknown>
+): Promise<void> {
+  for (const col of V2_TOKEN_COLUMNS) {
+    await query(`ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS ${col} INTEGER`);
+  }
+}
+
+function runMigrationV5TimingPhasesSqlite(ctx: SqliteMigrationContext): void {
+  for (const col of V2_TIMING_COLUMNS) {
+    if (!sqliteColumnExists(ctx.queryScalar, TABLE, col)) {
+      ctx.exec(`ALTER TABLE ${TABLE} ADD COLUMN ${col} INTEGER`);
+    }
+  }
+  for (const col of METRICS_TIMING_COLUMNS) {
+    if (!sqliteColumnExists(ctx.queryScalar, METRICS_TABLE, col)) {
+      ctx.exec(`ALTER TABLE ${METRICS_TABLE} ADD COLUMN ${col} INTEGER`);
+    }
+  }
+}
+
+async function runMigrationV5TimingPhasesSqliteAsync(ctx: {
+  exec: (sql: string) => void | Promise<void>;
+  queryScalar: (sql: string) => number | null | undefined | Promise<number | null | undefined>;
+}): Promise<void> {
+  for (const col of V2_TIMING_COLUMNS) {
+    const exists =
+      (await Promise.resolve(
+        ctx.queryScalar(
+          `SELECT COUNT(*) as c FROM pragma_table_info('${TABLE}') WHERE name='${col}'`
+        )
+      )) ?? 0;
+    if (exists === 0) {
+      await ctx.exec(`ALTER TABLE ${TABLE} ADD COLUMN ${col} INTEGER`);
+    }
+  }
+  for (const col of METRICS_TIMING_COLUMNS) {
+    const exists =
+      (await Promise.resolve(
+        ctx.queryScalar(
+          `SELECT COUNT(*) as c FROM pragma_table_info('${METRICS_TABLE}') WHERE name='${col}'`
+        )
+      )) ?? 0;
+    if (exists === 0) {
+      await ctx.exec(`ALTER TABLE ${METRICS_TABLE} ADD COLUMN ${col} INTEGER`);
+    }
+  }
+}
+
+async function runMigrationV5TimingPhasesPostgres(
+  query: (sql: string, params?: unknown[]) => Promise<unknown>
+): Promise<void> {
+  for (const col of V2_TIMING_COLUMNS) {
+    await query(`ALTER TABLE ${TABLE} ADD COLUMN IF NOT EXISTS ${col} INTEGER`);
+  }
+  for (const col of METRICS_TIMING_COLUMNS) {
+    await query(`ALTER TABLE ${METRICS_TABLE} ADD COLUMN IF NOT EXISTS ${col} INTEGER`);
+  }
+}
+
 function sqliteRecordMigration(exec: (sql: string) => void, version: number, name: string): void {
   exec(
     `INSERT OR REPLACE INTO ${MIGRATIONS_TABLE} (version, name, applied_at) VALUES (${version}, '${name}', ${Date.now()})`
@@ -482,6 +569,22 @@ export function runSqliteMigrations(ctx: SqliteMigrationContext): void {
     applied = true;
   }
 
+  if (maxVersion < 4) {
+    logMigration(`Applying v4 log_token_redundancy${suffix}`);
+    runMigrationV4LogTokenRedundancySqlite(ctx);
+    sqliteRecordMigration(ctx.exec, 4, "log_token_redundancy");
+    logMigration(`v4 log_token_redundancy applied${suffix}`);
+    applied = true;
+  }
+
+  if (maxVersion < 5) {
+    logMigration(`Applying v5 timing_phases${suffix}`);
+    runMigrationV5TimingPhasesSqlite(ctx);
+    sqliteRecordMigration(ctx.exec, 5, "timing_phases");
+    logMigration(`v5 timing_phases applied${suffix}`);
+    applied = true;
+  }
+
   if (!applied) {
     logMigration(`Schema up to date (version ${maxVersion})${suffix}`);
   } else {
@@ -581,6 +684,26 @@ export async function runSqliteMigrationsAsync(ctx: SqliteMigrationAsyncContext)
       `INSERT OR REPLACE INTO ${MIGRATIONS_TABLE} (version, name, applied_at) VALUES (3, 'add_headers', ${Date.now()})`
     );
     logMigration(`v3 add_headers applied${suffix}`);
+    applied = true;
+  }
+
+  if (maxVersion < 4) {
+    logMigration(`Applying v4 log_token_redundancy${suffix}`);
+    await runMigrationV4LogTokenRedundancySqliteAsync(ctx);
+    await ctx.exec(
+      `INSERT OR REPLACE INTO ${MIGRATIONS_TABLE} (version, name, applied_at) VALUES (4, 'log_token_redundancy', ${Date.now()})`
+    );
+    logMigration(`v4 log_token_redundancy applied${suffix}`);
+    applied = true;
+  }
+
+  if (maxVersion < 5) {
+    logMigration(`Applying v5 timing_phases${suffix}`);
+    await runMigrationV5TimingPhasesSqliteAsync(ctx);
+    await ctx.exec(
+      `INSERT OR REPLACE INTO ${MIGRATIONS_TABLE} (version, name, applied_at) VALUES (5, 'timing_phases', ${Date.now()})`
+    );
+    logMigration(`v5 timing_phases applied${suffix}`);
     applied = true;
   }
 
@@ -707,6 +830,22 @@ export async function runPostgresMigrations(ctx: PostgresMigrationContext): Prom
     }
     await postgresRecordMigration(ctx.query, 3, "add_headers");
     logMigration(`v3 add_headers applied${suffix}`);
+    applied = true;
+  }
+
+  if (maxVersion < 4) {
+    logMigration(`Applying v4 log_token_redundancy${suffix}`);
+    await runMigrationV4LogTokenRedundancyPostgres(ctx.query);
+    await postgresRecordMigration(ctx.query, 4, "log_token_redundancy");
+    logMigration(`v4 log_token_redundancy applied${suffix}`);
+    applied = true;
+  }
+
+  if (maxVersion < 5) {
+    logMigration(`Applying v5 timing_phases${suffix}`);
+    await runMigrationV5TimingPhasesPostgres(ctx.query);
+    await postgresRecordMigration(ctx.query, 5, "timing_phases");
+    logMigration(`v5 timing_phases applied${suffix}`);
     applied = true;
   }
 

--- a/packages/core/src/database/schema.ts
+++ b/packages/core/src/database/schema.ts
@@ -32,6 +32,10 @@ export const SQLITE_CREATE_TABLE_V2 = `
     output_tokens INTEGER,
     cache_tokens INTEGER,
     ttfb INTEGER,
+    queue_wait_ms INTEGER,
+    upstream_ttfb_ms INTEGER,
+    gen_ms INTEGER,
+    total_ms INTEGER,
     request_headers TEXT,
     response_headers TEXT
   )
@@ -46,7 +50,7 @@ export const SQLITE_INDEXES_V2 = [
   `CREATE INDEX IF NOT EXISTS idx_v2_status ON ${TABLE}(status)`,
 ] as const;
 
-/** Final-state v2 DDL (no token columns) for new databases after migration v2. */
+/** Final-state v2 DDL (token columns redundant for per-log display; metrics table drives dashboard). */
 export const SQLITE_CREATE_TABLE_V2_FINAL = `
   CREATE TABLE IF NOT EXISTS ${TABLE} (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -67,6 +71,14 @@ export const SQLITE_CREATE_TABLE_V2_FINAL = `
     client_id TEXT,
     status TEXT DEFAULT 'completed',
     route_type TEXT,
+    input_tokens INTEGER,
+    output_tokens INTEGER,
+    cache_tokens INTEGER,
+    ttfb INTEGER,
+    queue_wait_ms INTEGER,
+    upstream_ttfb_ms INTEGER,
+    gen_ms INTEGER,
+    total_ms INTEGER,
     request_headers TEXT,
     response_headers TEXT
   )
@@ -93,6 +105,10 @@ export const SQLITE_CREATE_TABLE_METRICS = `
     cache_tokens INTEGER,
     ttfb INTEGER,
     duration INTEGER,
+    queue_wait_ms INTEGER,
+    upstream_ttfb_ms INTEGER,
+    gen_ms INTEGER,
+    total_ms INTEGER,
     success INTEGER,
     status_code INTEGER
   )
@@ -105,6 +121,20 @@ export const SQLITE_INDEXES_METRICS = [
 ] as const;
 
 export const V2_TOKEN_COLUMNS = ["input_tokens", "output_tokens", "cache_tokens", "ttfb"] as const;
+
+export const V2_TIMING_COLUMNS = [
+  "queue_wait_ms",
+  "upstream_ttfb_ms",
+  "gen_ms",
+  "total_ms",
+] as const;
+
+export const METRICS_TIMING_COLUMNS = [
+  "queue_wait_ms",
+  "upstream_ttfb_ms",
+  "gen_ms",
+  "total_ms",
+] as const;
 
 export const POSTGRES_CREATE_TABLE_V2 = `
   CREATE TABLE IF NOT EXISTS ${TABLE} (
@@ -130,6 +160,10 @@ export const POSTGRES_CREATE_TABLE_V2 = `
     output_tokens INTEGER,
     cache_tokens INTEGER,
     ttfb INTEGER,
+    queue_wait_ms INTEGER,
+    upstream_ttfb_ms INTEGER,
+    gen_ms INTEGER,
+    total_ms INTEGER,
     request_headers TEXT,
     response_headers TEXT
   )
@@ -164,6 +198,14 @@ export const POSTGRES_CREATE_TABLE_V2_FINAL = `
     client_id TEXT,
     status TEXT DEFAULT 'completed',
     route_type TEXT,
+    input_tokens INTEGER,
+    output_tokens INTEGER,
+    cache_tokens INTEGER,
+    ttfb INTEGER,
+    queue_wait_ms INTEGER,
+    upstream_ttfb_ms INTEGER,
+    gen_ms INTEGER,
+    total_ms INTEGER,
     request_headers TEXT,
     response_headers TEXT
   )
@@ -190,6 +232,10 @@ export const POSTGRES_CREATE_TABLE_METRICS = `
     cache_tokens INTEGER,
     ttfb INTEGER,
     duration INTEGER,
+    queue_wait_ms INTEGER,
+    upstream_ttfb_ms INTEGER,
+    gen_ms INTEGER,
+    total_ms INTEGER,
     success INTEGER,
     status_code INTEGER
   )

--- a/packages/core/src/database/shared-utils.ts
+++ b/packages/core/src/database/shared-utils.ts
@@ -203,6 +203,10 @@ export function dbRowToLogWithoutBody(row: Record<string, unknown>): RequestLog 
     outputTokens: row.output_tokens as number | undefined,
     cacheTokens: row.cache_tokens as number | undefined,
     ttfb: row.ttfb as number | undefined,
+    queueWaitMs: row.queue_wait_ms as number | undefined,
+    upstreamTtfbMs: row.upstream_ttfb_ms as number | undefined,
+    genMs: row.gen_ms as number | undefined,
+    totalMs: row.total_ms as number | undefined,
     ...models,
   };
 
@@ -246,6 +250,10 @@ export function dbRowToLog(row: Record<string, unknown>): RequestLog {
     outputTokens: row.output_tokens as number | undefined,
     cacheTokens: row.cache_tokens as number | undefined,
     ttfb: row.ttfb as number | undefined,
+    queueWaitMs: row.queue_wait_ms as number | undefined,
+    upstreamTtfbMs: row.upstream_ttfb_ms as number | undefined,
+    genMs: row.gen_ms as number | undefined,
+    totalMs: row.total_ms as number | undefined,
     ...models,
   };
 }

--- a/packages/core/src/database/stream-metrics.ts
+++ b/packages/core/src/database/stream-metrics.ts
@@ -4,5 +4,14 @@
  */
 export const STREAM_GEN_TIME_MIN_MS = 500;
 
-/** SQL condition for metrics rows with meaningful stream perf (SQLite/Postgres). */
+/** SQL condition for metrics rows with meaningful stream perf (legacy ttfb/duration). */
 export const STREAM_PERF_SQL_COND = `ttfb IS NOT NULL AND (duration - ttfb) > ${STREAM_GEN_TIME_MIN_MS}`;
+
+/** SQL condition for output TPS using phase timings (gen_ms). */
+export const STREAM_GEN_SQL_COND = `gen_ms IS NOT NULL AND gen_ms > ${STREAM_GEN_TIME_MIN_MS}`;
+
+/** SQL condition for upstream TTFB using phase timings. */
+export const UPSTREAM_TTFB_SQL_COND = `upstream_ttfb_ms IS NOT NULL AND upstream_ttfb_ms > 0`;
+
+/** SQL condition for end-to-end latency percentiles. */
+export const TOTAL_MS_SQL_COND = `total_ms IS NOT NULL AND total_ms > 0`;

--- a/packages/core/src/database/types.ts
+++ b/packages/core/src/database/types.ts
@@ -41,10 +41,26 @@ export interface RequestLog {
   outputTokens?: number;
   cacheTokens?: number;
   ttfb?: number;
+  /** Queue wait time (enqueue → worker start), ms. */
+  queueWaitMs?: number;
+  /** Upstream TTFB (request sent → first byte), ms. */
+  upstreamTtfbMs?: number;
+  /** Post-header generation time (first byte → end), ms. */
+  genMs?: number;
+  /** End-to-end time (client receive → end), ms. */
+  totalMs?: number;
   /** Masked JSON string of upstream-bound request headers (sensitive values masked). */
   requestHeaders?: string;
   /** Masked JSON string of upstream response headers (sensitive values masked). */
   responseHeaders?: string;
+}
+
+/** Per-request phase timings (milliseconds). */
+export interface LogResponseTiming {
+  queueWaitMs?: number;
+  upstreamTtfbMs?: number;
+  genMs?: number;
+  totalMs?: number;
 }
 
 /**
@@ -108,6 +124,8 @@ export interface DatabaseStats {
   avgTtfb: number;
   outputTps: number;
   outputTpsSampleCount: number;
+  /** Average queue wait across rows with queue_wait_ms recorded. */
+  avgQueueWaitMs: number;
   p50Duration: number;
   p90Duration: number;
   providerBreakdown: ProviderStatRow[];
@@ -191,7 +209,8 @@ export interface DatabaseDriver {
     outputTokens?: number,
     cacheTokens?: number,
     ttfb?: number,
-    responseHeadersMasked?: string
+    responseHeadersMasked?: string,
+    timing?: LogResponseTiming
   ): void;
 
   /**

--- a/packages/core/src/database/worker/client.ts
+++ b/packages/core/src/database/worker/client.ts
@@ -14,6 +14,7 @@ import type {
   LogFilter,
   LogQueryResult,
   DatabaseStats,
+  LogResponseTiming,
   RequestStatus,
   DatabaseDriverConfig,
   StatsQuery,
@@ -311,7 +312,8 @@ export class DatabaseWorkerClient implements DatabaseDriver {
     outputTokens?: number,
     cacheTokens?: number,
     ttfb?: number,
-    responseHeadersMasked?: string
+    responseHeadersMasked?: string,
+    timing?: LogResponseTiming
   ): void {
     void this.send("updateLogCompleted", {
       clientId,
@@ -326,6 +328,7 @@ export class DatabaseWorkerClient implements DatabaseDriver {
       cacheTokens,
       ttfb,
       responseHeadersMasked,
+      timing,
     }).catch(err => {
       this.log.error("[DatabaseWorker] updateLogCompleted error:", err);
     });
@@ -431,6 +434,7 @@ export class DatabaseWorkerClient implements DatabaseDriver {
         avgTtfb: 0,
         outputTps: 0,
         outputTpsSampleCount: 0,
+        avgQueueWaitMs: 0,
         p50Duration: 0,
         p90Duration: 0,
         providerBreakdown: [],

--- a/packages/core/src/database/worker/worker.ts
+++ b/packages/core/src/database/worker/worker.ts
@@ -133,6 +133,7 @@ async function handleMessage(message: WorkerMessage): Promise<WorkerResponse> {
           cacheTokens?: number;
           ttfb?: number;
           responseHeadersMasked?: string;
+          timing?: import("../types").LogResponseTiming;
         };
         driver?.updateLogCompleted(
           p.clientId,
@@ -146,7 +147,8 @@ async function handleMessage(message: WorkerMessage): Promise<WorkerResponse> {
           p.outputTokens,
           p.cacheTokens,
           p.ttfb,
-          p.responseHeadersMasked
+          p.responseHeadersMasked,
+          p.timing
         );
         return { id, success: true };
       }

--- a/packages/core/src/queue/concurrency-manager.ts
+++ b/packages/core/src/queue/concurrency-manager.ts
@@ -259,6 +259,8 @@ export class ConcurrencyManager {
     const { task, resolve, reject, queuedAt } = queuedTask;
     const startedAt = Date.now();
     const waitTime = startedAt - queuedAt;
+    task.queuedAt = queuedAt;
+    task.startedAt = startedAt;
 
     // Track the task
     const processingTask: ProcessingTask = {

--- a/packages/core/src/server/proxy/executor.ts
+++ b/packages/core/src/server/proxy/executor.ts
@@ -52,6 +52,7 @@ import {
 import {
   applyPlatformResponseTransforms,
   applyAnthropicSseRowsPlatformTransform,
+  matchAnthropicSseRule,
   parseAnthropicSseRows,
   serializeAnthropicSseRows,
 } from "../../converter/platform-transforms";
@@ -867,6 +868,28 @@ export class ProxyExecutor {
 
     if (shouldBufferGlmAnthropicHostedSearchSse) {
       this.handleAnthropicSseBufferedWebSearchPassthrough(
+        proxyRes,
+        task,
+        ctx,
+        onClientDisconnect,
+        status,
+        responseHeaders,
+        resolve
+      );
+      return;
+    }
+
+    const shouldStreamAnthropicSsePlatformTransform =
+      !needsResponseConversion &&
+      upstreamWire === "anthropic" &&
+      clientSurface === "anthropic" &&
+      status === 200 &&
+      isSSEResponse &&
+      clientRes &&
+      matchAnthropicSseRule(provider.baseUrl)?.anthropicSseStream;
+
+    if (shouldStreamAnthropicSsePlatformTransform) {
+      this.handleAnthropicSseStreamingPlatformTransform(
         proxyRes,
         task,
         ctx,
@@ -2088,6 +2111,119 @@ export class ProxyExecutor {
         responseBodyChunks: ctx.responseChunks,
         streamed: true,
         streamCompleted: true,
+      });
+    });
+  }
+
+  /**
+   * Anthropic same-protocol SSE with per-event platform transforms (e.g. LongCat `message_start` usage).
+   */
+  private handleAnthropicSseStreamingPlatformTransform(
+    proxyRes: http.IncomingMessage,
+    task: RequestTask,
+    ctx: ExecutionContext,
+    onClientDisconnect: () => void,
+    status: number,
+    responseHeaders: Record<string, string | string[]>,
+    resolve: (value: ProxyResult) => void
+  ): void {
+    const { clientId, provider, res: clientRes } = task;
+    if (!clientRes) {
+      resolve({
+        statusCode: 500,
+        headers: {},
+        duration: Date.now() - ctx.startTime,
+        errorMessage: "Missing client response for Anthropic SSE platform transform",
+      });
+      return;
+    }
+
+    log.info(`[A->A SSE stream] Platform Anthropic SSE transform (${provider.id})`);
+    clientRes.writeHead(status, responseHeaders);
+
+    const upstreamLog: Buffer[] = [];
+    const sseBuffer = createAnthropicSseEnvelopeBuffer(envelope => {
+      if (ctx.clientDisconnected) {
+        return;
+      }
+      const rows = applyAnthropicSseRowsPlatformTransform([{ data: envelope }], provider.baseUrl);
+      const outgoing = serializeAnthropicSseRows(rows);
+      if (outgoing.length > 0) {
+        this.writeClientStreamForLog(clientRes, outgoing, ctx);
+      }
+    });
+
+    proxyRes.on("data", (chunk: Buffer) => {
+      ctx.streamChunkCount++;
+      ctx.streamTotalBytes += chunk.length;
+
+      if (!ctx.upstreamTerminalSeen && chunkContainsTerminalMarker(chunk)) {
+        ctx.upstreamTerminalSeen = true;
+      }
+
+      if (!ctx.firstChunkLogged) {
+        ctx.firstChunkLogged = true;
+        const firstChunkDelay = Date.now() - ctx.firstByteTime;
+        log.info(
+          `[Perf:${clientId}] FirstChunk: ${firstChunkDelay}ms after headers, ${chunk.length} bytes`
+        );
+      }
+
+      this.recordUpstreamChunkForLog(chunk, upstreamLog, ctx);
+      sseBuffer.push(chunk);
+    });
+
+    proxyRes.on("error", (err: Error) => {
+      log.error(`[${clientId}] Anthropic SSE platform transform upstream error: ${err.message}`);
+      if (!clientRes.writableEnded) {
+        try {
+          clientRes.end();
+        } catch {
+          // Ignore errors when ending already-closed stream
+        }
+      }
+    });
+
+    clientRes.on("error", (err: Error) => {
+      log.error(
+        `[${clientId}] Client connection error during Anthropic SSE platform transform: ${err.message}`
+      );
+      proxyRes.destroy();
+    });
+
+    proxyRes.on("end", () => {
+      ctx.upstreamEndedNaturally = true;
+      sseBuffer.flush();
+
+      if (!ctx.clientDisconnected) {
+        clientRes.end();
+      }
+
+      clientRes.off("close", onClientDisconnect);
+      const totalDuration = Date.now() - ctx.startTime;
+      const aborted = ctx.clientDisconnected && !ctx.upstreamEndedNaturally;
+
+      task.streamCompleted = !aborted;
+      this.responseLogger.logResponse(
+        clientId,
+        totalDuration,
+        aborted ? 499 : status,
+        ctx.responseChunks,
+        aborted ? "Client disconnected" : undefined,
+        this.upstreamLogBody(upstreamLog),
+        ttfbForStreamLog(ctx, true),
+        undefined,
+        ctx.responseHeadersMasked,
+        computeTiming(ctx, task)
+      );
+      resolve({
+        statusCode: aborted ? 499 : status,
+        headers: responseHeaders,
+        duration: totalDuration,
+        responseBodyChunks: ctx.responseChunks,
+        streamed: true,
+        streamCompleted: task.streamCompleted,
+        errorMessage: aborted ? "Client disconnected" : undefined,
       });
     });
   }

--- a/packages/core/src/server/proxy/executor.ts
+++ b/packages/core/src/server/proxy/executor.ts
@@ -58,6 +58,7 @@ import {
 import type { ApiSurface } from "../../types";
 import type { RequestTask, ProxyResult } from "../../types";
 import type { ResponseLogger } from "../responseLogger";
+import type { LogResponseTiming } from "../../database/types";
 import type { ModelCatalog } from "../smartRouting/modelCatalog";
 import {
   synthesizeSmartRoutingModelsListBody,
@@ -161,6 +162,41 @@ function ttfbForStreamLog(ctx: ExecutionContext, isStream: boolean): number | un
     return undefined;
   }
   return ctx.firstByteTime - ctx.startTime;
+}
+
+/** Phase timings for DB persistence (queue wait, upstream TTFB, generation, total). */
+function computeTiming(
+  ctx: ExecutionContext,
+  task: RequestTask,
+  endTime: number = Date.now()
+): LogResponseTiming {
+  const queueWaitMs =
+    task.queuedAt !== undefined && task.startedAt !== undefined
+      ? task.startedAt - task.queuedAt
+      : 0;
+
+  let upstreamTtfbMs: number | undefined;
+  if (ctx.requestSentTime > 0 && ctx.firstByteTime > 0) {
+    const ttfb = ctx.firstByteTime - ctx.requestSentTime;
+    if (ttfb > 0) {
+      upstreamTtfbMs = ttfb;
+    }
+  }
+
+  let genMs: number | undefined;
+  if (ctx.firstByteTime > 0) {
+    const gen = endTime - ctx.firstByteTime;
+    if (gen >= 0) {
+      genMs = gen;
+    }
+  }
+
+  const totalMs =
+    task.requestReceiveStart !== undefined
+      ? endTime - task.requestReceiveStart
+      : endTime - ctx.startTime;
+
+  return { queueWaitMs, upstreamTtfbMs, genMs, totalMs };
 }
 
 /** Cheap regex check for SSE terminal events across the supported protocols. */
@@ -939,7 +975,8 @@ export class ProxyExecutor {
         this.upstreamLogBody(upstreamLog),
         ttfbForStreamLog(ctx, true),
         undefined,
-        ctx.responseHeadersMasked
+        ctx.responseHeadersMasked,
+        computeTiming(ctx, task)
       );
       resolve({
         statusCode: aborted ? 499 : status,
@@ -1057,7 +1094,8 @@ export class ProxyExecutor {
         this.upstreamLogBody(upstreamLog),
         ttfbForStreamLog(ctx, true),
         undefined,
-        ctx.responseHeadersMasked
+        ctx.responseHeadersMasked,
+        computeTiming(ctx, task)
       );
 
       resolve({
@@ -1180,7 +1218,8 @@ export class ProxyExecutor {
         upstreamBody,
         ttfbForStreamLog(ctx, false),
         undefined,
-        ctx.responseHeadersMasked
+        ctx.responseHeadersMasked,
+        computeTiming(ctx, task)
       );
 
       resolve({
@@ -1259,7 +1298,8 @@ export class ProxyExecutor {
           ctx.originalResponseBody,
           ttfbForStreamLog(ctx, false),
           undefined,
-          ctx.responseHeadersMasked
+          ctx.responseHeadersMasked,
+          computeTiming(ctx, task)
         );
 
         resolve({
@@ -1294,7 +1334,8 @@ export class ProxyExecutor {
           ctx.originalResponseBody,
           ttfbForStreamLog(ctx, false),
           undefined,
-          ctx.responseHeadersMasked
+          ctx.responseHeadersMasked,
+          computeTiming(ctx, task)
         );
 
         resolve({
@@ -1362,7 +1403,8 @@ export class ProxyExecutor {
           ctx.originalResponseBody,
           ttfbForStreamLog(ctx, false),
           undefined,
-          ctx.responseHeadersMasked
+          ctx.responseHeadersMasked,
+          computeTiming(ctx, task)
         );
 
         resolve({
@@ -1397,7 +1439,8 @@ export class ProxyExecutor {
           ctx.originalResponseBody,
           ttfbForStreamLog(ctx, false),
           undefined,
-          ctx.responseHeadersMasked
+          ctx.responseHeadersMasked,
+          computeTiming(ctx, task)
         );
 
         resolve({
@@ -1460,7 +1503,8 @@ export class ProxyExecutor {
             ctx.originalResponseBody,
             ttfbForStreamLog(ctx, false),
             undefined,
-            ctx.responseHeadersMasked
+            ctx.responseHeadersMasked,
+            computeTiming(ctx, task)
           );
           resolve({
             statusCode: status,
@@ -1482,7 +1526,8 @@ export class ProxyExecutor {
             ctx.originalResponseBody,
             ttfbForStreamLog(ctx, false),
             undefined,
-            ctx.responseHeadersMasked
+            ctx.responseHeadersMasked,
+            computeTiming(ctx, task)
           );
           resolve({
             statusCode: status,
@@ -1513,7 +1558,8 @@ export class ProxyExecutor {
           ctx.originalResponseBody,
           ttfbForStreamLog(ctx, false),
           undefined,
-          ctx.responseHeadersMasked
+          ctx.responseHeadersMasked,
+          computeTiming(ctx, task)
         );
         resolve({
           statusCode: 502,
@@ -1592,7 +1638,8 @@ export class ProxyExecutor {
             ctx.originalResponseBody,
             ttfbForStreamLog(ctx, false),
             undefined,
-            ctx.responseHeadersMasked
+            ctx.responseHeadersMasked,
+            computeTiming(ctx, task)
           );
           resolve({
             statusCode: status,
@@ -1614,7 +1661,8 @@ export class ProxyExecutor {
             ctx.originalResponseBody,
             ttfbForStreamLog(ctx, false),
             undefined,
-            ctx.responseHeadersMasked
+            ctx.responseHeadersMasked,
+            computeTiming(ctx, task)
           );
           resolve({
             statusCode: status,
@@ -1641,7 +1689,8 @@ export class ProxyExecutor {
           ctx.originalResponseBody,
           ttfbForStreamLog(ctx, false),
           undefined,
-          ctx.responseHeadersMasked
+          ctx.responseHeadersMasked,
+          computeTiming(ctx, task)
         );
         resolve({
           statusCode: 502,
@@ -1753,7 +1802,8 @@ export class ProxyExecutor {
         this.upstreamLogBody(upstreamLog),
         ttfbForStreamLog(ctx, true),
         undefined,
-        ctx.responseHeadersMasked
+        ctx.responseHeadersMasked,
+        computeTiming(ctx, task)
       );
 
       resolve({
@@ -1832,7 +1882,8 @@ export class ProxyExecutor {
             ctx.originalResponseBody,
             ttfbForStreamLog(ctx, false),
             undefined,
-            ctx.responseHeadersMasked
+            ctx.responseHeadersMasked,
+            computeTiming(ctx, task)
           );
           resolve({
             statusCode: status,
@@ -1854,7 +1905,8 @@ export class ProxyExecutor {
             ctx.originalResponseBody,
             ttfbForStreamLog(ctx, false),
             undefined,
-            ctx.responseHeadersMasked
+            ctx.responseHeadersMasked,
+            computeTiming(ctx, task)
           );
           resolve({
             statusCode: status,
@@ -1881,7 +1933,8 @@ export class ProxyExecutor {
           ctx.originalResponseBody,
           ttfbForStreamLog(ctx, false),
           undefined,
-          ctx.responseHeadersMasked
+          ctx.responseHeadersMasked,
+          computeTiming(ctx, task)
         );
         resolve({
           statusCode: 502,
@@ -1969,7 +2022,8 @@ export class ProxyExecutor {
           undefined,
           ttfbForStreamLog(ctx, false),
           undefined,
-          ctx.responseHeadersMasked
+          ctx.responseHeadersMasked,
+          computeTiming(ctx, task)
         );
         resolve({
           statusCode: 499,
@@ -2024,7 +2078,8 @@ export class ProxyExecutor {
         undefined,
         ttfbForStreamLog(ctx, false),
         undefined,
-        ctx.responseHeadersMasked
+        ctx.responseHeadersMasked,
+        computeTiming(ctx, task)
       );
       resolve({
         statusCode: status,
@@ -2142,7 +2197,8 @@ export class ProxyExecutor {
         undefined,
         ttfbForStreamLog(ctx, true),
         undefined,
-        ctx.responseHeadersMasked
+        ctx.responseHeadersMasked,
+        computeTiming(ctx, task)
       );
       if (!aborted) {
         task.streamCompleted = true;
@@ -2346,7 +2402,8 @@ export class ProxyExecutor {
         undefined,
         ttfbForStreamLog(ctx, false),
         undefined,
-        ctx.responseHeadersMasked
+        ctx.responseHeadersMasked,
+        computeTiming(ctx, task)
       );
       resolve({
         statusCode: outStatus,
@@ -2401,7 +2458,8 @@ export class ProxyExecutor {
             undefined,
             ttfbForStreamLog(ctx, true),
             undefined,
-            ctx.responseHeadersMasked
+            ctx.responseHeadersMasked,
+            computeTiming(ctx, task)
           );
           resolve({
             statusCode: 200,
@@ -2424,7 +2482,8 @@ export class ProxyExecutor {
           undefined,
           ttfbForStreamLog(ctx, false),
           undefined,
-          ctx.responseHeadersMasked
+          ctx.responseHeadersMasked,
+          computeTiming(ctx, task)
         );
         resolve({
           statusCode: 499,
@@ -2466,7 +2525,10 @@ export class ProxyExecutor {
         ctx.responseChunks,
         err.message,
         undefined,
-        undefined
+        undefined,
+        undefined,
+        undefined,
+        computeTiming(ctx, task)
       );
       reject(new Error(`Proxy error: ${err.message}`));
     });
@@ -2489,7 +2551,10 @@ export class ProxyExecutor {
         ctx.responseChunks,
         "Timeout",
         undefined,
-        undefined
+        undefined,
+        undefined,
+        undefined,
+        computeTiming(ctx, task)
       );
       reject(new Error("Proxy timeout"));
     });

--- a/packages/core/src/server/request/taskExecutor.ts
+++ b/packages/core/src/server/request/taskExecutor.ts
@@ -38,6 +38,7 @@ export class TaskExecutor {
   ): void {
     // Build the task
     const task = this.buildTask(routing, bodyResult, clientId, responseWriter.response);
+    task.requestReceiveStart = requestReceiveStart;
 
     // Check if queue is configured for this path
     const queueInfo = this.queueManager.getQueueForPath(routing.path);

--- a/packages/core/src/server/responseLogger.ts
+++ b/packages/core/src/server/responseLogger.ts
@@ -8,6 +8,7 @@
 import * as zlib from "zlib";
 import { ScopedLogger } from "../utils/logger";
 import type { LogDatabase } from "../database";
+import type { LogResponseTiming } from "../database/types";
 import { isTokenUsageRequestPath } from "../converter/paths";
 
 export interface LogResponseTokenOverrides {
@@ -16,31 +17,47 @@ export interface LogResponseTokenOverrides {
   cacheTokens?: number;
 }
 
+interface UsageRecord {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_input_tokens?: number;
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  effectiveCachedTokens?: number;
+  prompt_tokens_details?: { cached_tokens?: number };
+  input_tokens_details?: { cached_tokens?: number };
+  completion_tokens_details?: { reasoning_tokens?: number };
+}
+
 interface UsageFields {
-  usage?: {
-    input_tokens?: number;
-    output_tokens?: number;
-    cache_read_input_tokens?: number;
-    prompt_tokens?: number;
-    completion_tokens?: number;
-    prompt_tokens_details?: { cached_tokens?: number };
-  };
+  usage?: UsageRecord;
   message?: {
-    usage?: {
-      input_tokens?: number;
-      output_tokens?: number;
-      cache_read_input_tokens?: number;
-      prompt_tokens?: number;
-      completion_tokens?: number;
-      prompt_tokens_details?: { cached_tokens?: number };
-    };
+    usage?: UsageRecord;
   };
+}
+
+function firstNonZero(...values: Array<number | undefined>): number | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && value > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function firstDefined(...values: Array<number | undefined>): number | undefined {
+  for (const value of values) {
+    if (typeof value === "number") {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 /**
  * Extract token usage from a response body (handles both JSON and SSE formats).
  */
-function extractTokenUsage(body: string | undefined): LogResponseTokenOverrides {
+export function extractTokenUsage(body: string | undefined): LogResponseTokenOverrides {
   if (!body) {
     return {};
   }
@@ -80,7 +97,8 @@ function extractTokenUsage(body: string | undefined): LogResponseTokenOverrides 
 }
 
 /**
- * Extract usage from a parsed JSON object (Anthropic or OpenAI format).
+ * Extract usage from a parsed JSON object (Anthropic, OpenAI Chat, or Responses format).
+ * Stored input_tokens always means total prompt tokens; cache_tokens is the cached subset.
  */
 function extractUsageFromObj(obj: UsageFields): LogResponseTokenOverrides {
   const usage = obj.usage || obj.message?.usage;
@@ -88,25 +106,54 @@ function extractUsageFromObj(obj: UsageFields): LogResponseTokenOverrides {
     return {};
   }
 
-  // Anthropic format
-  if (typeof usage.input_tokens === "number") {
-    return {
-      inputTokens: usage.input_tokens,
-      outputTokens: usage.output_tokens,
-      cacheTokens: usage.cache_read_input_tokens,
-    };
+  const cacheTokens =
+    firstNonZero(
+      usage.prompt_tokens_details?.cached_tokens,
+      usage.input_tokens_details?.cached_tokens,
+      usage.cache_read_input_tokens,
+      usage.effectiveCachedTokens
+    ) ??
+    firstDefined(
+      usage.prompt_tokens_details?.cached_tokens,
+      usage.input_tokens_details?.cached_tokens,
+      usage.cache_read_input_tokens,
+      usage.effectiveCachedTokens
+    );
+
+  const inputTokens = normalizeTotalInputTokens(usage);
+  const outputTokens =
+    firstNonZero(usage.completion_tokens, usage.output_tokens) ??
+    firstDefined(usage.completion_tokens, usage.output_tokens);
+
+  if (inputTokens === undefined && outputTokens === undefined && cacheTokens === undefined) {
+    return {};
   }
 
-  // OpenAI format
-  if (typeof usage.prompt_tokens === "number") {
-    return {
-      inputTokens: usage.prompt_tokens,
-      outputTokens: usage.completion_tokens,
-      cacheTokens: usage.prompt_tokens_details?.cached_tokens,
-    };
+  return {
+    inputTokens,
+    outputTokens,
+    cacheTokens,
+  };
+}
+
+function normalizeTotalInputTokens(usage: UsageRecord): number | undefined {
+  const promptTotal = firstNonZero(usage.prompt_tokens) ?? firstDefined(usage.prompt_tokens);
+  if (promptTotal !== undefined) {
+    return promptTotal;
   }
 
-  return {};
+  const inputRaw = firstNonZero(usage.input_tokens) ?? firstDefined(usage.input_tokens);
+  if (inputRaw === undefined) {
+    return undefined;
+  }
+
+  // Anthropic: input_tokens excludes cache; total prompt = input + cache_read.
+  if (typeof usage.cache_read_input_tokens === "number") {
+    return inputRaw + usage.cache_read_input_tokens;
+  }
+
+  // Responses and others: input_tokens is already total prompt.
+  return inputRaw;
 }
 
 /**
@@ -156,7 +203,8 @@ export class ResponseLogger {
     originalResponseBody?: string,
     ttfb?: number,
     tokenOverrides?: LogResponseTokenOverrides,
-    responseHeadersMasked?: string
+    responseHeadersMasked?: string,
+    timing?: LogResponseTiming
   ): void {
     if (!this.database.enabled) {
       this.log.info(`logResponse skipped - database not enabled. clientId=${clientId}`);
@@ -224,7 +272,8 @@ export class ResponseLogger {
       tokens.outputTokens,
       tokens.cacheTokens,
       ttfb,
-      responseHeadersMasked
+      responseHeadersMasked,
+      timing
     );
   }
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -783,6 +783,11 @@ export interface RequestTask {
   priority?: number;
   timeout?: number;
   createdAt: number;
+  /** Client request arrival time (ms epoch); used for total_ms. */
+  requestReceiveStart?: number;
+  /** When the task was enqueued (ms epoch); set by ConcurrencyManager. */
+  queuedAt?: number;
+  /** When queue worker started executing (ms epoch); set by ConcurrencyManager. */
   startedAt?: number;
   /** Client had `stream: true` on POST /v1/responses; response may be synthesized as SSE */
   responsesStreamRequested?: boolean;

--- a/tests/unit/converter/platform-transforms/index.test.ts
+++ b/tests/unit/converter/platform-transforms/index.test.ts
@@ -139,6 +139,13 @@ describe("matchHostedToolRuleForBaseUrl", () => {
     expect(r?.provider).toBe("deepseek");
     expect(r?.requestSanitize).toBe("deepseek-chat-sanitize");
   });
+
+  it("hits LongCat rule for api.longcat.chat", () => {
+    const r = matchHostedToolRuleForBaseUrl("https://api.longcat.chat/anthropic/v1/messages");
+    expect(r?.provider).toBe("longcat");
+    expect(r?.anthropicSse).toBe("longcat-message-start-usage");
+    expect(r?.anthropicSseStream).toBe(true);
+  });
 });
 
 describe("normalizeToolForProvider", () => {

--- a/tests/unit/converter/platform-transforms/longcat-anthropic-sse.test.ts
+++ b/tests/unit/converter/platform-transforms/longcat-anthropic-sse.test.ts
@@ -1,0 +1,103 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { describe, expect, it } from "vitest";
+import type { AnthropicSseEventRow } from "@/converter/platform-transforms";
+import {
+  applyAnthropicSseRowsPlatformTransform,
+  transformLongcatAnthropicSseRows,
+} from "@/converter/platform-transforms";
+
+describe("transformLongcatAnthropicSseRows", () => {
+  it("fills missing numeric usage on message_start", () => {
+    const rows: AnthropicSseEventRow[] = [
+      {
+        data: {
+          type: "message_start",
+          message: {
+            id: "msg_1",
+            type: "message",
+            role: "assistant",
+            model: "LongCat-2.0",
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: {},
+          },
+        },
+      },
+    ];
+
+    const out = transformLongcatAnthropicSseRows(rows);
+    expect(out[0].data.message).toMatchObject({
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    });
+  });
+
+  it("preserves existing usage numbers on message_start", () => {
+    const rows: AnthropicSseEventRow[] = [
+      {
+        data: {
+          type: "message_start",
+          message: {
+            usage: {
+              input_tokens: 12,
+              output_tokens: 3,
+              cache_read_input_tokens: 99,
+            },
+          },
+        },
+      },
+    ];
+
+    const out = transformLongcatAnthropicSseRows(rows);
+    expect(out[0].data.message).toMatchObject({
+      usage: {
+        input_tokens: 12,
+        output_tokens: 3,
+        cache_read_input_tokens: 99,
+        cache_creation_input_tokens: 0,
+      },
+    });
+  });
+
+  it("leaves message_delta usage unchanged", () => {
+    const rows: AnthropicSseEventRow[] = [
+      {
+        data: {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 35, output_tokens: 73, cache_read_input_tokens: 7552 },
+        },
+      },
+    ];
+
+    expect(transformLongcatAnthropicSseRows(rows)).toEqual(rows);
+  });
+});
+
+describe("applyAnthropicSseRowsPlatformTransform (longcat)", () => {
+  it("applies LongCat rule for api.longcat.chat hostname", () => {
+    const rows: AnthropicSseEventRow[] = [
+      {
+        data: {
+          type: "message_start",
+          message: { usage: {} },
+        },
+      },
+    ];
+    const transformed = applyAnthropicSseRowsPlatformTransform(
+      rows,
+      "https://api.longcat.chat/anthropic/v1/messages"
+    );
+    expect((transformed[0].data.message as Record<string, unknown>).usage).toEqual({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    });
+  });
+});

--- a/tests/unit/database/log-db-migration.test.ts
+++ b/tests/unit/database/log-db-migration.test.ts
@@ -130,7 +130,7 @@ describe.skipIf(!nativeForNode)("log-db-migration", () => {
     db.close();
   });
 
-  it("split_metrics migration creates metrics table and drops v2 token columns", () => {
+  it("split_metrics migration creates metrics table; v4 restores log token columns", () => {
     createLegacyWithRows();
     const db = openDb();
     runSqliteStartupMigration(
@@ -161,12 +161,29 @@ describe.skipIf(!nativeForNode)("log-db-migration", () => {
     const tokenCol = db
       .prepare(`SELECT COUNT(*) as c FROM pragma_table_info('${TABLE}') WHERE name='input_tokens'`)
       .get() as { c: number };
-    expect(tokenCol.c).toBe(0);
+    expect(tokenCol.c).toBe(1);
 
     const metricsCount = db.prepare(`SELECT COUNT(*) as c FROM ${METRICS_TABLE}`).get() as {
       c: number;
     };
     expect(metricsCount.c).toBe(1);
+
+    const migrationVersion = db
+      .prepare(`SELECT MAX(version) as v FROM schema_migrations`)
+      .get() as { v: number };
+    expect(migrationVersion.v).toBeGreaterThanOrEqual(5);
+
+    const timingCols = ["queue_wait_ms", "upstream_ttfb_ms", "gen_ms", "total_ms"];
+    for (const col of timingCols) {
+      const onLogs = db
+        .prepare(`SELECT COUNT(*) as c FROM pragma_table_info('${TABLE}') WHERE name=?`)
+        .get(col) as { c: number };
+      expect(onLogs.c).toBe(1);
+      const onMetrics = db
+        .prepare(`SELECT COUNT(*) as c FROM pragma_table_info('${METRICS_TABLE}') WHERE name=?`)
+        .get(col) as { c: number };
+      expect(onMetrics.c).toBe(1);
+    }
 
     db.close();
   });

--- a/tests/unit/database/metrics-split.test.ts
+++ b/tests/unit/database/metrics-split.test.ts
@@ -121,6 +121,99 @@ describe.skipIf(!nativeForNode)("metrics split (native driver)", () => {
     await driver.close();
   });
 
+  it("phase timing is stored on logs and used for dashboard stats", async () => {
+    const driver = new SqliteNativeDriver({ type: "sqlite", path: dbPath });
+    await driver.initialize({ logsEnabled: true });
+
+    const clientId = "c-timing";
+    driver.insertLogPending({
+      timestamp: Date.now(),
+      providerId: "p1",
+      providerName: "P",
+      method: "POST",
+      path: "/chat/completions",
+      duration: 0,
+      success: false,
+      clientId,
+      model: "gpt-4",
+    });
+
+    driver.updateLogCompleted(
+      clientId,
+      200,
+      "{}",
+      120,
+      true,
+      undefined,
+      undefined,
+      100,
+      200,
+      0,
+      50,
+      undefined,
+      {
+        queueWaitMs: 80,
+        upstreamTtfbMs: 400,
+        genMs: 2000,
+        totalMs: 2600,
+      }
+    );
+
+    const { logs } = await driver.queryLogs({ limit: 10 });
+    const row = logs.find(l => l.clientId === clientId);
+    expect(row?.queueWaitMs).toBe(80);
+    expect(row?.upstreamTtfbMs).toBe(400);
+    expect(row?.genMs).toBe(2000);
+    expect(row?.totalMs).toBe(2600);
+
+    const stats = await driver.getStats();
+    expect(stats.avgTtfb).toBe(400);
+    expect(stats.avgQueueWaitMs).toBe(80);
+    expect(stats.p50Duration).toBe(2600);
+    expect(stats.outputTps).toBe(100);
+
+    await driver.clearAllMetrics();
+    const afterClear = await driver.queryLogs({ limit: 10 });
+    const rowAfter = afterClear.logs.find(l => l.clientId === clientId);
+    expect(rowAfter?.upstreamTtfbMs).toBe(400);
+    expect(rowAfter?.genMs).toBe(2000);
+
+    await driver.close();
+  });
+
+  it("clearAllMetrics clears dashboard stats but keeps redundant tokens on log rows", async () => {
+    const driver = new SqliteNativeDriver({ type: "sqlite", path: dbPath });
+    await driver.initialize({ logsEnabled: true });
+
+    const clientId = "c-redundant-tokens";
+    driver.insertLogPending({
+      timestamp: Date.now(),
+      providerId: "p1",
+      providerName: "P",
+      method: "POST",
+      path: "/chat/completions",
+      duration: 0,
+      success: false,
+      clientId,
+      model: "gpt-4",
+    });
+
+    driver.updateLogCompleted(clientId, 200, "{}", 120, true, undefined, undefined, 42, 24, 8, 50);
+
+    await driver.clearAllMetrics();
+
+    const stats = await driver.getStats();
+    expect(stats.totalInputTokens).toBe(0);
+
+    const { logs } = await driver.queryLogs({ limit: 10 });
+    const row = logs.find(l => l.clientId === clientId);
+    expect(row?.inputTokens).toBe(42);
+    expect(row?.outputTokens).toBe(24);
+    expect(row?.cacheTokens).toBe(8);
+
+    await driver.close();
+  });
+
   it("logsEnabled false writes metrics only (no request_logs_v2 rows)", async () => {
     const driver = new SqliteNativeDriver({ type: "sqlite", path: dbPath });
     await driver.initialize({ logsEnabled: false });

--- a/tests/unit/database/sqlite-cli.test.ts
+++ b/tests/unit/database/sqlite-cli.test.ts
@@ -135,6 +135,7 @@ describe("SqliteCliDriver", () => {
         avgTtfb: 0,
         outputTps: 0,
         outputTpsSampleCount: 0,
+        avgQueueWaitMs: 0,
         p50Duration: 0,
         p90Duration: 0,
         providerBreakdown: [],

--- a/tests/unit/server/responseLogger.tokenUsage.test.ts
+++ b/tests/unit/server/responseLogger.tokenUsage.test.ts
@@ -1,0 +1,155 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+// API response fields use snake_case (prompt_tokens, input_tokens, etc.)
+
+import { describe, it, expect } from "vitest";
+import { extractTokenUsage } from "../../../packages/core/src/server/responseLogger";
+
+describe("server: responseLogger token usage extraction", () => {
+  it("extracts longcat mixed usage fields with zero placeholders", () => {
+    const body = JSON.stringify({
+      usage: {
+        effectiveCachedTokens: 56320,
+        completion_tokens: 127,
+        prompt_tokens: 56836,
+        total_tokens: 56963,
+        completion_tokens_details: {
+          reasoning_tokens: 32,
+        },
+        prompt_tokens_details: {
+          cached_tokens: 56320,
+          audio_tokens: 0,
+          image_tokens: 0,
+          video_tokens: 0,
+          text_tokens: 0,
+        },
+        cache_write_tokens: 0,
+        cache_read_tokens: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        output_tokens_details: null,
+        cached_tokens: 0,
+      },
+    });
+
+    expect(extractTokenUsage(body)).toEqual({
+      inputTokens: 56836,
+      outputTokens: 127,
+      cacheTokens: 56320,
+    });
+  });
+
+  it("extracts OpenAI Responses usage including cached tokens", () => {
+    const body = JSON.stringify({
+      usage: {
+        input_tokens: 1200,
+        output_tokens: 340,
+        total_tokens: 1540,
+        input_tokens_details: {
+          cached_tokens: 800,
+        },
+        output_tokens_details: {
+          reasoning_tokens: 120,
+        },
+      },
+    });
+
+    expect(extractTokenUsage(body)).toEqual({
+      inputTokens: 1200,
+      outputTokens: 340,
+      cacheTokens: 800,
+    });
+  });
+
+  it("extracts OpenAI Chat usage", () => {
+    const body = JSON.stringify({
+      usage: {
+        prompt_tokens: 100,
+        completion_tokens: 50,
+        total_tokens: 150,
+        prompt_tokens_details: {
+          cached_tokens: 25,
+        },
+      },
+    });
+
+    expect(extractTokenUsage(body)).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheTokens: 25,
+    });
+  });
+
+  it("extracts Anthropic usage from message envelope", () => {
+    const body = JSON.stringify({
+      message: {
+        usage: {
+          input_tokens: 90,
+          output_tokens: 40,
+          cache_read_input_tokens: 30,
+        },
+      },
+    });
+
+    expect(extractTokenUsage(body)).toEqual({
+      inputTokens: 120,
+      outputTokens: 40,
+      cacheTokens: 30,
+    });
+  });
+
+  it("extracts Anthropic top-level usage as total prompt input", () => {
+    const body = JSON.stringify({
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 400,
+      },
+    });
+
+    expect(extractTokenUsage(body)).toEqual({
+      inputTokens: 500,
+      outputTokens: 50,
+      cacheTokens: 400,
+    });
+  });
+
+  it("accumulates usage from SSE chunks", () => {
+    const body = [
+      'data: {"choices":[{"delta":{"content":"hi"}}]}',
+      'data: {"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}',
+      'data: {"usage":{"prompt_tokens":200,"completion_tokens":80,"total_tokens":280,"prompt_tokens_details":{"cached_tokens":60}}}',
+      "data: [DONE]",
+    ].join("\n");
+
+    expect(extractTokenUsage(body)).toEqual({
+      inputTokens: 200,
+      outputTokens: 80,
+      cacheTokens: 60,
+    });
+  });
+
+  it("returns zeros when all usage fields are explicitly zero", () => {
+    const body = JSON.stringify({
+      usage: {
+        prompt_tokens: 0,
+        completion_tokens: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        prompt_tokens_details: {
+          cached_tokens: 0,
+        },
+        input_tokens_details: {
+          cached_tokens: 0,
+        },
+        cache_read_input_tokens: 0,
+        effectiveCachedTokens: 0,
+      },
+    });
+
+    expect(extractTokenUsage(body)).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheTokens: 0,
+    });
+  });
+});

--- a/tests/unit/web/streamPerf.test.ts
+++ b/tests/unit/web/streamPerf.test.ts
@@ -1,9 +1,23 @@
 import { describe, expect, it } from "vitest";
 import {
+  effectiveGenMs,
+  effectiveTtfb,
   hasStreamPerfMetrics,
   hasStreamTtfb,
   outputTps,
 } from "../../../web/src/features/logs/streamPerf";
+
+describe("effectiveTtfb", () => {
+  it("prefers upstreamTtfbMs over legacy ttfb", () => {
+    expect(effectiveTtfb({ upstreamTtfbMs: 300, ttfb: 500, duration: 1000 })).toBe(300);
+  });
+});
+
+describe("effectiveGenMs", () => {
+  it("prefers genMs over duration - ttfb", () => {
+    expect(effectiveGenMs({ genMs: 1500, ttfb: 200, duration: 600 })).toBe(1500);
+  });
+});
 
 describe("hasStreamTtfb", () => {
   it("returns false when ttfb is missing", () => {
@@ -43,5 +57,15 @@ describe("outputTps", () => {
   it("uses actual gen time when above 1s", () => {
     const tps = outputTps({ ttfb: 200, duration: 3200, outputTokens: 1000 });
     expect(tps).toBeCloseTo(1000 / 3, 5);
+  });
+
+  it("uses phase timing fields when present", () => {
+    const tps = outputTps({
+      upstreamTtfbMs: 400,
+      genMs: 2000,
+      duration: 2400,
+      outputTokens: 200,
+    });
+    expect(tps).toBe(100);
   });
 });

--- a/web/src/features/dashboard/Dashboard.tsx
+++ b/web/src/features/dashboard/Dashboard.tsx
@@ -319,6 +319,17 @@ export default function Dashboard() {
                       </span>
                     </div>
                     <div className="flex items-center justify-between">
+                      <span
+                        className="text-xs text-muted-foreground"
+                        title={t("dashboard.performance.avgQueueWaitTooltip")}
+                      >
+                        {t("dashboard.performance.avgQueueWait")}
+                      </span>
+                      <span className="text-xs font-medium">
+                        {stats?.avgQueueWaitMs ? formatDuration(stats.avgQueueWaitMs) : "-"}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
                       <span className="text-xs text-muted-foreground">
                         {t("dashboard.performance.successRate")}
                       </span>

--- a/web/src/features/dashboard/Dashboard.tsx
+++ b/web/src/features/dashboard/Dashboard.tsx
@@ -25,6 +25,10 @@ function formatTokenCount(n: number): string {
   return n.toLocaleString();
 }
 
+function nonCacheInputTokens(input: number, cache: number): number {
+  return Math.max(0, input - cache);
+}
+
 function formatDuration(ms: number): string {
   if (ms >= 60_000) return `${(ms / 60_000).toFixed(1)}m`;
   if (ms >= 1_000) return `${(ms / 1_000).toFixed(1)}s`;
@@ -427,6 +431,9 @@ export default function Dashboard() {
                       {t("dashboard.tokens.input")}
                     </th>
                     <th className="text-right py-1.5 px-2 text-muted-foreground font-medium">
+                      {t("dashboard.providerBreakdown.nonCacheInput")}
+                    </th>
+                    <th className="text-right py-1.5 px-2 text-muted-foreground font-medium">
                       {t("dashboard.tokens.output")}
                     </th>
                     <th className="text-right py-1.5 pl-2 text-muted-foreground font-medium">
@@ -447,6 +454,11 @@ export default function Dashboard() {
                       <td className="text-right py-1.5 px-2 font-mono">{p.count}</td>
                       <td className="text-right py-1.5 px-2 font-mono text-muted-foreground">
                         {formatTokenCount(p.totalInputTokens)}
+                      </td>
+                      <td className="text-right py-1.5 px-2 font-mono">
+                        {formatTokenCount(
+                          nonCacheInputTokens(p.totalInputTokens, p.totalCacheTokens)
+                        )}
                       </td>
                       <td className="text-right py-1.5 px-2 font-mono">
                         {formatTokenCount(p.totalOutputTokens)}

--- a/web/src/features/logs/Logs.tsx
+++ b/web/src/features/logs/Logs.tsx
@@ -35,7 +35,13 @@ import { api, type LogEntry } from "@/api/client";
 import { isSseLogBody, reconstructMessageFromSseLogBody } from "./reconstructAnthropicSseMessage";
 import { reconstructOpenAIChatFromSseLogBody } from "./reconstructOpenAIChatSseMessage";
 import { reconstructOpenAIResponsesFromSseLogBody } from "./reconstructOpenAIResponsesSseMessage";
-import { hasStreamPerfMetrics, outputTps } from "./streamPerf";
+import {
+  effectiveGenMs,
+  effectiveTtfb,
+  formatMs,
+  hasStreamPerfMetrics,
+  outputTps,
+} from "./streamPerf";
 
 const PAGE_SIZE = 50;
 
@@ -684,12 +690,9 @@ export default function Logs() {
       header: t("logs.table.header.ttfb"),
       headerTitle: t("logs.table.ttfbTooltip"),
       cell: log => {
-        if (!hasStreamPerfMetrics(log)) return <span className="text-[11px]">-</span>;
-        return (
-          <span className="text-[11px]">
-            {log.ttfb! >= 1000 ? `${(log.ttfb! / 1000).toFixed(1)}s` : `${log.ttfb}ms`}
-          </span>
-        );
+        const ttfb = effectiveTtfb(log);
+        if (ttfb == null) return <span className="text-[11px]">-</span>;
+        return <span className="text-[11px]">{formatMs(ttfb)}</span>;
       },
       className: "hidden md:table-cell",
       headerClassName: "hidden md:table-cell",
@@ -702,7 +705,7 @@ export default function Logs() {
       cell: log => {
         const tps = outputTps(log);
         if (tps == null) return <span className="text-[11px]">-</span>;
-        const genTime = log.duration - log.ttfb!;
+        const genTime = effectiveGenMs(log)!;
         return (
           <span
             className="font-mono text-[11px]"
@@ -896,7 +899,9 @@ export default function Logs() {
                     </div>
                     <div className="flex items-center gap-1.5">
                       <span className="text-muted-foreground">{t("logs.detail.duration")}</span>
-                      <span className="font-medium font-mono">{selectedLog.duration}ms</span>
+                      <span className="font-medium font-mono">
+                        {(selectedLog.totalMs ?? selectedLog.duration).toLocaleString()}ms
+                      </span>
                     </div>
                     <div className="flex items-center gap-1.5 min-w-[120px]">
                       <span className="text-muted-foreground">{t("logs.detail.time")}</span>
@@ -966,13 +971,42 @@ export default function Logs() {
                     </div>
                   )}
 
+                  {(selectedLog.queueWaitMs != null ||
+                    selectedLog.upstreamTtfbMs != null ||
+                    selectedLog.genMs != null ||
+                    selectedLog.totalMs != null) && (
+                    <div className="text-xs space-y-1">
+                      <span className="text-muted-foreground">{t("logs.detail.timingPhases")}</span>
+                      <div className="grid grid-cols-2 gap-x-4 gap-y-1 font-mono text-[11px] mt-0.5">
+                        {selectedLog.queueWaitMs != null && (
+                          <span>
+                            {t("logs.detail.queueWait")}: {formatMs(selectedLog.queueWaitMs)}
+                          </span>
+                        )}
+                        {selectedLog.upstreamTtfbMs != null && (
+                          <span>
+                            {t("logs.detail.upstreamTtfb")}: {formatMs(selectedLog.upstreamTtfbMs)}
+                          </span>
+                        )}
+                        {selectedLog.genMs != null && (
+                          <span>
+                            {t("logs.detail.generation")}: {formatMs(selectedLog.genMs)}
+                          </span>
+                        )}
+                        {selectedLog.totalMs != null && (
+                          <span>
+                            {t("logs.detail.totalTime")}: {formatMs(selectedLog.totalMs)}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  )}
+
                   {hasStreamPerfMetrics(selectedLog) && (
                     <div className="text-xs">
-                      <span className="text-muted-foreground">TTFB</span>
+                      <span className="text-muted-foreground">{t("logs.detail.ttfb")}</span>
                       <p className="font-mono text-[11px] mt-0.5">
-                        {selectedLog.ttfb! >= 1000
-                          ? `${(selectedLog.ttfb! / 1000).toFixed(2)}s`
-                          : `${selectedLog.ttfb}ms`}
+                        {formatMs(effectiveTtfb(selectedLog)!)}
                       </p>
                     </div>
                   )}
@@ -980,10 +1014,10 @@ export default function Logs() {
                   {(() => {
                     const tps = outputTps(selectedLog);
                     if (tps == null) return null;
-                    const genTime = selectedLog.duration - selectedLog.ttfb!;
+                    const genTime = effectiveGenMs(selectedLog)!;
                     return (
                       <div className="text-xs">
-                        <span className="text-muted-foreground">Output TPS</span>
+                        <span className="text-muted-foreground">{t("logs.detail.outputTps")}</span>
                         <p className="font-mono text-[11px] mt-0.5">
                           {tps.toFixed(1)} t/s
                           <span className="text-muted-foreground ml-2">

--- a/web/src/features/logs/streamPerf.ts
+++ b/web/src/features/logs/streamPerf.ts
@@ -1,32 +1,67 @@
 /**
  * Matches backend stats aggregation (Dashboard avg TTFB / output TPS).
- * Per-log UI trusts backend `ttfb` (only written for incremental SSE) instead.
+ * Per-log UI prefers phase timing fields when present.
  */
 export const STREAM_GEN_TIME_MIN_MS = 500;
 
+export interface StreamPerfLog {
+  ttfb?: number;
+  upstreamTtfbMs?: number;
+  genMs?: number;
+  duration: number;
+  outputTokens?: number;
+}
+
+/** Effective upstream TTFB: phase field first, legacy ttfb fallback. */
+export function effectiveTtfb(log: StreamPerfLog): number | undefined {
+  if (log.upstreamTtfbMs != null && log.upstreamTtfbMs > 0) {
+    return log.upstreamTtfbMs;
+  }
+  if (log.ttfb != null && log.ttfb > 0) {
+    return log.ttfb;
+  }
+  return undefined;
+}
+
+/** Effective post-header generation time in ms. */
+export function effectiveGenMs(log: StreamPerfLog): number | undefined {
+  if (log.genMs != null && log.genMs > 0) {
+    return log.genMs;
+  }
+  const ttfb = effectiveTtfb(log);
+  if (ttfb != null && log.duration > ttfb) {
+    return log.duration - ttfb;
+  }
+  return undefined;
+}
+
 /** True when the log row has stream TTFB persisted by the proxy. */
-export function hasStreamTtfb(log: { ttfb?: number; duration: number }): boolean {
-  if (log.ttfb == null || log.ttfb <= 0 || !log.duration) {
+export function hasStreamTtfb(log: StreamPerfLog): boolean {
+  const ttfb = effectiveTtfb(log);
+  if (ttfb == null || !log.duration) {
     return false;
   }
-  // Require a post-header generation window (filters legacy rows where duration ≈ ttfb).
-  return log.duration > log.ttfb;
+  const gen = effectiveGenMs(log);
+  return gen != null && gen > 0;
 }
 
 /** @deprecated Alias for log list/detail TTFB column. */
-export function hasStreamPerfMetrics(log: { ttfb?: number; duration: number }): boolean {
+export function hasStreamPerfMetrics(log: StreamPerfLog): boolean {
   return hasStreamTtfb(log);
 }
 
-export function outputTps(log: {
-  ttfb?: number;
-  duration: number;
-  outputTokens?: number;
-}): number | null {
+export function outputTps(log: StreamPerfLog): number | null {
   if (!hasStreamTtfb(log) || log.outputTokens == null) {
     return null;
   }
-  const genTime = log.duration - log.ttfb!;
+  const genTime = effectiveGenMs(log);
+  if (genTime == null || genTime <= 0) {
+    return null;
+  }
   const calcTime = Math.max(genTime, 1000);
   return (log.outputTokens / calcTime) * 1000;
+}
+
+export function formatMs(ms: number): string {
+  return ms >= 1000 ? `${(ms / 1000).toFixed(ms >= 10000 ? 1 : 2)}s` : `${ms}ms`;
 }

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -107,6 +107,7 @@
       "provider": "Provider",
       "requests": "Requests",
       "tokens": "Tokens",
+      "nonCacheInput": "Non-cache Input",
       "cacheHitRate": "Cache Hit Rate"
     },
     "queue": {

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -72,9 +72,11 @@
       "p50Latency": "P50 Latency",
       "p90Latency": "P90 Latency",
       "avgTtfb": "Avg TTFB",
-      "avgTtfbTooltip": "From genuinely streamed SSE requests only",
+      "avgTtfbTooltip": "Upstream request sent → first response byte (rows with phase timing only)",
+      "avgQueueWait": "Avg Queue Wait",
+      "avgQueueWaitTooltip": "Time waiting in queue before upstream execution starts",
       "outputTps": "Output TPS",
-      "outputTpsTooltip": "From genuinely streamed SSE requests only (gen time > 500ms)"
+      "outputTpsTooltip": "Output tokens per second using post-header generation time (gen > 500ms)"
     },
     "tokens": {
       "title": "Token Usage",
@@ -92,7 +94,7 @@
     "resetStats": {
       "action": "Reset stats",
       "title": "Reset dashboard statistics",
-      "description": "Clear all token usage and performance metrics on the Dashboard. Request logs in the Logs tab are not affected.",
+      "description": "Clear all token usage and performance metrics on the Dashboard. Per-request token display in the Logs tab is preserved.",
       "confirm": "Reset statistics",
       "resetting": "Resetting…"
     },
@@ -569,8 +571,8 @@
         "ttfb": "TTFB",
         "tps": "TPS"
       },
-      "ttfbTooltip": "Time to first byte — streamed SSE requests only",
-      "tpsTooltip": "Output tokens per second — streamed SSE requests only",
+      "ttfbTooltip": "Upstream TTFB (request sent → first byte)",
+      "tpsTooltip": "Output tokens per second (post-header generation time)",
       "routeType": {
         "block": "Block",
         "pass": "Pass",
@@ -600,6 +602,13 @@
       "tokenIn": "In",
       "tokenOut": "Out",
       "tokenCache": "Cache",
+      "timingPhases": "Timing breakdown",
+      "queueWait": "Queue wait",
+      "upstreamTtfb": "Upstream TTFB",
+      "generation": "Generation",
+      "totalTime": "Total",
+      "ttfb": "TTFB",
+      "outputTps": "Output TPS",
       "error": "Error",
       "statusOk": "OK",
       "statusErr": "Err",

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -107,6 +107,7 @@
       "provider": "提供商",
       "requests": "请求数",
       "tokens": "Token",
+      "nonCacheInput": "非缓存输入",
       "cacheHitRate": "缓存命中率"
     },
     "queue": {

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -72,9 +72,11 @@
       "p50Latency": "P50 延迟",
       "p90Latency": "P90 延迟",
       "avgTtfb": "平均首字节时间",
-      "avgTtfbTooltip": "仅统计真实 SSE 流式请求",
+      "avgTtfbTooltip": "上游请求发出 → 首字节返回（仅统计有阶段时间的记录）",
+      "avgQueueWait": "平均队列等待",
+      "avgQueueWaitTooltip": "入队后等待开始执行上游请求的时间",
       "outputTps": "输出 TPS",
-      "outputTpsTooltip": "仅统计真实 SSE 流式请求（生成时间 > 500ms）"
+      "outputTpsTooltip": "基于首字节后的生成时间计算（生成时间 > 500ms）"
     },
     "tokens": {
       "title": "Token 用量",
@@ -92,7 +94,7 @@
     "resetStats": {
       "action": "复位统计",
       "title": "复位仪表盘统计",
-      "description": "清空仪表盘上的 Token 用量与性能指标。Logs 页中的请求记录不受影响。",
+      "description": "清空仪表盘上的 Token 用量与性能指标。Logs 页中每条记录的 token 显示会保留。",
       "confirm": "确认复位",
       "resetting": "复位中…"
     },
@@ -568,8 +570,8 @@
         "ttfb": "TTFB",
         "tps": "TPS"
       },
-      "ttfbTooltip": "首字节时间 — 仅流式 SSE 请求",
-      "tpsTooltip": "输出 token 速率 — 仅流式 SSE 请求",
+      "ttfbTooltip": "上游 TTFB（请求发出 → 首字节）",
+      "tpsTooltip": "输出 token 速率（首字节后的生成时间）",
       "routeType": {
         "block": "拦截",
         "pass": "透传",
@@ -599,6 +601,13 @@
       "tokenIn": "输入",
       "tokenOut": "输出",
       "tokenCache": "缓存",
+      "timingPhases": "阶段耗时",
+      "queueWait": "队列等待",
+      "upstreamTtfb": "上游 TTFB",
+      "generation": "生成",
+      "totalTime": "总耗时",
+      "ttfb": "TTFB",
+      "outputTps": "输出 TPS",
       "error": "错误",
       "statusOk": "成功",
       "statusErr": "错误",

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -158,6 +158,10 @@ export interface LogEntry {
   outputTokens?: number;
   cacheTokens?: number;
   ttfb?: number;
+  queueWaitMs?: number;
+  upstreamTtfbMs?: number;
+  genMs?: number;
+  totalMs?: number;
 }
 
 export interface LogsQuery {
@@ -199,6 +203,7 @@ export interface LogStats {
   avgTtfb: number;
   outputTps: number;
   outputTpsSampleCount: number;
+  avgQueueWaitMs: number;
   p50Duration: number;
   p90Duration: number;
   providerBreakdown: ProviderBreakdownRow[];


### PR DESCRIPTION
## Summary
- Record queue wait, upstream TTFB, generation, and total latency on logs/metrics; recalculate Dashboard TTFB, TPS, P50/P90, and queue-wait stats from the new fields (stats only count rows with phase data).
- Fix cross-format token usage extraction (LongCat mixed fields, OpenAI Responses cache) and persist per-log tokens on `request_logs_v2` so Logs token display survives stats reset.
- Dashboard provider breakdown adds a non-cache input column (`input - cache`) for clearer billable prompt visibility.
- Add a streaming platform transform for `api.longcat.chat` that fills numeric `usage` fields on `message_start`, fixing strict Anthropic SSE clients (e.g. ZCode) when LongCat returns `usage: {}`.

## Test plan
- [ ] Run a streamed request through LongCat (`api.longcat.chat`) with ZCode; confirm `message_start` passes schema validation and final usage still arrives on `message_delta`.
- [ ] Verify Dashboard TTFB/TPS/P50 and queue-wait card reflect new phase fields for recent requests.
- [ ] Confirm LongCat and OpenAI Responses requests show correct input/output/cache in Logs and provider breakdown (including non-cache input column).
- [ ] `npm run format && npm run lint` and unit tests pass locally.


Made with [Cursor](https://cursor.com)