### PR TITLE
feat: LongCat support, Responses tools fix, and edit-provider endpoint test

### DIFF
--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -39,7 +39,11 @@ import {
   handleSmartRoutingAliasDriftApply,
   setServer as setSmartRoutingServer,
 } from "./smartRouting";
-import { handleWizardProbeModels, handleWizardEndpointTest } from "./wizardUpstream";
+import {
+  handleWizardProbeModels,
+  handleWizardEndpointTest,
+  setServer as setWizardUpstreamServer,
+} from "./wizardUpstream";
 import { sendJson } from "./httpJson";
 import { setProxyServerForApi } from "./serverRef";
 import { getUiAccessToken } from "../server/httpAccessGate";
@@ -59,6 +63,7 @@ export function setServer(server: ProxyServer): void {
   setClientConfigServer(server);
   setSettingsServer(server);
   setSmartRoutingServer(server);
+  setWizardUpstreamServer(server);
 }
 
 /** Return this leader's UI access token (for followers to proxy dashboard auth). */

--- a/packages/core/src/api/wizardUpstream.ts
+++ b/packages/core/src/api/wizardUpstream.ts
@@ -5,12 +5,46 @@
 /* eslint-disable @typescript-eslint/naming-convention -- upstream JSON bodies and HTTP header names */
 
 import * as http from "http";
+import type { ProxyServer } from "../server/handler";
 import { Logger } from "../utils/logger";
 import { parseJsonBody, sendJson } from "./httpJson";
 
 const log = Logger.getInstance();
 
 const REQUEST_TIMEOUT_MS = 30_000;
+
+let serverInstance: ProxyServer | null = null;
+
+/** Wire ProxyServer so endpoint tests can resolve stored provider API keys. */
+export function setServer(server: ProxyServer | null): void {
+  serverInstance = server;
+}
+
+/** True when the value looks like a UI-masked key (`****…****`), not a real secret. */
+export function looksLikeMaskedApiKey(apiKey: string | undefined): boolean {
+  return typeof apiKey === "string" && apiKey.includes("************");
+}
+
+/**
+ * Prefer a non-masked `apiKey`; otherwise look up the stored key for `providerId`.
+ */
+export function resolveWizardApiKey(
+  apiKey: string | undefined,
+  providerId: string | undefined
+): string | undefined {
+  const trimmed = typeof apiKey === "string" ? apiKey.trim() : "";
+  if (trimmed && !looksLikeMaskedApiKey(trimmed)) {
+    return trimmed;
+  }
+  const id = typeof providerId === "string" ? providerId.trim() : "";
+  if (id && serverInstance) {
+    const stored = serverInstance.getConfig().providers[id]?.apiKey?.trim();
+    if (stored) {
+      return stored;
+    }
+  }
+  return undefined;
+}
 
 export type WizardProviderType = "anthropic" | "openai" | "openai_chat";
 
@@ -67,8 +101,10 @@ export function parseModelsResponseBody(data: unknown): string[] | null {
 
 export interface WizardProbeModelsBody {
   baseUrl: string;
-  apiKey: string;
+  apiKey?: string;
   providerType: WizardProviderType;
+  /** When set (and apiKey is missing/masked), use the stored provider secret. */
+  providerId?: string;
 }
 
 export type WizardProbeModelsResponse =
@@ -78,8 +114,9 @@ export type WizardProbeModelsResponse =
 export async function executeWizardProbeModels(
   body: WizardProbeModelsBody
 ): Promise<WizardProbeModelsResponse> {
-  const { baseUrl, apiKey, providerType } = body;
-  if (!baseUrl?.trim() || !apiKey?.trim()) {
+  const { baseUrl, providerType } = body;
+  const apiKey = resolveWizardApiKey(body.apiKey, body.providerId);
+  if (!baseUrl?.trim() || !apiKey) {
     return { ok: false, errorCode: "format" };
   }
   if (!validateHttpsUrl(baseUrl)) {
@@ -91,10 +128,10 @@ export async function executeWizardProbeModels(
     accept: "application/json",
   };
   if (providerType === "anthropic") {
-    headers["x-api-key"] = apiKey.trim();
+    headers["x-api-key"] = apiKey;
     headers["anthropic-version"] = "2023-06-01";
   } else {
-    headers.authorization = `Bearer ${apiKey.trim()}`;
+    headers.authorization = `Bearer ${apiKey}`;
   }
 
   log.info(`[wizard/models] Probing ${providerType} GET ${url}`);
@@ -144,9 +181,10 @@ export async function handleWizardProbeModels(
 ): Promise<void> {
   try {
     const body = await parseJsonBody<WizardProbeModelsBody>(req);
+    const resolvedKey = resolveWizardApiKey(body.apiKey, body.providerId);
     if (
       !body.baseUrl ||
-      !body.apiKey ||
+      !resolvedKey ||
       (body.providerType !== "anthropic" &&
         body.providerType !== "openai" &&
         body.providerType !== "openai_chat")
@@ -154,7 +192,10 @@ export async function handleWizardProbeModels(
       sendJson(res, 400, { error: "Missing or invalid baseUrl, apiKey, or providerType" });
       return;
     }
-    const result = await executeWizardProbeModels(body);
+    const result = await executeWizardProbeModels({
+      ...body,
+      apiKey: resolvedKey,
+    });
     sendJson(res, 200, result);
   } catch (err) {
     sendJson(res, 500, {
@@ -245,7 +286,9 @@ export interface WizardEndpointVariantInput {
 }
 
 export interface WizardEndpointTestBody {
-  apiKey: string;
+  apiKey?: string;
+  /** When set (and apiKey is missing/masked), use the stored provider secret. */
+  providerId?: string;
   modelId: string;
   variants: WizardEndpointVariantInput[];
 }
@@ -349,9 +392,10 @@ async function runSingleVariantTest(
 export async function executeWizardEndpointTest(
   body: WizardEndpointTestBody
 ): Promise<WizardEndpointTestResponse> {
-  const { apiKey, modelId, variants } = body;
+  const { modelId, variants } = body;
+  const apiKey = resolveWizardApiKey(body.apiKey, body.providerId);
   const trimmedModel = modelId.trim();
-  if (!trimmedModel || !apiKey?.trim() || !Array.isArray(variants) || variants.length === 0) {
+  if (!trimmedModel || !apiKey || !Array.isArray(variants) || variants.length === 0) {
     return { ok: true, results: [] };
   }
 
@@ -387,8 +431,9 @@ export async function handleWizardEndpointTest(
 ): Promise<void> {
   try {
     const body = await parseJsonBody<WizardEndpointTestBody>(req);
+    const resolvedKey = resolveWizardApiKey(body.apiKey, body.providerId);
     if (
-      !body.apiKey ||
+      !resolvedKey ||
       !body.modelId ||
       !Array.isArray(body.variants) ||
       body.variants.length === 0
@@ -408,7 +453,10 @@ export async function handleWizardEndpointTest(
         return;
       }
     }
-    const result = await executeWizardEndpointTest(body);
+    const result = await executeWizardEndpointTest({
+      ...body,
+      apiKey: resolvedKey,
+    });
     sendJson(res, 200, result);
   } catch (err) {
     sendJson(res, 500, {

--- a/packages/core/src/converter/adapters/openai-responses-to-chat.ts
+++ b/packages/core/src/converter/adapters/openai-responses-to-chat.ts
@@ -49,6 +49,33 @@ export function extractFunctionToolsForEcho(tools: unknown): unknown[] {
   return out;
 }
 
+/**
+ * Merge top-level `tools` with tools nested under `input[]` items of type `additional_tools`
+ * (Codex / desktop clients often declare tools this way instead of the top-level field).
+ */
+export function collectResponsesToolsRaw(raw: Record<string, unknown>): unknown[] {
+  const merged: unknown[] = [];
+  if (Array.isArray(raw.tools)) {
+    for (const t of raw.tools as unknown[]) {
+      merged.push(t);
+    }
+  }
+  if (Array.isArray(raw.input)) {
+    for (const item of raw.input as unknown[]) {
+      if (!item || typeof item !== "object") {
+        continue;
+      }
+      const o = item as Record<string, unknown>;
+      if (o.type === "additional_tools" && Array.isArray(o.tools)) {
+        for (const t of o.tools as unknown[]) {
+          merged.push(t);
+        }
+      }
+    }
+  }
+  return merged;
+}
+
 function asRecord(val: unknown): Record<string, unknown> | undefined {
   if (!val || typeof val !== "object" || Array.isArray(val)) {
     return undefined;
@@ -60,7 +87,7 @@ function asRecord(val: unknown): Record<string, unknown> | undefined {
  * Pull echo fields from parsed OpenAI Responses request JSON (`raw`).
  */
 export function extractResponsesEcho(raw: Record<string, unknown>): ResponsesRequestEcho {
-  const tools = extractFunctionToolsForEcho(raw.tools);
+  const tools = extractFunctionToolsForEcho(collectResponsesToolsRaw(raw));
   const parallel =
     typeof raw.parallel_tool_calls === "boolean" ? raw.parallel_tool_calls : undefined;
   const store = typeof raw.store === "boolean" ? raw.store : undefined;
@@ -236,7 +263,7 @@ export function convertResponsesRequestToChatCompletions(
     }
   }
 
-  const tools = mapResponsesTools(raw.tools);
+  const tools = mapResponsesTools(collectResponsesToolsRaw(raw));
   if (tools.length) {
     out.tools = tools;
   }
@@ -342,9 +369,10 @@ function mapEasyMessageContentToText(content: unknown): string | undefined {
       continue;
     }
     const b = block as { type?: string; text?: string };
-    if (b.type === "input_text" && typeof b.text === "string") {
-      parts.push(b.text);
-    } else if (b.type === "text" && typeof b.text === "string") {
+    if (
+      (b.type === "input_text" || b.type === "output_text" || b.type === "text") &&
+      typeof b.text === "string"
+    ) {
       parts.push(b.text);
     }
   }
@@ -374,6 +402,11 @@ function appendInputItemsToMessages(items: unknown[], messages: OpenAIMessage[])
     const o = item as Record<string, unknown>;
     const typ = o.type;
 
+    // Codex embeds tool defs in input; collected via collectResponsesToolsRaw — never as messages.
+    if (typ === "additional_tools") {
+      continue;
+    }
+
     if (typ === "message" || o.role !== undefined) {
       const role = o.role;
       const r = typeof role === "string" ? role : "user";
@@ -389,7 +422,8 @@ function appendInputItemsToMessages(items: unknown[], messages: OpenAIMessage[])
               : r === "assistant"
                 ? "assistant"
                 : "user";
-        if (oaiRole === "assistant" && !text && !Array.isArray(o.content)) {
+        // Skip empty assistant/developer/system placeholders (e.g. unmapped content types).
+        if (!text && oaiRole !== "user") {
           continue;
         }
         messages.push({ role: oaiRole, content: text });

--- a/packages/core/src/converter/index.ts
+++ b/packages/core/src/converter/index.ts
@@ -68,6 +68,7 @@ export {
   extractResponsesEcho,
   mergedResponseShellEcho,
   extractFunctionToolsForEcho,
+  collectResponsesToolsRaw,
 } from "./adapters/openai-responses-to-chat";
 
 export {

--- a/packages/core/src/converter/platform-transforms/index.ts
+++ b/packages/core/src/converter/platform-transforms/index.ts
@@ -17,6 +17,7 @@ import {
   MESSAGE_TRANSFORM_REGISTRY,
   REQUEST_OVERRIDE_REGISTRY,
   REQUEST_SANITIZE_REGISTRY,
+  CHAT_RESPONSE_SANITIZE_REGISTRY,
   RESPONSE_TRANSFORM_REGISTRY,
   TOOL_TRANSFORM_REGISTRY,
   ANTHROPIC_SSE_TRANSFORM_REGISTRY,
@@ -36,6 +37,7 @@ export type {
   PlatformAnthropicSseTransform,
   PlatformMessageTransform,
   PlatformRequestSanitizeTransform,
+  PlatformChatResponseSanitizeTransform,
   PlatformResponseTransform,
   PlatformToolTransform,
 } from "./registries";
@@ -62,10 +64,14 @@ export {
   isPlainObject,
   customToFunctionShim,
   openaiChatStrictToolsSanitize,
+  extractLongcatToolCalls,
+  parseLongcatArgValue,
+  sanitizeLongcatChatCompletion,
   TOOL_TRANSFORM_REGISTRY,
   MESSAGE_TRANSFORM_REGISTRY,
   REQUEST_OVERRIDE_REGISTRY,
   REQUEST_SANITIZE_REGISTRY,
+  CHAT_RESPONSE_SANITIZE_REGISTRY,
   RESPONSE_TRANSFORM_REGISTRY,
   ANTHROPIC_SSE_TRANSFORM_REGISTRY,
   TRANSFORM_REGISTRY,
@@ -286,6 +292,29 @@ export function applyPlatformRequestSanitize(body: Record<string, unknown>, base
   }
   const fn = REQUEST_SANITIZE_REGISTRY[key];
   fn?.(body);
+}
+
+/**
+ * Apply inbound OpenAI Chat Completions sanitization (e.g. LongCat XML → `tool_calls`)
+ * when the platform rule declares `chatResponseSanitize`.
+ */
+export function applyPlatformChatResponseSanitize(
+  body: Record<string, unknown>,
+  baseUrl: string
+): void {
+  const rule = matchHostedToolRuleForBaseUrl(baseUrl);
+  const key = rule?.chatResponseSanitize;
+  if (!key) {
+    return;
+  }
+  const fn = CHAT_RESPONSE_SANITIZE_REGISTRY[key];
+  fn?.(body);
+}
+
+/** True when the platform rule buffers streamed assistant text to rewrite tool XML at finish. */
+export function platformBuffersChatContentForToolParse(baseUrl: string): boolean {
+  const rule = matchHostedToolRuleForBaseUrl(baseUrl);
+  return typeof rule?.chatResponseSanitize === "string" && rule.chatResponseSanitize.length > 0;
 }
 
 /**

--- a/packages/core/src/converter/platform-transforms/longcat/chat-tool-calls.ts
+++ b/packages/core/src/converter/platform-transforms/longcat/chat-tool-calls.ts
@@ -1,0 +1,175 @@
+/**
+ * LongCat Chat Completions: convert embedded `<longcat_tool_call>` XML in assistant
+ * content into OpenAI `message.tool_calls` (Meituan LongCat wire format).
+ *
+ * Format:
+ * ```
+ * <longcat_tool_call>{function-name}
+ * <longcat_arg_key>{key}</longcat_arg_key>
+ * <longcat_arg_value>{value}</longcat_arg_value>
+ * ...
+ * </longcat_tool_call>
+ * ```
+ */
+
+import { randomUUID } from "crypto";
+
+const TOOL_CALL_BLOCK_RE = /<longcat_tool_call>([\s\S]*?)<\/longcat_tool_call>/g;
+const ARG_PAIR_RE =
+  /<longcat_arg_key>([\s\S]*?)<\/longcat_arg_key>\s*<longcat_arg_value>([\s\S]*?)<\/longcat_arg_value>/g;
+
+export interface LongcatParsedToolCall {
+  id: string;
+  type: "function";
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+export interface LongcatToolCallExtractResult {
+  /** Assistant-visible text with tool-call XML removed. */
+  content: string;
+  toolCalls: LongcatParsedToolCall[];
+}
+
+function asRecord(val: unknown): Record<string, unknown> | undefined {
+  if (!val || typeof val !== "object" || Array.isArray(val)) {
+    return undefined;
+  }
+  return val as Record<string, unknown>;
+}
+
+function messageContentToString(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  const parts: string[] = [];
+  for (const block of content) {
+    const o = asRecord(block);
+    if (!o) {
+      continue;
+    }
+    if (typeof o.text === "string") {
+      parts.push(o.text);
+    }
+  }
+  return parts.join("");
+}
+
+/** Parse a single arg value: JSON when possible, otherwise raw string. */
+export function parseLongcatArgValue(raw: string): unknown {
+  const s = raw.trim();
+  if (s.length === 0) {
+    return "";
+  }
+  try {
+    return JSON.parse(s) as unknown;
+  } catch {
+    return s;
+  }
+}
+
+function newToolCallId(): string {
+  return `call_${randomUUID().replace(/-/g, "").slice(0, 24)}`;
+}
+
+/**
+ * Extract LongCat XML tool calls from assistant text.
+ * Returns original text unchanged when no complete tool-call blocks are found.
+ */
+export function extractLongcatToolCalls(text: string): LongcatToolCallExtractResult {
+  if (!text.includes("<longcat_tool_call>")) {
+    return { content: text, toolCalls: [] };
+  }
+
+  const toolCalls: LongcatParsedToolCall[] = [];
+  let match: RegExpExecArray | null;
+  TOOL_CALL_BLOCK_RE.lastIndex = 0;
+  while ((match = TOOL_CALL_BLOCK_RE.exec(text)) !== null) {
+    const body = match[1] ?? "";
+    const nameMatch = body.trim().match(/^([^\n<]+)/);
+    const name = nameMatch?.[1]?.trim() ?? "";
+    if (!name) {
+      continue;
+    }
+
+    const args: Record<string, unknown> = {};
+    ARG_PAIR_RE.lastIndex = 0;
+    let pair: RegExpExecArray | null;
+    while ((pair = ARG_PAIR_RE.exec(body)) !== null) {
+      const key = (pair[1] ?? "").trim();
+      if (!key) {
+        continue;
+      }
+      args[key] = parseLongcatArgValue(pair[2] ?? "");
+    }
+
+    toolCalls.push({
+      id: newToolCallId(),
+      type: "function",
+      function: {
+        name,
+        arguments: JSON.stringify(args),
+      },
+    });
+  }
+
+  if (toolCalls.length === 0) {
+    return { content: text, toolCalls: [] };
+  }
+
+  const content = text
+    .replace(TOOL_CALL_BLOCK_RE, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  return { content, toolCalls };
+}
+
+/**
+ * Mutate an OpenAI Chat Completions response body in place: lift LongCat XML
+ * tool calls out of `choices[].message.content` into `tool_calls`.
+ */
+export function sanitizeLongcatChatCompletion(body: Record<string, unknown>): void {
+  const choices = body.choices;
+  if (!Array.isArray(choices) || choices.length === 0) {
+    return;
+  }
+
+  for (const choice of choices) {
+    const c = asRecord(choice);
+    if (!c) {
+      continue;
+    }
+    const message = asRecord(c.message);
+    if (!message) {
+      continue;
+    }
+
+    const text = messageContentToString(message.content);
+    if (!text.includes("<longcat_tool_call>")) {
+      continue;
+    }
+
+    const { content, toolCalls } = extractLongcatToolCalls(text);
+    if (toolCalls.length === 0) {
+      continue;
+    }
+
+    message.content = content.length > 0 ? content : null;
+
+    const existing = Array.isArray(message.tool_calls)
+      ? (message.tool_calls as LongcatParsedToolCall[])
+      : [];
+    message.tool_calls = [...existing, ...toolCalls];
+
+    const fr = c.finish_reason;
+    if (fr === "stop" || fr === null || fr === undefined || fr === "") {
+      c.finish_reason = "tool_calls";
+    }
+  }
+}

--- a/packages/core/src/converter/platform-transforms/registries.ts
+++ b/packages/core/src/converter/platform-transforms/registries.ts
@@ -11,6 +11,7 @@ import { azureWebSearchRequestOverride } from "./azure-openai/request-override";
 import { azureResponsesWebSearchResponseTransform } from "./azure-openai/responses-web-search";
 import { transformGlmAnthropicSearchSseRows } from "./glm/anthropic-sse";
 import { transformLongcatAnthropicSseRows } from "./longcat/anthropic-sse";
+import { sanitizeLongcatChatCompletion } from "./longcat/chat-tool-calls";
 import { glmFlattenContentTransform } from "./glm/messages";
 import { mimoWebSearchTransform } from "./xiaomimimo/tools";
 import { mimoAnnotationsWebSearchResponseTransform } from "./xiaomimimo/responses";
@@ -45,6 +46,9 @@ export type PlatformAnthropicSseTransform = (
 
 /** Outbound Chat Completions JSON body sanitize (provider-specific). */
 export type PlatformRequestSanitizeTransform = (body: Record<string, unknown>) => void;
+
+/** Inbound OpenAI Chat Completions JSON sanitize (before cross-protocol conversion). */
+export type PlatformChatResponseSanitizeTransform = (body: Record<string, unknown>) => void;
 
 export const REQUEST_OVERRIDE_REGISTRY: Readonly<Record<string, PlatformRequestOverrideTransform>> =
   {
@@ -83,6 +87,12 @@ export const REQUEST_SANITIZE_REGISTRY: Readonly<Record<string, PlatformRequestS
     "minimax-chat-sanitize": minimaxChatSanitize,
   };
 
+export const CHAT_RESPONSE_SANITIZE_REGISTRY: Readonly<
+  Record<string, PlatformChatResponseSanitizeTransform>
+> = {
+  "longcat-xml-tool-calls": sanitizeLongcatChatCompletion,
+};
+
 export { passthroughTransform, isPlainObject } from "./passthrough";
 export { glmFlattenContentTransform } from "./glm/messages";
 export { mimoAnnotationsWebSearchResponseTransform } from "./xiaomimimo/responses";
@@ -105,6 +115,11 @@ export { geminiThoughtTagsResponseTransform } from "./gemini/response-thoughts";
 export { minimaxChatSanitize } from "./minimax/request-sanitize";
 export { minimaxReasoningDetailsResponseTransform } from "./minimax/response-reasoning";
 export { customToFunctionShim, openaiChatStrictToolsSanitize } from "./openai-chat-strict-tools";
+export {
+  extractLongcatToolCalls,
+  parseLongcatArgValue,
+  sanitizeLongcatChatCompletion,
+} from "./longcat/chat-tool-calls";
 
 /** @deprecated Prefer `TOOL_TRANSFORM_REGISTRY`. */
 export const TRANSFORM_REGISTRY = TOOL_TRANSFORM_REGISTRY;

--- a/packages/core/src/converter/platform-transforms/rules.ts
+++ b/packages/core/src/converter/platform-transforms/rules.ts
@@ -41,6 +41,11 @@ export interface PlatformTransformRule {
   strictTools?: boolean;
   /** Outbound Chat Completions JSON sanitize registry key (runs after tools/messages transforms). */
   requestSanitize?: string;
+  /**
+   * Inbound OpenAI Chat Completions JSON sanitize registry key (before Chat→Responses / Chat→Anthropic).
+   * e.g. LongCat XML `<longcat_tool_call>` → `message.tool_calls`.
+   */
+  chatResponseSanitize?: string;
 }
 
 /** Legacy name for tooling that matched hosted-tool-only rules (same payload). */
@@ -116,5 +121,7 @@ export const PLATFORM_TRANSFORM_RULES: readonly PlatformTransformRule[] = [
     domains: ["api.longcat.chat"],
     anthropicSse: "longcat-message-start-usage",
     anthropicSseStream: true,
+    chatResponseSanitize: "longcat-xml-tool-calls",
+    strictTools: true,
   },
 ];

--- a/packages/core/src/converter/streaming/openai-chat-stream-to-responses.ts
+++ b/packages/core/src/converter/streaming/openai-chat-stream-to-responses.ts
@@ -11,6 +11,7 @@ import { randomUUID } from "crypto";
 
 import type { ResponsesRequestEcho } from "../../types";
 import { mergedResponseShellEcho } from "../adapters/openai-responses-to-chat";
+import { extractLongcatToolCalls } from "../platform-transforms/longcat/chat-tool-calls";
 
 const SSE_TEXT_CHUNK = 64;
 
@@ -40,6 +41,11 @@ export interface StreamingConversionState {
   outputIndex: number;
   /** Tool calls received finish_reason; close on [DONE] after trailing arg deltas. */
   toolsPendingClose: boolean;
+  /**
+   * When true, buffer assistant `content` deltas and rewrite LongCat XML tool calls at finish
+   * instead of streaming raw XML as `output_text`.
+   */
+  bufferContentForToolParse: boolean;
   /** Original Responses request fields to echo back in response shells */
   echo?: ResponsesRequestEcho;
   usage?: {
@@ -57,6 +63,7 @@ export interface StreamingConversionState {
 
 export function createStreamingState(opts?: {
   echo?: ResponsesRequestEcho;
+  bufferContentForToolParse?: boolean;
 }): StreamingConversionState {
   return {
     responseId: `resp_${randomUUID().replace(/-/g, "")}`,
@@ -72,6 +79,7 @@ export function createStreamingState(opts?: {
     currentToolIndex: 0,
     outputIndex: 0,
     toolsPendingClose: false,
+    bufferContentForToolParse: opts?.bufferContentForToolParse === true,
     ...(opts?.echo !== undefined ? { echo: opts.echo } : {}),
   };
 }
@@ -163,18 +171,24 @@ export function processStreamingChunk(state: StreamingConversionState, line: str
         events.push(...emitResponseCreated(state));
       }
       state.phase = "text";
-      events.push(...emitOutputItemAdded(state, "message"));
-      events.push(...emitContentPartAdded(state, state.messageId, "output_text"));
+      if (!state.bufferContentForToolParse) {
+        events.push(...emitOutputItemAdded(state, "message"));
+        events.push(...emitContentPartAdded(state, state.messageId, "output_text"));
+      }
     } else if (state.phase === "reasoning") {
       events.push(...emitReasoningTextDone(state));
       events.push(...emitReasoningItemDone(state));
       state.outputIndex++;
       state.phase = "text";
-      events.push(...emitOutputItemAdded(state, "message"));
-      events.push(...emitContentPartAdded(state, state.messageId, "output_text"));
+      if (!state.bufferContentForToolParse) {
+        events.push(...emitOutputItemAdded(state, "message"));
+        events.push(...emitContentPartAdded(state, state.messageId, "output_text"));
+      }
     }
     state.accumulatedText += delta.content;
-    events.push(...emitTextDeltasForItem(state, state.messageId, delta.content));
+    if (!state.bufferContentForToolParse) {
+      events.push(...emitTextDeltasForItem(state, state.messageId, delta.content));
+    }
   }
 
   // Tool call deltas
@@ -202,9 +216,7 @@ export function processStreamingChunk(state: StreamingConversionState, line: str
       if (fn && typeof fn.name === "string") {
         // If we have accumulated text, close the text item first
         if (state.phase === "text" && state.accumulatedText) {
-          events.push(...emitTextDone(state));
-          events.push(...emitOutputItemDone(state, "message"));
-          state.outputIndex++;
+          events.push(...closeBufferedOrStreamedTextPhase(state));
         }
         state.phase = "tool";
 
@@ -236,9 +248,7 @@ export function processStreamingChunk(state: StreamingConversionState, line: str
       events.push(...emitReasoningItemDone(state));
       state.outputIndex++;
     } else if (state.phase === "text") {
-      events.push(...emitTextDone(state));
-      events.push(...emitOutputItemDone(state, "message"));
-      state.outputIndex++;
+      events.push(...closeBufferedOrStreamedTextPhase(state));
     } else if (state.phase === "tool") {
       // Defer tool close until [DONE] so trailing argument deltas after finish_reason are included.
       state.toolsPendingClose = true;
@@ -289,6 +299,54 @@ export function createSseLineBuffer(callback: (line: string) => void): {
 /* -------------------------------------------------------------------------- */
 /*  Internal helpers                                                          */
 /* -------------------------------------------------------------------------- */
+
+/**
+ * Close the text phase. When buffering for LongCat XML tool calls, rewrite
+ * accumulated text into cleaned content + function_call items before emitting.
+ */
+function closeBufferedOrStreamedTextPhase(state: StreamingConversionState): string[] {
+  const events: string[] = [];
+
+  if (state.bufferContentForToolParse) {
+    const { content, toolCalls } = extractLongcatToolCalls(state.accumulatedText);
+    state.accumulatedText = content;
+
+    if (content.length > 0) {
+      events.push(...emitOutputItemAdded(state, "message"));
+      events.push(...emitContentPartAdded(state, state.messageId, "output_text"));
+      events.push(...emitTextDeltasForItem(state, state.messageId, content));
+      events.push(...emitTextDone(state));
+      events.push(...emitOutputItemDone(state, "message"));
+      state.outputIndex++;
+    }
+
+    if (toolCalls.length > 0) {
+      state.phase = "tool";
+      for (let i = 0; i < toolCalls.length; i++) {
+        const tc = toolCalls[i];
+        const tcIndex = state.toolCalls.length;
+        state.toolCalls[tcIndex] = {
+          id: `fc_${randomUUID().replace(/-/g, "")}`,
+          name: tc.function.name,
+          callId: tc.id,
+          arguments: tc.function.arguments,
+        };
+        events.push(...emitOutputItemAdded(state, "function_call", tcIndex));
+        if (tc.function.arguments.length > 0) {
+          events.push(...emitFunctionCallArgDeltas(state, tcIndex, tc.function.arguments));
+        }
+      }
+      state.toolsPendingClose = true;
+    }
+
+    return events;
+  }
+
+  events.push(...emitTextDone(state));
+  events.push(...emitOutputItemDone(state, "message"));
+  state.outputIndex++;
+  return events;
+}
 
 function sseLine(data: string): string {
   return `${data}\n\n`;
@@ -709,9 +767,11 @@ function flushCompletion(state: StreamingConversionState): string[] {
     state.outputIndex++;
     events.push(...emitResponseCompleted(state));
   } else if (state.phase === "text") {
-    events.push(...emitTextDone(state));
-    events.push(...emitOutputItemDone(state, "message"));
-    state.outputIndex++;
+    events.push(...closeBufferedOrStreamedTextPhase(state));
+    if (state.toolsPendingClose) {
+      events.push(...emitPendingToolCallCloseEvents(state));
+      state.toolsPendingClose = false;
+    }
     events.push(...emitResponseCompleted(state));
   } else if (state.phase === "tool") {
     events.push(...emitPendingToolCallCloseEvents(state));

--- a/packages/core/src/server/proxy/executor.ts
+++ b/packages/core/src/server/proxy/executor.ts
@@ -51,10 +51,12 @@ import {
 } from "../../converter";
 import {
   applyPlatformResponseTransforms,
+  applyPlatformChatResponseSanitize,
   applyAnthropicSseRowsPlatformTransform,
   matchAnthropicSseRule,
   parseAnthropicSseRows,
   serializeAnthropicSseRows,
+  platformBuffersChatContentForToolParse,
 } from "../../converter/platform-transforms";
 import type { ApiSurface } from "../../types";
 import type { RequestTask, ProxyResult } from "../../types";
@@ -1300,6 +1302,10 @@ export class ProxyExecutor {
 
       try {
         const openaiResponse = JSON.parse(responseBody) as OpenAIChatCompletionResponse;
+        applyPlatformChatResponseSanitize(
+          openaiResponse as unknown as Record<string, unknown>,
+          provider.baseUrl
+        );
         const anthropicResponse = convertResponseToAnthropic(
           openaiResponse,
           originalModel || "none"
@@ -1641,6 +1647,10 @@ export class ProxyExecutor {
           }
         }
         const openaiResponse = JSON.parse(jsonBody) as OpenAIChatCompletionResponse;
+        applyPlatformChatResponseSanitize(
+          openaiResponse as unknown as Record<string, unknown>,
+          provider.baseUrl
+        );
         const out = convertChatCompletionToResponses(
           openaiResponse,
           originalModel || "none",
@@ -1753,7 +1763,10 @@ export class ProxyExecutor {
     let firstChunkTime = 0;
     let totalBytes = 0;
 
-    const state = createStreamingState({ echo: task.originalResponsesEcho });
+    const state = createStreamingState({
+      echo: task.originalResponsesEcho,
+      bufferContentForToolParse: platformBuffersChatContentForToolParse(provider.baseUrl),
+    });
     const upstreamLog: Buffer[] = [];
 
     const processLine = (line: string): void => {

--- a/tests/unit/api/wizard-upstream.test.ts
+++ b/tests/unit/api/wizard-upstream.test.ts
@@ -1,5 +1,45 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { executeWizardEndpointTest, executeWizardProbeModels } from "@/api/wizardUpstream";
+import {
+  executeWizardEndpointTest,
+  executeWizardProbeModels,
+  resolveWizardApiKey,
+  setServer,
+} from "@/api/wizardUpstream";
+
+describe("resolveWizardApiKey", () => {
+  afterEach(() => {
+    setServer(null);
+  });
+
+  it("returns a non-masked apiKey as-is", () => {
+    expect(resolveWizardApiKey("sk-real", undefined)).toBe("sk-real");
+  });
+
+  it("resolves stored key when client sends a masked value", () => {
+    setServer({
+      getConfig: () => ({
+        providers: {
+          p1: { apiKey: "sk-stored-secret" },
+        },
+      }),
+    } as never);
+
+    expect(resolveWizardApiKey("sk-s************cret", "p1")).toBe("sk-stored-secret");
+  });
+
+  it("resolves stored key when apiKey is empty and providerId is set", () => {
+    setServer({
+      getConfig: () => ({
+        providers: {
+          p1: { apiKey: "sk-from-config" },
+        },
+      }),
+    } as never);
+
+    expect(resolveWizardApiKey("", "p1")).toBe("sk-from-config");
+    expect(resolveWizardApiKey(undefined, "p1")).toBe("sk-from-config");
+  });
+});
 
 describe("executeWizardProbeModels", () => {
   beforeEach(() => {
@@ -8,6 +48,7 @@ describe("executeWizardProbeModels", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    setServer(null);
   });
 
   it("returns model ids on 200 with OpenAI-style payload", async () => {
@@ -37,6 +78,33 @@ describe("executeWizardProbeModels", () => {
     });
     expect(r).toEqual({ ok: false, errorCode: "auth" });
   });
+
+  it("uses stored provider apiKey when client key is masked", async () => {
+    setServer({
+      getConfig: () => ({
+        providers: {
+          longcat: { apiKey: "sk-real-longcat" },
+        },
+      }),
+    } as never);
+
+    vi.mocked(fetch).mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify({ data: [{ id: "LongCat-2.0" }] })),
+    } as Response);
+
+    const r = await executeWizardProbeModels({
+      baseUrl: "https://api.longcat.chat/openai",
+      apiKey: "sk-r************cat",
+      providerId: "longcat",
+      providerType: "openai",
+    });
+    expect(r).toEqual({ ok: true, modelIds: ["LongCat-2.0"] });
+    const init = vi.mocked(fetch).mock.calls[0]?.[1];
+    expect(init?.headers).toMatchObject({
+      authorization: "Bearer sk-real-longcat",
+    });
+  });
 });
 
 describe("executeWizardEndpointTest", () => {
@@ -46,6 +114,7 @@ describe("executeWizardEndpointTest", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    setServer(null);
   });
 
   function jsonOkResponse(): Response {
@@ -104,6 +173,37 @@ describe("executeWizardEndpointTest", () => {
       pass: false,
       httpStatus: 401,
       detail: "auth",
+    });
+  });
+
+  it("uses stored provider apiKey for endpoint test when client key is masked", async () => {
+    setServer({
+      getConfig: () => ({
+        providers: {
+          p1: { apiKey: "sk-stored" },
+        },
+      }),
+    } as never);
+    vi.mocked(fetch).mockResolvedValue(jsonOkResponse());
+
+    const r = await executeWizardEndpointTest({
+      apiKey: "sk-s************ored",
+      providerId: "p1",
+      modelId: "gpt-4o",
+      variants: [
+        {
+          id: "v1",
+          name: "t",
+          baseUrl: "https://api.openai.com/v1",
+          providerType: "openai",
+        },
+      ],
+    });
+
+    expect(r.results[0]?.pass).toBe(true);
+    const init = vi.mocked(fetch).mock.calls[0]?.[1];
+    expect(init?.headers).toMatchObject({
+      authorization: "Bearer sk-stored",
     });
   });
 });

--- a/tests/unit/converter/adapters/openai-responses-to-chat.test.ts
+++ b/tests/unit/converter/adapters/openai-responses-to-chat.test.ts
@@ -5,8 +5,12 @@ import {
   isOpenAIResponsesRequest,
   extractResponsesEcho,
   extractFunctionToolsForEcho,
+  collectResponsesToolsRaw,
 } from "@/converter/adapters/openai-responses-to-chat";
-import { normalizeToolsForProvider } from "@/converter/platform-transforms";
+import {
+  normalizeToolsForProvider,
+  openaiChatStrictToolsSanitize,
+} from "@/converter/platform-transforms";
 
 describe("isOpenAIResponsesRequest", () => {
   it("is true for input string", () => {
@@ -252,6 +256,205 @@ describe("convertResponsesRequestToChatCompletions", () => {
     expect(request.reasoning_effort).toBe("medium");
     expect("reasoning" in request).toBe(false);
   });
+
+  it("collects tools from input additional_tools (Codex) and does not emit empty developer", () => {
+    const { request } = convertResponsesRequestToChatCompletions(
+      {
+        model: "m",
+        input: [
+          {
+            type: "additional_tools",
+            role: "developer",
+            tools: [
+              {
+                type: "custom",
+                name: "exec",
+                description: "Run JS",
+                format: { type: "grammar", syntax: "lark", definition: "start: SOURCE" },
+              },
+              {
+                type: "function",
+                name: "wait",
+                description: "Wait on exec cell",
+                parameters: {
+                  type: "object",
+                  properties: { cell_id: { type: "string" } },
+                  required: ["cell_id"],
+                },
+              },
+              {
+                type: "namespace",
+                name: "collaboration",
+                tools: [
+                  {
+                    type: "function",
+                    name: "spawn_agent",
+                    description: "Spawn agent",
+                    parameters: {
+                      type: "object",
+                      properties: {
+                        task_name: { type: "string" },
+                        message: { type: "string" },
+                      },
+                      required: ["task_name", "message"],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "list dirs" }],
+          },
+        ],
+      },
+      "/v1/responses"
+    );
+
+    expect(request.messages.every(m => m.content !== "")).toBe(true);
+    expect(request.messages.find(m => m.role === "developer")).toBeUndefined();
+    expect(request.messages).toEqual([{ role: "user", content: "list dirs" }]);
+
+    expect(request.tools).toHaveLength(3);
+    expect(request.tools?.[0]).toMatchObject({ type: "custom", name: "exec" });
+    expect(request.tools?.[1]).toMatchObject({
+      type: "function",
+      function: { name: "wait" },
+    });
+    expect(request.tools?.[2]).toMatchObject({
+      type: "function",
+      function: { name: "spawn_agent" },
+    });
+  });
+
+  it("merges top-level tools with additional_tools from input", () => {
+    const { request } = convertResponsesRequestToChatCompletions(
+      {
+        model: "m",
+        tools: [
+          {
+            type: "function",
+            name: "top_fn",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+        input: [
+          {
+            type: "additional_tools",
+            role: "developer",
+            tools: [
+              {
+                type: "function",
+                name: "extra_fn",
+                parameters: { type: "object", properties: {} },
+              },
+            ],
+          },
+          { type: "message", role: "user", content: "hi" },
+        ],
+      },
+      "/v1/responses"
+    );
+    expect(request.tools?.map(t => (t as { function?: { name?: string } }).function?.name)).toEqual(
+      ["top_fn", "extra_fn"]
+    );
+  });
+
+  it("maps assistant output_text history into chat message content", () => {
+    const { request } = convertResponsesRequestToChatCompletions(
+      {
+        model: "m",
+        input: [
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "hi" }],
+          },
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "hello from history" }],
+          },
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "again" }],
+          },
+        ],
+      },
+      "/v1/responses"
+    );
+    expect(request.messages).toEqual([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello from history" },
+      { role: "user", content: "again" },
+    ]);
+  });
+
+  it("shims additional_tools custom entries for GLM strictTools", () => {
+    const { request } = convertResponsesRequestToChatCompletions(
+      {
+        model: "glm-5.2",
+        input: [
+          {
+            type: "additional_tools",
+            role: "developer",
+            tools: [
+              {
+                type: "custom",
+                name: "exec",
+                description: "Run JS",
+                format: { type: "grammar", syntax: "lark", definition: "start: SOURCE" },
+              },
+            ],
+          },
+          { type: "message", role: "user", content: "run" },
+        ],
+      },
+      "/v1/responses"
+    );
+    const body = { ...request } as unknown as Record<string, unknown>;
+    openaiChatStrictToolsSanitize(body, "https://api.z.ai/v1");
+    const tools = body.tools as Record<string, unknown>[];
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({
+      type: "function",
+      function: {
+        name: "exec",
+        parameters: {
+          type: "object",
+          properties: {
+            input: {
+              type: "string",
+              description: "Freeform tool input.",
+            },
+          },
+          required: ["input"],
+        },
+      },
+    });
+    const fn = tools[0].function as { description?: string };
+    expect(fn.description).toContain("Run JS");
+  });
+});
+
+describe("collectResponsesToolsRaw", () => {
+  it("merges top-level and additional_tools", () => {
+    const got = collectResponsesToolsRaw({
+      tools: [{ type: "function", name: "a" }],
+      input: [
+        {
+          type: "additional_tools",
+          tools: [{ type: "function", name: "b" }],
+        },
+      ],
+    });
+    expect(got).toHaveLength(2);
+    expect((got[0] as { name?: string }).name).toBe("a");
+    expect((got[1] as { name?: string }).name).toBe("b");
+  });
 });
 
 describe("extractFunctionToolsForEcho", () => {
@@ -306,5 +509,30 @@ describe("extractResponsesEcho", () => {
     expect(echo.truncation).toBe("auto");
     expect(echo.store).toBe(false);
     expect(echo.tool_choice).toEqual({ type: "auto" });
+  });
+
+  it("echoes tools from input additional_tools when top-level tools are absent", () => {
+    const echo = extractResponsesEcho({
+      model: "m",
+      input: [
+        {
+          type: "additional_tools",
+          role: "developer",
+          tools: [
+            { type: "function", name: "wait", parameters: {} },
+            {
+              type: "namespace",
+              name: "collaboration",
+              tools: [{ type: "function", name: "spawn_agent", parameters: {} }],
+            },
+            { type: "custom", name: "exec" },
+          ],
+        },
+      ],
+    });
+    expect(echo.tools).toHaveLength(3);
+    expect((echo.tools[0] as { name?: string }).name).toBe("wait");
+    expect((echo.tools[1] as { name?: string }).name).toBe("spawn_agent");
+    expect((echo.tools[2] as { type?: string; name?: string }).name).toBe("exec");
   });
 });

--- a/tests/unit/converter/platform-transforms/index.test.ts
+++ b/tests/unit/converter/platform-transforms/index.test.ts
@@ -146,6 +146,8 @@ describe("matchHostedToolRuleForBaseUrl", () => {
     expect(r?.provider).toBe("longcat");
     expect(r?.anthropicSse).toBe("longcat-message-start-usage");
     expect(r?.anthropicSseStream).toBe(true);
+    expect(r?.chatResponseSanitize).toBe("longcat-xml-tool-calls");
+    expect(r?.strictTools).toBe(true);
   });
 });
 

--- a/tests/unit/converter/platform-transforms/longcat-chat-tool-calls.test.ts
+++ b/tests/unit/converter/platform-transforms/longcat-chat-tool-calls.test.ts
@@ -1,0 +1,248 @@
+/* eslint-disable @typescript-eslint/naming-convention -- OpenAI Chat Completions wire names */
+import { describe, it, expect } from "vitest";
+import {
+  extractLongcatToolCalls,
+  parseLongcatArgValue,
+  sanitizeLongcatChatCompletion,
+  applyPlatformChatResponseSanitize,
+  platformBuffersChatContentForToolParse,
+} from "@/converter/platform-transforms";
+import {
+  convertChatCompletionToResponses,
+  createStreamingState,
+  processStreamingChunk,
+} from "@/converter";
+import type { OpenAIChatCompletionResponse } from "@/converter/adapters/openai-chat-to-anthropic-response";
+
+const LONGCAT_BASE = "https://api.longcat.chat/openai/v1";
+
+describe("parseLongcatArgValue", () => {
+  it("parses JSON numbers, booleans, arrays, objects", () => {
+    expect(parseLongcatArgValue("10000")).toBe(10000);
+    expect(parseLongcatArgValue("true")).toBe(true);
+    expect(parseLongcatArgValue('["a","b"]')).toEqual(["a", "b"]);
+    expect(parseLongcatArgValue('{"x":1}')).toEqual({ x: 1 });
+  });
+
+  it("keeps plain strings", () => {
+    expect(parseLongcatArgValue("ls -la ~/Documents")).toBe("ls -la ~/Documents");
+  });
+});
+
+describe("extractLongcatToolCalls", () => {
+  it("extracts function name and arg key/value pairs", () => {
+    const text = `<longcat_tool_call>exec
+<longcat_arg_key>command</longcat_arg_key>
+<longcat_arg_value>ls -la ~/Documents | grep -P '[\\x{4e00}-\\x{9fff}]'</longcat_arg_value>
+<longcat_arg_key>timeout</longcat_arg_key>
+<longcat_arg_value>10000</longcat_arg_value>
+</longcat_tool_call>
+`;
+    const { content, toolCalls } = extractLongcatToolCalls(text);
+    expect(content).toBe("");
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0].type).toBe("function");
+    expect(toolCalls[0].function.name).toBe("exec");
+    expect(JSON.parse(toolCalls[0].function.arguments)).toEqual({
+      command: "ls -la ~/Documents | grep -P '[\\x{4e00}-\\x{9fff}]'",
+      timeout: 10000,
+    });
+  });
+
+  it("preserves preamble text before tool calls", () => {
+    const text = `Looking that up now.
+<longcat_tool_call>wait
+<longcat_arg_key>cell_id</longcat_arg_key>
+<longcat_arg_value>abc</longcat_arg_value>
+</longcat_tool_call>`;
+    const { content, toolCalls } = extractLongcatToolCalls(text);
+    expect(content).toBe("Looking that up now.");
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0].function.name).toBe("wait");
+  });
+
+  it("supports multiple tool call blocks", () => {
+    const text = `<longcat_tool_call>a
+<longcat_arg_key>x</longcat_arg_key>
+<longcat_arg_value>1</longcat_arg_value>
+</longcat_tool_call>
+<longcat_tool_call>b
+<longcat_arg_key>y</longcat_arg_key>
+<longcat_arg_value>2</longcat_arg_value>
+</longcat_tool_call>`;
+    const { toolCalls } = extractLongcatToolCalls(text);
+    expect(toolCalls.map(t => t.function.name)).toEqual(["a", "b"]);
+  });
+
+  it("returns original text when no tags", () => {
+    expect(extractLongcatToolCalls("hello")).toEqual({ content: "hello", toolCalls: [] });
+  });
+});
+
+describe("sanitizeLongcatChatCompletion", () => {
+  it("lifts XML into tool_calls and sets finish_reason", () => {
+    const body: Record<string, unknown> = {
+      id: "chatcmpl_1",
+      object: "chat.completion",
+      created: 1,
+      model: "LongCat-2.0",
+      choices: [
+        {
+          index: 0,
+          finish_reason: "stop",
+          message: {
+            role: "assistant",
+            content: `<longcat_tool_call>exec
+<longcat_arg_key>command</longcat_arg_key>
+<longcat_arg_value>echo hi</longcat_arg_value>
+</longcat_tool_call>`,
+          },
+        },
+      ],
+    };
+    sanitizeLongcatChatCompletion(body);
+    const choice = (body.choices as Record<string, unknown>[])[0];
+    const message = choice.message as Record<string, unknown>;
+    expect(message.content).toBeNull();
+    expect(choice.finish_reason).toBe("tool_calls");
+    const toolCalls = message.tool_calls as {
+      function: { name: string; arguments: string };
+    }[];
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0].function.name).toBe("exec");
+    expect(JSON.parse(toolCalls[0].function.arguments)).toEqual({ command: "echo hi" });
+  });
+});
+
+describe("applyPlatformChatResponseSanitize", () => {
+  it("applies for LongCat baseUrl", () => {
+    const body: Record<string, unknown> = {
+      choices: [
+        {
+          finish_reason: "stop",
+          message: {
+            role: "assistant",
+            content: `<longcat_tool_call>spawn_agent
+<longcat_arg_key>task_name</longcat_arg_key>
+<longcat_arg_value>t1</longcat_arg_value>
+<longcat_arg_key>message</longcat_arg_key>
+<longcat_arg_value>go</longcat_arg_value>
+</longcat_tool_call>`,
+          },
+        },
+      ],
+    };
+    applyPlatformChatResponseSanitize(body, LONGCAT_BASE);
+    const msg = (body.choices as Record<string, unknown>[])[0].message as Record<string, unknown>;
+    expect((msg.tool_calls as unknown[]).length).toBe(1);
+  });
+
+  it("no-ops for unknown hosts", () => {
+    const body: Record<string, unknown> = {
+      choices: [
+        {
+          finish_reason: "stop",
+          message: {
+            role: "assistant",
+            content: `<longcat_tool_call>exec
+<longcat_arg_key>command</longcat_arg_key>
+<longcat_arg_value>x</longcat_arg_value>
+</longcat_tool_call>`,
+          },
+        },
+      ],
+    };
+    applyPlatformChatResponseSanitize(body, "https://api.openai.com/v1");
+    const msg = (body.choices as Record<string, unknown>[])[0].message as Record<string, unknown>;
+    expect(msg.tool_calls).toBeUndefined();
+    expect(typeof msg.content).toBe("string");
+  });
+
+  it("platformBuffersChatContentForToolParse matches LongCat only", () => {
+    expect(platformBuffersChatContentForToolParse(LONGCAT_BASE)).toBe(true);
+    expect(platformBuffersChatContentForToolParse("https://api.openai.com/v1")).toBe(false);
+  });
+});
+
+describe("LongCat Chat → Responses conversion", () => {
+  it("produces function_call output items instead of XML output_text", () => {
+    const chat: OpenAIChatCompletionResponse = {
+      id: "chatcmpl_x",
+      object: "chat.completion",
+      created: 1,
+      model: "LongCat-2.0",
+      choices: [
+        {
+          index: 0,
+          finish_reason: "stop",
+          message: {
+            role: "assistant",
+            content: `<longcat_tool_call>exec
+<longcat_arg_key>command</longcat_arg_key>
+<longcat_arg_value>ls</longcat_arg_value>
+<longcat_arg_key>timeout</longcat_arg_key>
+<longcat_arg_value>10000</longcat_arg_value>
+</longcat_tool_call>`,
+          },
+        },
+      ],
+    };
+    applyPlatformChatResponseSanitize(chat as unknown as Record<string, unknown>, LONGCAT_BASE);
+    const out = convertChatCompletionToResponses(chat, "LongCat-2.0");
+    const fcs = out.output.filter(
+      (o): o is Record<string, unknown> =>
+        !!o && typeof o === "object" && (o as { type?: string }).type === "function_call"
+    );
+    expect(fcs).toHaveLength(1);
+    expect(fcs[0].name).toBe("exec");
+    expect(JSON.parse(String(fcs[0].arguments))).toEqual({ command: "ls", timeout: 10000 });
+    const msgs = out.output.filter(
+      (o): o is Record<string, unknown> =>
+        !!o && typeof o === "object" && (o as { type?: string }).type === "message"
+    );
+    expect(msgs).toHaveLength(0);
+  });
+});
+
+describe("LongCat streaming Chat → Responses", () => {
+  it("buffers content and emits function_call at finish", () => {
+    const state = createStreamingState({ bufferContentForToolParse: true });
+    const xml = `<longcat_tool_call>exec
+<longcat_arg_key>command</longcat_arg_key>
+<longcat_arg_value>pwd</longcat_arg_value>
+</longcat_tool_call>`;
+
+    let events = processStreamingChunk(
+      state,
+      JSON.stringify({
+        id: "1",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "LongCat-2.0",
+        choices: [{ index: 0, delta: { role: "assistant", content: xml }, finish_reason: null }],
+      })
+    );
+    // Buffered: should not stream raw XML as output_text.delta
+    expect(events.join("")).not.toContain("response.output_text.delta");
+    expect(events.join("")).not.toContain("longcat_tool_call");
+
+    events = processStreamingChunk(
+      state,
+      JSON.stringify({
+        id: "1",
+        object: "chat.completion.chunk",
+        created: 1,
+        model: "LongCat-2.0",
+        choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      })
+    );
+    expect(events.join("")).toContain("function_call");
+    expect(events.join("")).toContain('"name":"exec"');
+
+    const done = processStreamingChunk(state, "[DONE]");
+    const all = done.join("");
+    expect(all).toContain("response.function_call_arguments.done");
+    expect(all).toContain("response.completed");
+    expect(all).not.toContain("longcat_tool_call");
+  });
+});

--- a/tests/unit/web/presets-display.test.ts
+++ b/tests/unit/web/presets-display.test.ts
@@ -29,6 +29,10 @@ describe("upstreamModelIdToDisplayName", () => {
     expect(upstreamModelIdToDisplayName("deepseek-v4-pro")).toBe("DeepSeek V4 Pro");
     expect(upstreamModelIdToDisplayName("deepseek-v4-flash")).toBe("DeepSeek V4 Flash");
   });
+
+  it("formats LongCat model ids", () => {
+    expect(upstreamModelIdToDisplayName("LongCat-2.0")).toBe("LongCat 2.0");
+  });
 });
 
 describe("defaultModelIdsAsText", () => {
@@ -37,6 +41,12 @@ describe("defaultModelIdsAsText", () => {
     expect(p).toBeDefined();
     const text = defaultModelIdsAsText(p!);
     expect(text).toBe("glm-5.1;GLM 5.1\nglm-5-turbo;GLM 5 Turbo\nglm-4.7;GLM 4.7");
+  });
+
+  it("expands LongCat preset with explicit display name", () => {
+    const p = getPresetById("longcat");
+    expect(p).toBeDefined();
+    expect(defaultModelIdsAsText(p!)).toBe("LongCat-2.0;LongCat 2.0");
   });
 
   it("keeps explicit display name after semicolon", () => {

--- a/tests/unit/web/wizard-engine.test.ts
+++ b/tests/unit/web/wizard-engine.test.ts
@@ -446,6 +446,34 @@ describe("generateProviders", () => {
     expect(out[1].id).toBe("company-glm-intl-openai");
     expect(new Set(out.map(p => p.id)).size).toBe(2);
   });
+
+  it("generates LongCat OpenAI and Anthropic providers with fixed endpoints", () => {
+    const preset = getPresetById("longcat");
+    if (!preset) {
+      throw new Error("preset longcat");
+    }
+    const out = generateProviders(preset, {
+      selections: initSelections(preset),
+      apiKey: "lc-key",
+      modelIds: ["LongCat-2.0"],
+      claudeSupport: true,
+      useCustomModels: true,
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({
+      id: "longcat-openai",
+      providerType: "openai_chat",
+      baseUrl: "https://api.longcat.chat/openai",
+      apiKey: "lc-key",
+    });
+    expect(out[1]).toMatchObject({
+      id: "longcat-anthropic",
+      providerType: "anthropic",
+      baseUrl: "https://api.longcat.chat/anthropic",
+      apiKey: "lc-key",
+    });
+    expect(out[0].customModelsList?.[0]).toMatch(/^LongCat-2\.0;/);
+  });
 });
 
 describe("slugifyProviderId", () => {

--- a/web/src/features/providers/Providers.tsx
+++ b/web/src/features/providers/Providers.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useState, useRef, useCallback } from "react";
+import { useState, useRef, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Check,
@@ -44,8 +44,14 @@ import type { AliasHashProtocol } from "@ccrelay/shared/aliasHash";
 import { api } from "@/api/client";
 import type { AddProviderRequest, Provider, ModelMapEntry } from "@/types/api";
 import { WizardDialog } from "./wizard/WizardDialog";
+import { WizardEndpointTest } from "./wizard/WizardEndpointTest";
+import { useUpstreamModels } from "./wizard/useUpstreamModels";
+import type { TestVariantInput } from "./wizard/useEndpointTest";
 import { CoworkAliasHelper } from "./CoworkAliasHelper";
 
+function looksLikeMaskedApiKey(apiKey: string | undefined): boolean {
+  return typeof apiKey === "string" && apiKey.includes("************");
+}
 const PROVIDER_PROTOCOL_LABEL: Record<string, { label: string; className: string }> = {
   anthropic: { label: "providers.protocol.anthropic", className: "bg-indigo-500 text-white" },
   openai: { label: "providers.protocol.openai", className: "bg-emerald-600 text-white" },
@@ -155,6 +161,88 @@ export default function Providers() {
   const srEnabled = config?.smartRouting?.enabled === true;
   const aliasPrefix = config?.smartRouting?.aliasPrefix ?? "claude-";
   const coworkHelperReady = formData.id.trim().length > 0 && Boolean(formData.providerType);
+
+  const endpointTestApiKey = useMemo(() => {
+    const key = formData.apiKey ?? "";
+    return looksLikeMaskedApiKey(key) ? "" : key;
+  }, [formData.apiKey]);
+
+  const endpointTestProviderId = useMemo(() => {
+    if (!editingProvider) {
+      return undefined;
+    }
+    if (endpointTestApiKey.trim()) {
+      return undefined;
+    }
+    return editingProvider.id;
+  }, [editingProvider, endpointTestApiKey]);
+
+  const probeProviderType = useMemo(() => {
+    const pt = formData.providerType;
+    if (pt === "anthropic" || pt === "openai" || pt === "openai_chat") {
+      return pt;
+    }
+    return "openai" as const;
+  }, [formData.providerType]);
+
+  const upstreamProbeEnabled =
+    showAddModal &&
+    formData.useCustomModelsList !== true &&
+    Boolean(formData.baseUrl.trim()) &&
+    (Boolean(endpointTestApiKey.trim()) || Boolean(endpointTestProviderId));
+
+  const upstreamModels = useUpstreamModels(
+    formData.baseUrl,
+    endpointTestApiKey,
+    probeProviderType,
+    upstreamProbeEnabled,
+    endpointTestProviderId
+  );
+
+  const customFirstModelId = useMemo(() => {
+    const first = customModelsText
+      .split("\n")
+      .map(l => l.trim())
+      .find(l => l.length > 0);
+    if (!first) {
+      return null;
+    }
+    const i = first.indexOf(";");
+    if (i === -1) {
+      return first;
+    }
+    const id = first.slice(0, i).trim();
+    return id.length > 0 ? id : null;
+  }, [customModelsText]);
+
+  const testVariants: TestVariantInput[] | null = useMemo(() => {
+    if (!showAddModal) {
+      return null;
+    }
+    const pt = formData.providerType;
+    if (pt !== "anthropic" && pt !== "openai" && pt !== "openai_chat") {
+      return null;
+    }
+    if (!formData.baseUrl.trim() || !formData.id.trim()) {
+      return null;
+    }
+    return [
+      {
+        id: formData.id.trim(),
+        name: formData.name.trim() || formData.id.trim(),
+        baseUrl: formData.baseUrl.trim(),
+        providerType: pt,
+        authHeader: formData.authHeader,
+      },
+    ];
+  }, [
+    showAddModal,
+    formData.id,
+    formData.name,
+    formData.baseUrl,
+    formData.providerType,
+    formData.authHeader,
+  ]);
 
   const { data: catalog, isLoading: catalogLoading } = useQuery({
     queryKey: ["smartRoutingCatalog"],
@@ -1305,30 +1393,42 @@ export default function Providers() {
             </CardContent>
 
             {/* Modal Footer */}
-            <div className="border-t px-4 pt-4 pb-5 flex-shrink-0 flex justify-end gap-2">
-              <Button size="sm" variant="outline" className="h-7 text-xs" onClick={closeModal}>
-                {t("common.cancel")}
-              </Button>
-              <Button
-                size="sm"
-                className="h-7 text-xs"
-                onClick={handleAddSubmit}
-                disabled={
-                  saveProviderMutation.isPending ||
-                  !formData.id ||
-                  !formData.name ||
-                  !formData.baseUrl ||
-                  (formData.modelMappingEnabled !== false && !!modelMapError)
-                }
-              >
-                {saveProviderMutation.isPending ? (
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                ) : editingProvider ? (
-                  t("common.save")
-                ) : (
-                  t("providers.modal.submitAdd")
-                )}
-              </Button>
+            <div className="border-t px-4 pt-4 pb-5 flex-shrink-0 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <WizardEndpointTest
+                wizardOpen={showAddModal}
+                variants={testVariants}
+                apiKey={endpointTestApiKey}
+                providerId={endpointTestProviderId}
+                useCustomModels={formData.useCustomModelsList === true}
+                customFirstModelId={customFirstModelId}
+                probeModels={formData.useCustomModelsList === true ? null : upstreamModels.models}
+                disabled={saveProviderMutation.isPending}
+              />
+              <div className="flex w-full shrink-0 flex-wrap justify-end gap-2 sm:w-auto">
+                <Button size="sm" variant="outline" className="h-7 text-xs" onClick={closeModal}>
+                  {t("common.cancel")}
+                </Button>
+                <Button
+                  size="sm"
+                  className="h-7 text-xs"
+                  onClick={handleAddSubmit}
+                  disabled={
+                    saveProviderMutation.isPending ||
+                    !formData.id ||
+                    !formData.name ||
+                    !formData.baseUrl ||
+                    (formData.modelMappingEnabled !== false && !!modelMapError)
+                  }
+                >
+                  {saveProviderMutation.isPending ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : editingProvider ? (
+                    t("common.save")
+                  ) : (
+                    t("providers.modal.submitAdd")
+                  )}
+                </Button>
+              </div>
             </div>
           </Card>
         </div>

--- a/web/src/features/providers/providerSortOrder.ts
+++ b/web/src/features/providers/providerSortOrder.ts
@@ -8,6 +8,7 @@ export const PARTNER_PRESET_DISPLAY_ORDER = [
   "xiaomi",
   "deepseek",
   "minimax",
+  "longcat",
   "azure-openai",
   "gemini-openai",
   "astraflow",

--- a/web/src/features/providers/wizard/WizardEndpointTest.tsx
+++ b/web/src/features/providers/wizard/WizardEndpointTest.tsx
@@ -18,6 +18,8 @@ export interface WizardEndpointTestProps {
   wizardOpen?: boolean;
   variants: TestVariantInput[] | null;
   apiKey: string;
+  /** When apiKey is missing/masked, server resolves the stored secret. */
+  providerId?: string;
   useCustomModels: boolean;
   /** First non-empty model line when custom list is on */
   customFirstModelId: string | null;
@@ -61,6 +63,7 @@ export function WizardEndpointTest({
   wizardOpen = true,
   variants,
   apiKey,
+  providerId,
   useCustomModels,
   customFirstModelId,
   probeModels,
@@ -98,9 +101,11 @@ export function WizardEndpointTest({
     setPrevWizardOpen(wizardOpen);
   }
 
+  const hasAuth = Boolean(apiKey.trim()) || Boolean(providerId?.trim());
+
   const canClickTest =
     Boolean(variants?.length) &&
-    Boolean(apiKey.trim()) &&
+    hasAuth &&
     !disabled &&
     state.phase !== "testing" &&
     (useCustomModels
@@ -127,14 +132,15 @@ export function WizardEndpointTest({
       runTest({
         variants,
         apiKey,
+        providerId,
         modelId: modelId.trim(),
       });
     },
-    [variants, apiKey, runTest]
+    [variants, apiKey, providerId, runTest]
   );
 
   const handleTestClick = useCallback(() => {
-    if (!variants?.length || !apiKey.trim()) {
+    if (!variants?.length || !hasAuth) {
       return;
     }
     if (useCustomModels) {
@@ -157,7 +163,7 @@ export function WizardEndpointTest({
     setModelPickerOpen(true);
   }, [
     variants,
-    apiKey,
+    hasAuth,
     useCustomModels,
     customFirstModelId,
     probeModels,

--- a/web/src/features/providers/wizard/presets.ts
+++ b/web/src/features/providers/wizard/presets.ts
@@ -12,6 +12,7 @@ const VENDOR_DISPLAY: Record<string, string> = {
   claude: "Claude",
   llama: "Llama",
   qwen: "Qwen",
+  longcat: "LongCat",
 };
 
 /**
@@ -445,6 +446,32 @@ const PARTNER_PRESETS_LIST: PartnerPreset[] = [
       {
         providerType: "anthropic",
         urlTemplate: "https://api.deepseek.com/anthropic",
+        idSuffix: "anthropic",
+        nameSuffix: "-Anthropic",
+      },
+    ],
+  },
+  {
+    id: "longcat",
+    nameKey: "wizard.brand.longcat",
+    mode: "inject",
+    idPrefix: "longcat",
+    namePrefix: "LongCat",
+    defaultModelIds: ["LongCat-2.0;LongCat 2.0"],
+    defaultCustomModels: true,
+    authHeader: "authorization",
+    options: [],
+    segmentRules: [],
+    variants: [
+      {
+        providerType: "openai_chat",
+        urlTemplate: "https://api.longcat.chat/openai",
+        idSuffix: "openai",
+        nameSuffix: "-OpenAI",
+      },
+      {
+        providerType: "anthropic",
+        urlTemplate: "https://api.longcat.chat/anthropic",
         idSuffix: "anthropic",
         nameSuffix: "-Anthropic",
       },

--- a/web/src/features/providers/wizard/useEndpointTest.ts
+++ b/web/src/features/providers/wizard/useEndpointTest.ts
@@ -29,6 +29,8 @@ export interface RunEndpointTestParams {
   variants: TestVariantInput[];
   apiKey: string;
   modelId: string;
+  /** When apiKey is missing/masked, server resolves the stored secret. */
+  providerId?: string;
 }
 
 export function shortLabel(name: string, id: string): string {
@@ -63,8 +65,11 @@ export function useEndpointTest(): {
 
   const runTest = useCallback(
     (params: RunEndpointTestParams) => {
-      const { variants, apiKey, modelId } = params;
+      const { variants, apiKey, modelId, providerId } = params;
       if (!modelId.trim() || variants.length === 0) {
+        return;
+      }
+      if (!apiKey.trim() && !providerId?.trim()) {
         return;
       }
 
@@ -87,7 +92,8 @@ export function useEndpointTest(): {
         try {
           const data = await api.wizardEndpointTest(
             {
-              apiKey,
+              apiKey: apiKey.trim() || undefined,
+              providerId: providerId?.trim() || undefined,
               modelId: modelId.trim(),
               variants,
             },

--- a/web/src/features/providers/wizard/useUpstreamModels.ts
+++ b/web/src/features/providers/wizard/useUpstreamModels.ts
@@ -16,9 +16,12 @@ export function useUpstreamModels(
   baseUrl: string,
   apiKey: string,
   providerType: "anthropic" | "openai" | "openai_chat",
-  enabled: boolean
+  enabled: boolean,
+  /** When apiKey is missing/masked, server resolves the stored secret. */
+  providerId?: string
 ): UpstreamModelsResult {
-  const canProbe = enabled && Boolean(baseUrl.trim()) && Boolean(apiKey.trim());
+  const canProbe =
+    enabled && Boolean(baseUrl.trim()) && (Boolean(apiKey.trim()) || Boolean(providerId?.trim()));
 
   const [result, setResult] = useState<UpstreamModelsResult>({
     loading: false,
@@ -50,8 +53,9 @@ export function useUpstreamModels(
         .wizardProbeModels(
           {
             baseUrl: baseUrl.trim(),
-            apiKey: apiKey.trim(),
+            apiKey: apiKey.trim() || undefined,
             providerType,
+            providerId: providerId?.trim() || undefined,
           },
           ac.signal
         )
@@ -86,7 +90,7 @@ export function useUpstreamModels(
       abortRef.current?.abort();
       abortRef.current = null;
     };
-  }, [canProbe, baseUrl, apiKey, providerType]);
+  }, [canProbe, baseUrl, apiKey, providerType, providerId]);
 
   if (!canProbe) {
     return { loading: false, models: null, errorCode: null };

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -469,6 +469,7 @@
       "xiaomi": "Xiaomi MiMo",
       "azure": "Azure OpenAI",
       "minimax": "MiniMax",
+      "longcat": "Meituan LongCat",
       "geminiOpenai": "Gemini (OpenAI-compatible)",
       "deepseek": "DeepSeek",
       "astraflow": "Astraflow (UCloud)"

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -468,9 +468,11 @@
       "xiaomi": "小米 MiMo",
       "azure": "Azure OpenAI",
       "minimax": "MiniMax",
+      "longcat": "美团 LongCat",
       "geminiOpenai": "Gemini（OpenAI 兼容）",
       "deepseek": "DeepSeek（深度求索）",
-      "astraflow": "Astraflow（优刻得）"
+      "astraflow": "Astraflow（优刻得）",
+      "tuningEngines": "Tuning Engines"
     },
     "toggle": {
       "off": "否",

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -522,8 +522,10 @@ export type WizardProviderType = "anthropic" | "openai" | "openai_chat";
 
 export interface WizardProbeModelsRequest {
   baseUrl: string;
-  apiKey: string;
+  apiKey?: string;
   providerType: WizardProviderType;
+  /** When apiKey is missing/masked, resolve the stored secret for this provider. */
+  providerId?: string;
 }
 
 export type WizardProbeModelsResponse =
@@ -539,7 +541,9 @@ export interface WizardEndpointVariantInput {
 }
 
 export interface WizardEndpointTestRequest {
-  apiKey: string;
+  apiKey?: string;
+  /** When apiKey is missing/masked, resolve the stored secret for this provider. */
+  providerId?: string;
   modelId: string;
   variants: WizardEndpointVariantInput[];
 }


### PR DESCRIPTION
## Summary
- Preserve tools and history when converting Responses → Chat (including `additional_tools` / `output_text`), and normalize LongCat XML tool calls into OpenAI `tool_calls`
- Add Meituan LongCat partner preset in the provider wizard
- Add endpoint/model test control to the edit-provider modal footer, resolving masked API keys server-side via `providerId`

## Test plan
- [ ] Run unit tests for Responses→Chat, LongCat tool-call sanitize, and wizard upstream key resolution
- [ ] Wizard: create LongCat providers from the partner preset and confirm endpoints/models
- [ ] Edit an existing provider with a stored (masked) API key and run Test without re-entering the key
- [ ] Edit provider after changing the API key and confirm Test uses the new key
- [ ] Responses client → LongCat Chat upstream: tools and history survive the round trip


Made with [Cursor](https://cursor.com)