### PR TITLE
ci: automate Open VSX publishing for prod VSIX releases

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -43,6 +43,8 @@ on:
         required: false
       APPLE_SIGNING_IDENTITY:
         required: false
+      OPEN_VSX_TOKEN:
+        required: false
 
 permissions:
   contents: write
@@ -548,3 +550,39 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-openvsx:
+    runs-on: ubuntu-latest
+    needs: [configure, build-vscode, release]
+    if: >-
+      ${{ always()
+        && inputs.is_prod
+        && inputs.create_release
+        && needs.configure.result == 'success'
+        && needs.configure.outputs.want_build_vscode == 'true'
+        && needs.build-vscode.result == 'success'
+        && needs.release.result == 'success'
+      }}
+    steps:
+      - name: Download vsix artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ccrelay-vscode-prod-${{ needs.configure.outputs.version }}${{ inputs.suffix }}
+          path: vsix
+
+      - name: Publish to Open VSX
+        env:
+          OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${OVSX_PAT}" ]; then
+            echo "OPEN_VSX_TOKEN not configured — skipping Open VSX publish"
+            exit 0
+          fi
+          shopt -s nullglob
+          files=(vsix/*.vsix)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No .vsix file found in artifact"
+            exit 1
+          fi
+          npx ovsx publish "${files[0]}" -p "$OVSX_PAT"

--- a/.github/workflows/publish-openvsx.yml
+++ b/.github/workflows/publish-openvsx.yml
@@ -1,0 +1,70 @@
+name: Publish Open VSX
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag to publish (e.g. v1.0.0). Leave empty for latest release.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Resolve release tag
+        id: meta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TAG: ${{ inputs.tag_name }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_TAG" ]; then
+            TAG_NAME="$INPUT_TAG"
+          else
+            TAG_NAME=$(gh release view --json tagName -q .tagName)
+          fi
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "Publishing from release tag: $TAG_NAME"
+
+      - name: Download VSIX from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p vsix
+          gh release download "${{ steps.meta.outputs.tag_name }}" --pattern '*.vsix' --dir vsix
+
+      - name: Validate VSIX asset
+        id: vsix
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(vsix/*.vsix)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No .vsix file found in release ${{ steps.meta.outputs.tag_name }}"
+            exit 1
+          fi
+          if [ ${#files[@]} -gt 1 ]; then
+            echo "::error::Expected one .vsix file, found ${#files[@]}: ${files[*]}"
+            exit 1
+          fi
+          echo "file=${files[0]}" >> "$GITHUB_OUTPUT"
+          echo "Publishing: ${files[0]}"
+
+      - name: Publish to Open VSX
+        env:
+          OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${OVSX_PAT}" ]; then
+            echo "::error::OPEN_VSX_TOKEN secret is not configured"
+            exit 1
+          fi
+          npx ovsx publish "${{ steps.vsix.outputs.file }}" -p "$OVSX_PAT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### CI/CD
+
+- Prod releases automatically publish the VSIX to Open VSX after GitHub Release creation; a manual **Publish Open VSX** workflow can republish from an existing release.
+
 ## [0.2.7] - 2026-07-16
 
 External web search adds **Parallel** as a backend with configurable search modes and source policy. Web search settings now save explicitly instead of on backend switch, and request logs record metadata for locally handled service routes. Forwarding to upstream models is more reliable when clients send hashed model aliases, unsupported reasoning fields, or inline system messages.


### PR DESCRIPTION
Publish the VSIX to Open VSX after prod GitHub Releases succeed, and add a manual workflow to republish from an existing release tag.