### PR TITLE
ci: skip CI tests and build only changed targets on main

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -12,9 +12,6 @@ on:
       is_prod:
         type: boolean
         default: false
-      skip_tests:
-        type: boolean
-        default: false
       create_release:
         type: boolean
         default: false
@@ -50,40 +47,11 @@ permissions:
   contents: write
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    if: ${{ !inputs.skip_tests }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: |
-            package-lock.json
-            web/package-lock.json
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Rebuild better-sqlite3 for Node (unit tests)
-        run: npm rebuild better-sqlite3
-
-      - name: Run lint
-        run: npm run lint
-
-      - name: Run tests (unit + integration)
-        run: npm run test:all
-
   configure:
     runs-on: ubuntu-latest
-    needs: test
-    if: ${{ always() && (needs.test.result == 'success' || needs.test.result == 'skipped') }}
     outputs:
       version: ${{ steps.meta.outputs.version }}
+      want_any_build: ${{ steps.targets.outputs.want_any_build }}
       want_build_vscode: ${{ steps.targets.outputs.want_build_vscode }}
       want_build_desktop: ${{ steps.targets.outputs.want_build_desktop }}
       want_build_tauri: ${{ steps.targets.outputs.want_build_tauri }}
@@ -104,6 +72,7 @@ jobs:
         env:
           TARGET: ${{ inputs.build_targets || 'all' }}
         run: |
+          set -euo pipefail
           MATRIX='[{"os":"macos-latest","platform":"mac","arch":"x64"},{"os":"macos-latest","platform":"mac","arch":"arm64"},{"os":"windows-latest","platform":"win","arch":"x64"},{"os":"windows-latest","platform":"win","arch":"arm64"}]'
           MATRIX_MAC='[{"os":"macos-latest","platform":"mac","arch":"x64"},{"os":"macos-latest","platform":"mac","arch":"arm64"}]'
           MATRIX_WIN='[{"os":"windows-latest","platform":"win","arch":"x64"},{"os":"windows-latest","platform":"win","arch":"arm64"}]'
@@ -121,78 +90,96 @@ jobs:
           WANT_V=false
           WANT_D=false
           WANT_T=false
+          DESKTOP_MATRIX='[]'
           TAURI_TARGETS='[]'
 
-          case "$TARGET" in
-            all)
-              WANT_V=true
-              WANT_D=true
-              WANT_T=true
-              DESKTOP_MATRIX="$MATRIX"
-              TAURI_TARGETS="$TAURI_MATRIX"
-              ;;
-            vscode)
-              WANT_V=true
-              DESKTOP_MATRIX='[]'
-              ;;
-            desktop)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX"
-              ;;
-            desktop-mac)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_MAC"
-              ;;
-            desktop-win)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_WIN"
-              ;;
-            desktop-mac-x64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_MAC_X64"
-              ;;
-            desktop-mac-arm64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_MAC_ARM64"
-              ;;
-            desktop-win-x64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_WIN_X64"
-              ;;
-            desktop-win-arm64)
-              WANT_D=true
-              DESKTOP_MATRIX="$MATRIX_WIN_ARM64"
-              ;;
-            tauri)
-              WANT_T=true
-              DESKTOP_MATRIX='[]'
-              TAURI_TARGETS="$TAURI_MATRIX"
-              ;;
-            tauri-mac)
-              WANT_T=true
-              DESKTOP_MATRIX='[]'
-              TAURI_TARGETS="$TAURI_MAC"
-              ;;
-            tauri-win)
-              WANT_T=true
-              DESKTOP_MATRIX='[]'
-              TAURI_TARGETS="$TAURI_WIN"
-              ;;
-            tauri-mac-arm64)
-              WANT_T=true
-              DESKTOP_MATRIX='[]'
-              TAURI_TARGETS="$TAURI_MAC_ARM64"
-              ;;
-            tauri-win-x64)
-              WANT_T=true
-              DESKTOP_MATRIX='[]'
-              TAURI_TARGETS="$TAURI_WIN_X64"
-              ;;
-            *)
-              echo "Unknown build_targets=$TARGET" >&2
-              exit 1
-              ;;
-          esac
+          apply_target() {
+            local t="$1"
+            case "$t" in
+              all)
+                WANT_V=true
+                WANT_D=true
+                WANT_T=true
+                DESKTOP_MATRIX="$MATRIX"
+                TAURI_TARGETS="$TAURI_MATRIX"
+                ;;
+              vscode)
+                WANT_V=true
+                ;;
+              desktop)
+                WANT_D=true
+                DESKTOP_MATRIX="$MATRIX"
+                ;;
+              desktop-mac)
+                WANT_D=true
+                DESKTOP_MATRIX="$MATRIX_MAC"
+                ;;
+              desktop-win)
+                WANT_D=true
+                DESKTOP_MATRIX="$MATRIX_WIN"
+                ;;
+              desktop-mac-x64)
+                WANT_D=true
+                DESKTOP_MATRIX="$MATRIX_MAC_X64"
+                ;;
+              desktop-mac-arm64)
+                WANT_D=true
+                DESKTOP_MATRIX="$MATRIX_MAC_ARM64"
+                ;;
+              desktop-win-x64)
+                WANT_D=true
+                DESKTOP_MATRIX="$MATRIX_WIN_X64"
+                ;;
+              desktop-win-arm64)
+                WANT_D=true
+                DESKTOP_MATRIX="$MATRIX_WIN_ARM64"
+                ;;
+              tauri)
+                WANT_T=true
+                TAURI_TARGETS="$TAURI_MATRIX"
+                ;;
+              tauri-mac)
+                WANT_T=true
+                TAURI_TARGETS="$TAURI_MAC"
+                ;;
+              tauri-win)
+                WANT_T=true
+                TAURI_TARGETS="$TAURI_WIN"
+                ;;
+              tauri-mac-arm64)
+                WANT_T=true
+                TAURI_TARGETS="$TAURI_MAC_ARM64"
+                ;;
+              tauri-win-x64)
+                WANT_T=true
+                TAURI_TARGETS="$TAURI_WIN_X64"
+                ;;
+              none)
+                ;;
+              *)
+                echo "Unknown build_targets token: $t" >&2
+                exit 1
+                ;;
+            esac
+          }
+
+          NORMALIZED_TARGET="${TARGET// /}"
+          if [ -z "$NORMALIZED_TARGET" ] || [ "$NORMALIZED_TARGET" = "none" ]; then
+            :
+          else
+            IFS=',' read -ra TOKENS <<< "$NORMALIZED_TARGET"
+            for token in "${TOKENS[@]}"; do
+              if [ -n "$token" ]; then
+                apply_target "$token"
+              fi
+            done
+          fi
+
+          if [ "$WANT_V" = true ] || [ "$WANT_D" = true ] || [ "$WANT_T" = true ]; then
+            echo "want_any_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "want_any_build=false" >> "$GITHUB_OUTPUT"
+          fi
 
           echo "want_build_vscode=$WANT_V" >> "$GITHUB_OUTPUT"
           echo "want_build_desktop=$WANT_D" >> "$GITHUB_OUTPUT"
@@ -526,6 +513,7 @@ jobs:
       ${{ always()
         && inputs.create_release
         && needs.configure.result == 'success'
+        && needs.configure.outputs.want_any_build == 'true'
         && (needs.configure.outputs.want_build_vscode != 'true' || needs.build-vscode.result == 'success')
         && (needs.configure.outputs.want_build_desktop != 'true' || needs.build-desktop.result == 'success')
         && (needs.configure.outputs.want_build_tauri != 'true' || needs.build-tauri.result == 'success')

--- a/.github/workflows/build-dev-auto.yml
+++ b/.github/workflows/build-dev-auto.yml
@@ -8,10 +8,11 @@ on:
       - '**.md'
       - 'docs/**'
       - '.gitignore'
+      - '.github/**'
   workflow_dispatch:
     inputs:
       build_targets:
-        description: 'Which artifacts to build (default on push / workflow_dispatch omission: all)'
+        description: 'Which artifacts to build (push auto-detects; manual default: all)'
         required: false
         type: choice
         options:
@@ -45,12 +46,80 @@ jobs:
       suffix: ${{ steps.meta.outputs.suffix }}
       tag_name: ${{ steps.meta.outputs.tag_name }}
       release_name: ${{ steps.meta.outputs.release_name }}
+      build_targets: ${{ steps.targets.outputs.build_targets }}
+      should_build: ${{ steps.targets.outputs.should_build }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Detect changed paths
+        if: github.event_name == 'push'
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            shared:
+              - 'packages/core/**'
+              - 'web/**'
+              - 'scripts/**'
+              - 'package.json'
+              - 'package-lock.json'
+            vscode:
+              - 'packages/vscode/**'
+            desktop:
+              - 'packages/desktop/**'
+            tauri:
+              - 'packages/desktop-tauri/**'
+
+      - name: Resolve build targets
+        id: targets
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_TARGET: ${{ inputs.build_targets }}
+          SHARED: ${{ steps.filter.outputs.shared }}
+          VSCODE: ${{ steps.filter.outputs.vscode }}
+          DESKTOP: ${{ steps.filter.outputs.desktop }}
+          TAURI: ${{ steps.filter.outputs.tauri }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "build_targets=${MANUAL_TARGET:-all}" >> "$GITHUB_OUTPUT"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "Manual build targets: ${MANUAL_TARGET:-all}"
+            exit 0
+          fi
+
+          if [ "$SHARED" = "true" ]; then
+            echo "build_targets=all" >> "$GITHUB_OUTPUT"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "Shared code changed — building all targets"
+            exit 0
+          fi
+
+          TARGETS=""
+          if [ "$VSCODE" = "true" ]; then
+            TARGETS="vscode"
+          fi
+          if [ "$DESKTOP" = "true" ]; then
+            TARGETS="${TARGETS:+$TARGETS,}desktop"
+          fi
+          if [ "$TAURI" = "true" ]; then
+            TARGETS="${TARGETS:+$TARGETS,}tauri"
+          fi
+
+          if [ -z "$TARGETS" ]; then
+            echo "build_targets=none" >> "$GITHUB_OUTPUT"
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "No buildable paths changed — skipping build"
+          else
+            echo "build_targets=$TARGETS" >> "$GITHUB_OUTPUT"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "Changed paths map to: $TARGETS"
+          fi
+
       - name: Resolve version, suffix & release metadata
         id: meta
+        if: steps.targets.outputs.should_build == 'true'
         run: |
           VERSION=$(node -p "require('./packages/vscode/package.json').version")
           DATE=$(date +%Y%m%d)
@@ -61,9 +130,10 @@ jobs:
 
   build:
     needs: prepare
+    if: needs.prepare.outputs.should_build == 'true'
     uses: ./.github/workflows/_build.yml
     with:
-      build_targets: ${{ inputs.build_targets || 'all' }}
+      build_targets: ${{ needs.prepare.outputs.build_targets }}
       suffix: ${{ needs.prepare.outputs.suffix }}
       create_release: true
       prerelease: true

--- a/.github/workflows/build-dev-manual.yml
+++ b/.github/workflows/build-dev-manual.yml
@@ -27,11 +27,6 @@ on:
         description: 'Optional suffix for artifact name (e.g., test, debug)'
         required: false
         type: string
-      skip_tests:
-        description: 'Skip tests (use with caution)'
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -62,5 +57,4 @@ jobs:
     with:
       build_targets: ${{ inputs.build_targets || 'all' }}
       suffix: ${{ needs.prepare.outputs.suffix }}
-      skip_tests: ${{ inputs.skip_tests }}
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### CI/CD
 
 - Prod releases automatically publish the VSIX to Open VSX after GitHub Release creation; a manual **Publish Open VSX** workflow can republish from an existing release.
+- CI no longer runs lint/tests in GitHub Actions; validate locally before merging.
+- **Build Dev (Auto)** on `main` builds only targets whose source paths changed (shared `core`/`web`/`scripts` changes still build all); workflow-only pushes are ignored.
 
 ## [0.2.7] - 2026-07-16
 


### PR DESCRIPTION
Remove lint/test from reusable workflows and make auto dev builds path-aware so unrelated merges and workflow-only pushes no longer trigger full artifact builds.