### PR TITLE
fix: sanitize Claude context_management and empty thinking blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+**Protocol/Conversion**
+
+- Claude models routed through Azure or other Anthropic-compatible gateways no longer fail when the client sends `context_management`; that beta field is stripped by default before the request reaches upstream.
+- Long Claude Code sessions no longer get stuck on empty thinking blocks in message history; whitespace-only shells are removed before forwarding.
+
 ### Changed
 
 **Protocol/Conversion**

--- a/packages/core/src/converter/model-meta/defaults.ts
+++ b/packages/core/src/converter/model-meta/defaults.ts
@@ -29,7 +29,11 @@ export const VENDOR_DEFAULT_META: Readonly<Record<ModelVendor, ModelMeta>> = {
     vendor: "anthropic",
     reasoning: { ...REASONING_CAPABLE },
     vision: { enabled: true },
-    anthropic: { supportsSystemRoleInMessages: true },
+    anthropic: {
+      supportsSystemRoleInMessages: true,
+      // Drop by default — Azure and most gateways reject this beta field.
+      supportsContextManagement: false,
+    },
   },
   openai: {
     id: "openai-default",

--- a/packages/core/src/converter/model-meta/families.anthropic.ts
+++ b/packages/core/src/converter/model-meta/families.anthropic.ts
@@ -1,6 +1,11 @@
 import { NO_REASONING, REASONING_CAPABLE } from "./defaults";
 import type { ModelFamilyEntry } from "./types";
 
+/** Beta fields many gateways (Azure, etc.) reject; opt in only for first-party Anthropic. */
+const ANTHROPIC_COMPAT_DEFAULTS = {
+  supportsContextManagement: false,
+} as const;
+
 export const ANTHROPIC_MODEL_FAMILIES: readonly ModelFamilyEntry[] = [
   {
     id: "claude-haiku",
@@ -9,7 +14,7 @@ export const ANTHROPIC_MODEL_FAMILIES: readonly ModelFamilyEntry[] = [
     meta: {
       reasoning: { ...NO_REASONING },
       vision: { enabled: true },
-      anthropic: { supportsSystemRoleInMessages: false },
+      anthropic: { ...ANTHROPIC_COMPAT_DEFAULTS, supportsSystemRoleInMessages: false },
     },
   },
   {
@@ -19,6 +24,7 @@ export const ANTHROPIC_MODEL_FAMILIES: readonly ModelFamilyEntry[] = [
     meta: {
       reasoning: { ...REASONING_CAPABLE },
       vision: { enabled: true },
+      anthropic: { ...ANTHROPIC_COMPAT_DEFAULTS },
     },
   },
   {
@@ -28,6 +34,7 @@ export const ANTHROPIC_MODEL_FAMILIES: readonly ModelFamilyEntry[] = [
     meta: {
       reasoning: { ...REASONING_CAPABLE },
       vision: { enabled: true },
+      anthropic: { ...ANTHROPIC_COMPAT_DEFAULTS },
     },
   },
 ];

--- a/packages/core/src/converter/model-meta/sanitize-anthropic.ts
+++ b/packages/core/src/converter/model-meta/sanitize-anthropic.ts
@@ -60,6 +60,50 @@ function stripContextManagement(data: Record<string, unknown>, changes: string[]
   }
 }
 
+function isEmptyThinkingBlock(block: Record<string, unknown>): boolean {
+  if (block.type !== "thinking") {
+    return false;
+  }
+  const thinking = block.thinking;
+  if (typeof thinking !== "string") {
+    return true;
+  }
+  return thinking.trim().length === 0;
+}
+
+/** Drop empty/whitespace-only `thinking` blocks (API rejects them). */
+function stripEmptyThinkingBlocks(data: Record<string, unknown>, changes: string[]): void {
+  const messages = data.messages;
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return;
+  }
+
+  let changed = false;
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object" || Array.isArray(msg)) {
+      continue;
+    }
+    const m = msg as Record<string, unknown>;
+    if (!Array.isArray(m.content)) {
+      continue;
+    }
+    const next = m.content.filter(part => {
+      if (!part || typeof part !== "object" || Array.isArray(part)) {
+        return true;
+      }
+      return !isEmptyThinkingBlock(part as Record<string, unknown>);
+    });
+    if (next.length !== m.content.length) {
+      m.content = next;
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    changes.push("messages.empty_thinking");
+  }
+}
+
 function stripDeferLoadingFromTools(data: Record<string, unknown>, changes: string[]): void {
   const tools = data.tools;
   if (!Array.isArray(tools) || tools.length === 0) {
@@ -278,6 +322,9 @@ export function sanitizeAnthropicRequestByMeta(
   if (anthropic?.supportsExtendedCacheTtl === false) {
     stripExtendedCacheTtl(data, changes);
   }
+
+  // Always drop empty thinking shells — independent of model meta / beta flags.
+  stripEmptyThinkingBlocks(data, changes);
 
   if (changes.length > 0) {
     const modelLabel = typeof data.model === "string" ? data.model : "?";

--- a/tests/unit/converter/model-meta/resolve.test.ts
+++ b/tests/unit/converter/model-meta/resolve.test.ts
@@ -18,6 +18,7 @@ describe("resolveModelMeta", () => {
     expect(meta.reasoning.supportsEffort).toBe(true);
     expect(meta.reasoning.supportsAdaptiveThinking).toBe(true);
     expect(meta.anthropic?.supportsSystemRoleInMessages).not.toBe(false);
+    expect(meta.anthropic?.supportsContextManagement).toBe(false);
   });
 
   it("matches gpt-5 max_completion_tokens family", () => {
@@ -74,6 +75,7 @@ describe("resolveModelMeta", () => {
     expect(meta.vendor).toBe("anthropic");
     expect(meta.reasoning.supportsEffort).toBe(true);
     expect(meta.anthropic?.supportsSystemRoleInMessages).toBe(true);
+    expect(meta.anthropic?.supportsContextManagement).toBe(false);
   });
 
   it("lists all registered families", () => {

--- a/tests/unit/converter/model-meta/sanitize-anthropic.test.ts
+++ b/tests/unit/converter/model-meta/sanitize-anthropic.test.ts
@@ -37,6 +37,50 @@ describe("sanitizeAnthropicRequestByMeta", () => {
     expect(data.thinking).toEqual({ type: "adaptive" });
   });
 
+  it("strips context_management for claude-opus by default", () => {
+    const data: Record<string, unknown> = {
+      model: "claude-opus-4-8",
+      thinking: { type: "adaptive" },
+      context_management: {
+        edits: [{ type: "clear_thinking_20251015", keep: "all" }],
+      },
+      messages: [{ role: "user", content: "hi" }],
+    };
+    const meta = resolveModelMeta("claude-opus-4-8", { vendor: "anthropic" });
+    const changes = sanitizeAnthropicRequestByMeta(data, meta);
+
+    expect(changes).toContain("context_management");
+    expect(data.context_management).toBeUndefined();
+    expect(data.thinking).toEqual({ type: "adaptive" });
+  });
+
+  it("drops empty and whitespace-only thinking blocks from messages", () => {
+    const data: Record<string, unknown> = {
+      model: "claude-opus-4-8",
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "   \n" },
+            { type: "thinking", thinking: "" },
+            { type: "thinking", signature: "sig_only" },
+            { type: "thinking", thinking: "real plan" },
+            { type: "text", text: "answer" },
+          ],
+        },
+      ],
+    };
+    const meta = resolveModelMeta("claude-opus-4-8", { vendor: "anthropic" });
+    const changes = sanitizeAnthropicRequestByMeta(data, meta);
+
+    expect(changes).toContain("messages.empty_thinking");
+    expect((data.messages as { content: unknown[] }[])[1].content).toEqual([
+      { type: "thinking", thinking: "real plan" },
+      { type: "text", text: "answer" },
+    ]);
+  });
+
   it("removes only effort when output_config has other keys", () => {
     const data: Record<string, unknown> = {
       model: "claude-haiku-4-5",


### PR DESCRIPTION
## Summary

- Strip Claude Code's `context_management` beta field by default for Anthropic model families, so Azure and other compatible gateways stop returning 400 errors.
- Remove empty or whitespace-only `thinking` blocks from outbound message history to prevent long sessions from getting stuck on API validation failures.

## Test plan

- [x] `npx vitest run tests/unit/converter/model-meta/sanitize-anthropic.test.ts tests/unit/converter/model-meta/resolve.test.ts`
- [x] `npm run format && npm run lint`
- [ ] Route Claude Desktop / Claude Code through CCRelay to an Azure Claude endpoint and confirm requests no longer fail with `context_management: Extra inputs are not permitted`
- [ ] Resume a long Claude Code session that previously hit `thinking block must contain non-whitespace thinking` and confirm forwarding succeeds


Made with [Cursor](https://cursor.com)