### PR TITLE
fix: strip structured outputs for Azure and gateway Anthropic routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Protocol/Conversion**
 
 - Claude models routed through Azure or other Anthropic-compatible gateways no longer fail when the client sends `context_management`; that beta field is stripped by default before the request reaches upstream.
+- Claude Code Stop hooks and other clients that request structured outputs (`output_config.format` / `json_schema`) no longer get a hard 400 from Azure Hosted-on-Azure or similar gateways; that field is stripped by default while effort/thinking are preserved when supported.
 - Long Claude Code sessions no longer get stuck on empty thinking blocks in message history; whitespace-only shells are removed before forwarding.
 
 ### Changed

--- a/packages/core/src/converter/model-meta/defaults.ts
+++ b/packages/core/src/converter/model-meta/defaults.ts
@@ -31,8 +31,9 @@ export const VENDOR_DEFAULT_META: Readonly<Record<ModelVendor, ModelMeta>> = {
     vision: { enabled: true },
     anthropic: {
       supportsSystemRoleInMessages: true,
-      // Drop by default — Azure and most gateways reject this beta field.
+      // Drop by default — Azure Hosted-on-Azure and most gateways reject these.
       supportsContextManagement: false,
+      supportsStructuredOutputs: false,
     },
   },
   openai: {

--- a/packages/core/src/converter/model-meta/families.anthropic.ts
+++ b/packages/core/src/converter/model-meta/families.anthropic.ts
@@ -1,9 +1,14 @@
 import { NO_REASONING, REASONING_CAPABLE } from "./defaults";
 import type { ModelFamilyEntry } from "./types";
 
-/** Beta fields many gateways (Azure, etc.) reject; opt in only for first-party Anthropic. */
+/**
+ * Fields many gateways (Azure Hosted-on-Azure, etc.) reject.
+ * Opt in only when the upstream is known to support them (first-party Anthropic /
+ * Foundry Hosted-on-Anthropic).
+ */
 const ANTHROPIC_COMPAT_DEFAULTS = {
   supportsContextManagement: false,
+  supportsStructuredOutputs: false,
 } as const;
 
 export const ANTHROPIC_MODEL_FAMILIES: readonly ModelFamilyEntry[] = [

--- a/packages/core/src/converter/model-meta/families.glm.ts
+++ b/packages/core/src/converter/model-meta/families.glm.ts
@@ -18,6 +18,7 @@ export const GLM_MODEL_FAMILIES: readonly ModelFamilyEntry[] = [
       anthropic: {
         supportsSystemRoleInMessages: false,
         supportsContextManagement: false,
+        supportsStructuredOutputs: false,
         supportsDeferLoading: false,
         supportsToolReferenceBlocks: false,
         supportsExtendedCacheTtl: false,

--- a/packages/core/src/converter/model-meta/sanitize-anthropic.ts
+++ b/packages/core/src/converter/model-meta/sanitize-anthropic.ts
@@ -7,15 +7,23 @@ const log = new ScopedLogger("ModelMeta");
 
 const DEFERRED_TOOL_PLACEHOLDER = "DeferredToolPlaceholder";
 
-function deleteOutputConfigEffort(data: Record<string, unknown>, changes: string[]): void {
+function sanitizeOutputConfig(
+  data: Record<string, unknown>,
+  options: { stripEffort: boolean; stripFormat: boolean },
+  changes: string[]
+): void {
   const oc = data.output_config;
   if (!oc || typeof oc !== "object" || Array.isArray(oc)) {
     return;
   }
   const out = oc as Record<string, unknown>;
-  if ("effort" in out) {
+  if (options.stripEffort && "effort" in out) {
     delete out.effort;
     changes.push("output_config.effort");
+  }
+  if (options.stripFormat && "format" in out) {
+    delete out.format;
+    changes.push("output_config.format");
   }
   if (Object.keys(out).length === 0) {
     delete data.output_config;
@@ -295,8 +303,15 @@ export function sanitizeAnthropicRequestByMeta(
   const reasoning = meta.reasoning;
   const anthropic = meta.anthropic;
 
-  if (!reasoning.supportsEffort) {
-    deleteOutputConfigEffort(data, changes);
+  if (!reasoning.supportsEffort || anthropic?.supportsStructuredOutputs === false) {
+    sanitizeOutputConfig(
+      data,
+      {
+        stripEffort: !reasoning.supportsEffort,
+        stripFormat: anthropic?.supportsStructuredOutputs === false,
+      },
+      changes
+    );
   }
 
   normalizeThinkingForMeta(data, meta, changes);

--- a/packages/core/src/converter/model-meta/types.ts
+++ b/packages/core/src/converter/model-meta/types.ts
@@ -48,6 +48,11 @@ export interface ModelAnthropicMeta {
   supportsSystemRoleInMessages?: boolean;
   /** When false, strip top-level `context_management`. */
   supportsContextManagement?: boolean;
+  /**
+   * When false, strip `output_config.format` (structured outputs / json_schema).
+   * Azure Hosted-on-Azure and many gateways reject this; official Anthropic supports it.
+   */
+  supportsStructuredOutputs?: boolean;
   /** When false, strip `defer_loading` from tools and drop deferred placeholder tools. */
   supportsDeferLoading?: boolean;
   /** When false, rewrite `tool_reference` blocks in tool results to plain text. */

--- a/tests/unit/converter/model-meta/resolve.test.ts
+++ b/tests/unit/converter/model-meta/resolve.test.ts
@@ -19,6 +19,7 @@ describe("resolveModelMeta", () => {
     expect(meta.reasoning.supportsAdaptiveThinking).toBe(true);
     expect(meta.anthropic?.supportsSystemRoleInMessages).not.toBe(false);
     expect(meta.anthropic?.supportsContextManagement).toBe(false);
+    expect(meta.anthropic?.supportsStructuredOutputs).toBe(false);
   });
 
   it("matches gpt-5 max_completion_tokens family", () => {
@@ -76,6 +77,7 @@ describe("resolveModelMeta", () => {
     expect(meta.reasoning.supportsEffort).toBe(true);
     expect(meta.anthropic?.supportsSystemRoleInMessages).toBe(true);
     expect(meta.anthropic?.supportsContextManagement).toBe(false);
+    expect(meta.anthropic?.supportsStructuredOutputs).toBe(false);
   });
 
   it("lists all registered families", () => {

--- a/tests/unit/converter/model-meta/sanitize-anthropic.test.ts
+++ b/tests/unit/converter/model-meta/sanitize-anthropic.test.ts
@@ -81,16 +81,94 @@ describe("sanitizeAnthropicRequestByMeta", () => {
     ]);
   });
 
-  it("removes only effort when output_config has other keys", () => {
+  it("removes only effort when output_config has other keys and structured outputs allowed", () => {
     const data: Record<string, unknown> = {
       model: "claude-haiku-4-5",
       output_config: { effort: "medium", format: { type: "text" } },
       messages: [],
     };
     const meta = resolveModelMeta("claude-haiku-4-5", { vendor: "anthropic" });
+    meta.anthropic = { ...meta.anthropic, supportsStructuredOutputs: true };
     sanitizeAnthropicRequestByMeta(data, meta);
 
     expect(data.output_config).toEqual({ format: { type: "text" } });
+  });
+
+  it("strips output_config.format for Claude families by default (Azure/gateway compat)", () => {
+    const data: Record<string, unknown> = {
+      model: "claude-opus-4-8",
+      thinking: { type: "adaptive" },
+      output_config: {
+        effort: "xhigh",
+        format: {
+          type: "json_schema",
+          schema: {
+            type: "object",
+            properties: { ok: { type: "boolean" }, reason: { type: "string" } },
+            required: ["ok", "reason"],
+            additionalProperties: false,
+          },
+        },
+      },
+      messages: [{ role: "user", content: "evaluate stop condition" }],
+    };
+    const meta = resolveModelMeta("claude-opus-4-8", { vendor: "anthropic" });
+    const changes = sanitizeAnthropicRequestByMeta(data, meta);
+
+    expect(meta.anthropic?.supportsStructuredOutputs).toBe(false);
+    expect(changes).toContain("output_config.format");
+    expect(data.output_config).toEqual({ effort: "xhigh" });
+    expect(data.thinking).toEqual({ type: "adaptive" });
+  });
+
+  it("strips entire output_config when format is the only key and unsupported", () => {
+    const data: Record<string, unknown> = {
+      model: "claude-sonnet-4-20250514",
+      output_config: {
+        format: { type: "json_schema", schema: { type: "object", properties: {} } },
+      },
+      messages: [],
+    };
+    const meta = resolveModelMeta("claude-sonnet-4-20250514", { vendor: "anthropic" });
+    const changes = sanitizeAnthropicRequestByMeta(data, meta);
+
+    expect(changes).toContain("output_config.format");
+    expect(changes).toContain("output_config");
+    expect(data.output_config).toBeUndefined();
+  });
+
+  it("preserves structured outputs when meta opts in", () => {
+    const format = {
+      type: "json_schema",
+      schema: { type: "object", properties: { ok: { type: "boolean" } } },
+    };
+    const data: Record<string, unknown> = {
+      model: "claude-opus-4-8",
+      output_config: { effort: "high", format },
+      messages: [],
+    };
+    const meta = resolveModelMeta("claude-opus-4-8", { vendor: "anthropic" });
+    meta.anthropic = { ...meta.anthropic, supportsStructuredOutputs: true };
+    const changes = sanitizeAnthropicRequestByMeta(data, meta);
+
+    expect(changes).not.toContain("output_config.format");
+    expect(data.output_config).toEqual({ effort: "high", format });
+  });
+
+  it("strips structured outputs for glm family", () => {
+    const data: Record<string, unknown> = {
+      model: "glm-4.7",
+      thinking: { type: "enabled" },
+      output_config: {
+        format: { type: "json_schema", schema: { type: "object" } },
+      },
+      messages: [],
+    };
+    const meta = resolveModelMeta("glm-4.7");
+    const changes = sanitizeAnthropicRequestByMeta(data, meta);
+
+    expect(changes).toContain("output_config.format");
+    expect(data.output_config).toBeUndefined();
   });
 
   it("hoists inline system messages for haiku Cowork-style payload", () => {


### PR DESCRIPTION
## Summary
- Add `supportsStructuredOutputs` to Anthropic model meta (default off for Claude/GLM families and vendor defaults) so ccrelay strips `output_config.format` before requests reach Azure Hosted-on-Azure and other gateways that reject `json_schema` structured outputs.
- Preserve `output_config.effort` and thinking when the model supports them; only remove the format field (or the whole `output_config` if it becomes empty).
- Fixes Claude Code Stop hooks and similar clients that previously received `structured_outputs not supported in your workspace` when routed through ccrelay to Azure.

## Test plan
- [x] `npm run format && npm run lint`
- [x] `npx vitest run tests/unit/converter/model-meta/ tests/unit/converter/anthropic-request-sanitize.test.ts`
- [ ] Manual: route Claude Code through ccrelay to Azure Foundry (Hosted on Azure) and confirm Stop hook no longer fails with structured_outputs 400


Made with [Cursor](https://cursor.com)