### PR TITLE
chore: 0.2.9 pre-release version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-07-25 (pre-release)
+
+Pre-release line for 0.2.9.
+
+### Fixed
+
+**Protocol/Conversion**
+
+- Codex Responses traffic converted to Chat Completions no longer fails validation on Azure or Azure-compatible Chat gateways: `developer` roles map to `system`, freeform `custom` tools are shimmed to `function`, and `input_image` blocks are preserved as Chat `image_url` parts.
+- Custom-domain Azure-compatible routers (not only `*.cognitiveservices.azure.com`) can opt into the same Chat sanitization with provider field `openaiCompat: azure_openai`.
+
+### Changed
+
+**Config**
+
+- Provider field `openaiCompat` is active again for Azure Chat shaping on custom hostnames; official Azure Cognitive Services hosts remain auto-detected.
+
 ## [0.2.8] - 2026-07-24
 
 Gateway and Claude Code compatibility is tighter on Azure and similar Anthropic routes. Responses clients keep tools and history when upstream is Chat, and Meituan LongCat is easier to set up and use. Provider editing can test endpoints without re-entering a masked API key; GLM OpenAI hosted web search and the GLM web-search backend are gone.

--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ Each provider supports:
 | `baseUrl`      | —                 | API base URL                                                                             |
 | `mode`         | `"passthrough"`   | `passthrough` (keep auth) or `inject` (replace auth)                                     |
 | `providerType` | `"anthropic"`     | `"anthropic"`, `"openai"` (full passthrough), or `"openai_chat"` (Chat Completions only) |
+| `openaiCompat` | —                 | Optional. Set `azure_openai` for Azure Chat shaping on custom domains (official `*.cognitiveservices.azure.com` is auto-detected) |
 | `apiKey`       | —                 | API key for inject mode. Supports `${ENV_VAR}`.                                          |
 | `authHeader`   | `"authorization"` | Auth header name                                                                         |
 | `modelMap`     | —                 | Model name mappings (`[{pattern, model}]`, wildcards supported)                          |

--- a/README_CN.md
+++ b/README_CN.md
@@ -479,6 +479,7 @@ CCRelay 使用 `~/.ccrelay/config.yaml`（首次启动时自动创建）。启�
 | `baseUrl`      | —                 | API 基础 URL                                                                   |
 | `mode`         | `"passthrough"`   | `passthrough`（保留认证）或 `inject`（替换认证）                               |
 | `providerType` | `"anthropic"`     | `"anthropic"`、`"openai"`（完全透传）或 `"openai_chat"`（仅 Chat Completions） |
+| `openaiCompat` | —                 | 可选。自定义域名上的 Azure Chat 整形设为 `azure_openai`（官方 `*.cognitiveservices.azure.com` 会自动识别） |
 | `apiKey`       | —                 | inject 模式的 API Key。支持 `${ENV_VAR}`。                                     |
 | `authHeader`   | `"authorization"` | 认证头名称                                                                     |
 | `modelMap`     | —                 | 模型名映射（`[{pattern, model}]`，支持通配符）                                 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccrelay-monorepo",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccrelay-monorepo",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -10347,7 +10347,7 @@
     },
     "packages/core": {
       "name": "@ccrelay/core",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.1",
@@ -10405,7 +10405,7 @@
     },
     "packages/desktop": {
       "name": "ccrelay-desktop",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -10421,7 +10421,7 @@
     },
     "packages/desktop-tauri": {
       "name": "@ccrelay/desktop-tauri",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "hasInstallScript": true,
       "dependencies": {
         "@ccrelay/core": "*",
@@ -11117,7 +11117,7 @@
     },
     "packages/vscode": {
       "name": "ccrelay-vscode",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "MIT",
       "dependencies": {
         "@ccrelay/core": "*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "ccrelay-monorepo",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "license": "MIT",
   "packageManager": "npm@10.9.4",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ccrelay/core",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "description": "CCRelay proxy server core (Node.js)",
   "license": "MIT",

--- a/packages/core/src/api/providers.ts
+++ b/packages/core/src/api/providers.ts
@@ -74,6 +74,7 @@ export function handleListProviders(
     useCustomModelsList: Boolean(p.useCustomModelsList),
     customModelsList: p.useCustomModelsList ? (p.customModelsList ?? []) : undefined,
     webSearchEnabled: webSearchProviders.includes(p.id),
+    ...(p.openaiCompat !== undefined ? { openaiCompat: p.openaiCompat } : {}),
   }));
 
   const response: ProvidersResponse = {
@@ -437,7 +438,7 @@ interface AddProviderRequest {
   headers?: Record<string, string>;
   useCustomModelsList?: boolean;
   customModelsList?: string[];
-  /** @deprecated Ignored at runtime; accepted for backward-compatible YAML/API. */
+  /** @deprecated comment removed — when `azure_openai`, apply Azure Chat sanitization for custom domains. */
   openaiCompat?: "default" | "azure_openai";
 }
 

--- a/packages/core/src/converter/adapters/openai-responses-to-chat.ts
+++ b/packages/core/src/converter/adapters/openai-responses-to-chat.ts
@@ -6,6 +6,7 @@
 
 import type { ResponsesRequestEcho } from "../../types";
 import type {
+  OpenAIContent,
   OpenAIMessage,
   OpenAIMessageRequest,
   OpenAITool,
@@ -13,6 +14,7 @@ import type {
 } from "./anthropic-to-openai-chat-request";
 import { assignOpenAiChatMaxOutput } from "../rules/openai-chat-model-rules";
 import { normalizeOpenAiToolCallArgumentsString } from "../rules/openai-tool-call-arguments";
+import { customToFunctionShim } from "../platform-transforms/openai-chat-strict-tools";
 import { isOpenAIChatCompletionsRequest } from "./openai-chat-to-anthropic-request";
 
 /** Collect tools for Responses echo: `function` defs, nested `namespace` bundles (inner tools), and hosted tools (web_search, etc.). */
@@ -301,6 +303,20 @@ function mapResponsesToolChoice(tc: unknown): OpenAIToolChoice | undefined {
   return undefined;
 }
 
+function mapFunctionToolEntry(o: Record<string, unknown>): OpenAITool {
+  return {
+    type: "function",
+    function: {
+      name: typeof o.name === "string" ? o.name : "",
+      description: typeof o.description === "string" ? o.description : undefined,
+      parameters: (o.parameters as Record<string, unknown>) ?? {
+        type: "object",
+        properties: {},
+      },
+    },
+  };
+}
+
 function mapResponsesTools(tools: unknown): OpenAITool[] {
   if (!Array.isArray(tools)) {
     return [];
@@ -313,18 +329,10 @@ function mapResponsesTools(tools: unknown): OpenAITool[] {
     const o = t as Record<string, unknown>;
     const typ = o.type;
     if (typ === "function") {
-      const fnName = typeof o.name === "string" ? o.name : "";
-      out.push({
-        type: "function",
-        function: {
-          name: fnName,
-          description: typeof o.description === "string" ? o.description : undefined,
-          parameters: (o.parameters as Record<string, unknown>) ?? {
-            type: "object",
-            properties: {},
-          },
-        },
-      });
+      out.push(mapFunctionToolEntry(o));
+    } else if (typ === "custom") {
+      // Chat Completions has no `custom` tools — always shim to string-arg function.
+      out.push(customToFunctionShim(o) as OpenAITool);
     } else if (typ === "namespace" && Array.isArray(o.tools)) {
       for (const inner of o.tools as unknown[]) {
         if (!inner || typeof inner !== "object") {
@@ -333,18 +341,9 @@ function mapResponsesTools(tools: unknown): OpenAITool[] {
         const inn = inner as Record<string, unknown>;
         const it = inn.type;
         if (it === "function") {
-          const f = inner as { name?: string; description?: string; parameters?: unknown };
-          out.push({
-            type: "function",
-            function: {
-              name: String(f.name ?? ""),
-              description: typeof f.description === "string" ? f.description : undefined,
-              parameters: (f.parameters as Record<string, unknown>) ?? {
-                type: "object",
-                properties: {},
-              },
-            },
-          });
+          out.push(mapFunctionToolEntry(inn));
+        } else if (it === "custom") {
+          out.push(customToFunctionShim(inn) as OpenAITool);
         } else if (typeof it === "string") {
           out.push(inn as OpenAITool);
         }
@@ -383,6 +382,73 @@ function mapEasyMessageContentToText(content: unknown): string | undefined {
 }
 
 /**
+ * Map Responses message content to Chat Completions content (string or multimodal parts).
+ * Preserves `input_image` as `image_url` so vision requests survive Responses→Chat.
+ */
+function mapEasyMessageContent(content: unknown): string | OpenAIContent[] | undefined {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return undefined;
+  }
+
+  const parts: OpenAIContent[] = [];
+  let hasImage = false;
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const b = block as {
+      type?: string;
+      text?: string;
+      image_url?: string | { url?: string };
+    };
+    if (
+      (b.type === "input_text" || b.type === "output_text" || b.type === "text") &&
+      typeof b.text === "string"
+    ) {
+      parts.push({ type: "text", text: b.text });
+      continue;
+    }
+    if (b.type === "input_image") {
+      let url: string | undefined;
+      if (typeof b.image_url === "string") {
+        url = b.image_url;
+      } else if (
+        b.image_url &&
+        typeof b.image_url === "object" &&
+        typeof b.image_url.url === "string"
+      ) {
+        url = b.image_url.url;
+      }
+      if (url) {
+        hasImage = true;
+        parts.push({ type: "image_url", image_url: { url } });
+      }
+    }
+  }
+
+  if (parts.length === 0) {
+    return undefined;
+  }
+  if (!hasImage && parts.every(p => p.type === "text")) {
+    return parts
+      .filter((p): p is { type: "text"; text: string } => p.type === "text")
+      .map(p => p.text)
+      .join("\n");
+  }
+  return parts;
+}
+
+function messageContentIsEmpty(content: string | OpenAIContent[]): boolean {
+  if (typeof content === "string") {
+    return content.length === 0;
+  }
+  return content.length === 0;
+}
+
+/**
  * Map Responses `input` array into Chat `messages` (subset of item types).
  */
 function appendInputItemsToMessages(items: unknown[], messages: OpenAIMessage[]): void {
@@ -411,22 +477,16 @@ function appendInputItemsToMessages(items: unknown[], messages: OpenAIMessage[])
       const role = o.role;
       const r = typeof role === "string" ? role : "user";
       if (r === "user" || r === "system" || r === "developer" || r === "assistant") {
-        const text =
-          mapEasyMessageContentToText(o.content) ??
-          (typeof o.content === "string" ? o.content : "");
+        const mapped =
+          mapEasyMessageContent(o.content) ?? (typeof o.content === "string" ? o.content : "");
+        // Chat Completions gateways (Azure and many routers) reject `developer`.
         const oaiRole: OpenAIMessage["role"] =
-          r === "developer"
-            ? "developer"
-            : r === "system"
-              ? "system"
-              : r === "assistant"
-                ? "assistant"
-                : "user";
-        // Skip empty assistant/developer/system placeholders (e.g. unmapped content types).
-        if (!text && oaiRole !== "user") {
+          r === "developer" || r === "system" ? "system" : r === "assistant" ? "assistant" : "user";
+        // Skip empty assistant/system placeholders (e.g. unmapped content types).
+        if (messageContentIsEmpty(mapped) && oaiRole !== "user") {
           continue;
         }
-        messages.push({ role: oaiRole, content: text });
+        messages.push({ role: oaiRole, content: mapped });
       }
       continue;
     }

--- a/packages/core/src/converter/platform-transforms/azure-openai/chat-sanitize.ts
+++ b/packages/core/src/converter/platform-transforms/azure-openai/chat-sanitize.ts
@@ -1,6 +1,6 @@
 /**
- * Azure OpenAI Chat Completions: strip fields the upstream rejects when relaying
- * from Anthropic-shaped cross-protocol conversion.
+ * Azure OpenAI Chat Completions: strip / rewrite fields the upstream rejects when
+ * relaying from Responses, Anthropic, or Codex-shaped conversion.
  */
 
 function stripCacheControlFromContent(content: unknown): unknown {
@@ -18,6 +18,11 @@ function stripCacheControlFromContent(content: unknown): unknown {
 }
 
 function sanitizeMessageRecord(msg: Record<string, unknown>): void {
+  // Azure Chat Completions OpenAPI enum: system | user | assistant | tool.
+  if (msg.role === "developer") {
+    msg.role = "system";
+  }
+
   delete msg.thinking;
   msg.content = stripCacheControlFromContent(msg.content);
 
@@ -34,7 +39,8 @@ function sanitizeMessageRecord(msg: Record<string, unknown>): void {
 
 /**
  * Strip legacy nested `reasoning`, message `thinking`, `cache_control` on content parts,
- * and `extra_content` on tool_calls. Top-level `reasoning_effort` (Chat Completions wire) is kept.
+ * and `extra_content` on tool_calls. Map `developer` → `system`. Top-level
+ * `reasoning_effort` (Chat Completions wire) is kept.
  */
 export function azureChatSanitize(data: Record<string, unknown>): void {
   delete data.reasoning;

--- a/packages/core/src/converter/platform-transforms/index.ts
+++ b/packages/core/src/converter/platform-transforms/index.ts
@@ -6,13 +6,8 @@ import type { AnthropicSseEventRow } from "./glm/anthropic-sse-emitter";
 
 import type { OpenAIMessage } from "../adapters/anthropic-to-openai-chat-request";
 import type { AnthropicContentBlock } from "../adapters/openai-chat-to-anthropic-response";
-import { normalizedHostnameFromBaseUrl } from "./hostname";
-import { ruleHostnameMatches } from "./ruleHostname";
-import {
-  PLATFORM_TRANSFORM_RULES,
-  type HostedToolRule,
-  type PlatformRequestOverrideResult,
-} from "./rules";
+import { matchHostedToolRuleForBaseUrl, type PlatformMatchOptions } from "./matchRule";
+import { type HostedToolRule, type PlatformRequestOverrideResult } from "./rules";
 import {
   MESSAGE_TRANSFORM_REGISTRY,
   REQUEST_OVERRIDE_REGISTRY,
@@ -31,6 +26,9 @@ export type {
   PlatformRequestOverrideResult,
   PlatformRequestOverrideTransform,
 } from "./rules";
+
+export type { PlatformMatchOptions } from "./matchRule";
+export { matchHostedToolRuleForBaseUrl } from "./matchRule";
 
 export type {
   HostedToolTransform,
@@ -104,21 +102,7 @@ export interface PlatformOutboundQueryRouting {
   targetUrl: string;
   targetQuery: string;
   targetPath: string;
-  provider: { baseUrl: string };
-}
-
-/** First matching provider rule wins (preserve `PLATFORM_TRANSFORM_RULES` order). */
-export function matchHostedToolRuleForBaseUrl(baseUrl: string): HostedToolRule | undefined {
-  const hostname = normalizedHostnameFromBaseUrl(baseUrl);
-  if (!hostname) {
-    return undefined;
-  }
-  for (const rule of PLATFORM_TRANSFORM_RULES) {
-    if (ruleHostnameMatches(hostname, rule)) {
-      return rule;
-    }
-  }
-  return undefined;
+  provider: { baseUrl: string; openaiCompat?: PlatformMatchOptions["openaiCompat"] };
 }
 
 /**
@@ -126,7 +110,9 @@ export function matchHostedToolRuleForBaseUrl(baseUrl: string): HostedToolRule |
  * without a query string (hostname-driven; no provider-specific code in callers).
  */
 export function applyPlatformQueryPolicy(routing: PlatformOutboundQueryRouting): void {
-  const rule = matchHostedToolRuleForBaseUrl(routing.provider.baseUrl);
+  const rule = matchHostedToolRuleForBaseUrl(routing.provider.baseUrl, {
+    openaiCompat: routing.provider.openaiCompat,
+  });
   if (!rule?.stripQuery || !routing.targetQuery) {
     return;
   }
@@ -137,71 +123,39 @@ export function applyPlatformQueryPolicy(routing: PlatformOutboundQueryRouting):
 }
 
 /** Match first rule that declares outbound `responses` transforms. */
-function matchPlatformResponseRule(baseUrl: string): HostedToolRule | undefined {
-  const hostname = normalizedHostnameFromBaseUrl(baseUrl);
-  if (!hostname) {
-    return undefined;
-  }
-  for (const rule of PLATFORM_TRANSFORM_RULES) {
-    if (!rule.responses) {
-      continue;
-    }
-    if (ruleHostnameMatches(hostname, rule)) {
-      return rule;
-    }
-  }
-  return undefined;
+function matchPlatformResponseRule(
+  baseUrl: string,
+  options?: PlatformMatchOptions
+): HostedToolRule | undefined {
+  const rule = matchHostedToolRuleForBaseUrl(baseUrl, options);
+  return rule?.responses ? rule : undefined;
 }
 
 /** Match first rule that declares `messages` transforms. */
-function matchPlatformMessageRule(baseUrl: string): HostedToolRule | undefined {
-  const hostname = normalizedHostnameFromBaseUrl(baseUrl);
-  if (!hostname) {
-    return undefined;
-  }
-  for (const rule of PLATFORM_TRANSFORM_RULES) {
-    if (!rule.messages) {
-      continue;
-    }
-    if (ruleHostnameMatches(hostname, rule)) {
-      return rule;
-    }
-  }
-  return undefined;
+function matchPlatformMessageRule(
+  baseUrl: string,
+  options?: PlatformMatchOptions
+): HostedToolRule | undefined {
+  const rule = matchHostedToolRuleForBaseUrl(baseUrl, options);
+  return rule?.messages ? rule : undefined;
 }
 
 /** Match first rule that declares `requestOverride` transforms. */
-function matchRequestOverrideRule(baseUrl: string): HostedToolRule | undefined {
-  const hostname = normalizedHostnameFromBaseUrl(baseUrl);
-  if (!hostname) {
-    return undefined;
-  }
-  for (const rule of PLATFORM_TRANSFORM_RULES) {
-    if (!rule.requestOverride) {
-      continue;
-    }
-    if (ruleHostnameMatches(hostname, rule)) {
-      return rule;
-    }
-  }
-  return undefined;
+function matchRequestOverrideRule(
+  baseUrl: string,
+  options?: PlatformMatchOptions
+): HostedToolRule | undefined {
+  const rule = matchHostedToolRuleForBaseUrl(baseUrl, options);
+  return rule?.requestOverride ? rule : undefined;
 }
 
 /** Match first rule that declares inbound Anthropic SSE buffered transforms. */
-export function matchAnthropicSseRule(baseUrl: string): HostedToolRule | undefined {
-  const hostname = normalizedHostnameFromBaseUrl(baseUrl);
-  if (!hostname) {
-    return undefined;
-  }
-  for (const rule of PLATFORM_TRANSFORM_RULES) {
-    if (!rule.anthropicSse) {
-      continue;
-    }
-    if (ruleHostnameMatches(hostname, rule)) {
-      return rule;
-    }
-  }
-  return undefined;
+export function matchAnthropicSseRule(
+  baseUrl: string,
+  options?: PlatformMatchOptions
+): HostedToolRule | undefined {
+  const rule = matchHostedToolRuleForBaseUrl(baseUrl, options);
+  return rule?.anthropicSse ? rule : undefined;
 }
 
 /**
@@ -210,10 +164,11 @@ export function matchAnthropicSseRule(baseUrl: string): HostedToolRule | undefin
  */
 export function normalizeToolForProvider(
   tool: Record<string, unknown>,
-  baseUrl: string
+  baseUrl: string,
+  options?: PlatformMatchOptions
 ): Record<string, unknown> {
   const toolType = typeof tool.type === "string" ? tool.type : "";
-  const rule = matchHostedToolRuleForBaseUrl(baseUrl);
+  const rule = matchHostedToolRuleForBaseUrl(baseUrl, options);
   const transformName = rule?.tools?.[toolType] ?? "passthrough";
   const transform = TOOL_TRANSFORM_REGISTRY[transformName] ?? passthroughTransform;
   return transform(tool);
@@ -230,13 +185,14 @@ export interface NormalizeToolsResult {
 export function normalizeToolsForProvider(
   tools: Record<string, unknown>[],
   baseUrl: string,
-  toolChoice?: unknown
+  toolChoice?: unknown,
+  options?: PlatformMatchOptions
 ): NormalizeToolsResult {
   if (tools.length === 0) {
     return { tools, toolChoice };
   }
 
-  const normalized = tools.map(t => normalizeToolForProvider(t, baseUrl));
+  const normalized = tools.map(t => normalizeToolForProvider(t, baseUrl, options));
   return { tools: normalized, toolChoice };
 }
 
@@ -244,9 +200,10 @@ export function normalizeToolsForProvider(
 export function applyPlatformToolTransforms(
   tools: Record<string, unknown>[],
   baseUrl: string,
-  toolChoice?: unknown
+  toolChoice?: unknown,
+  options?: PlatformMatchOptions
 ): NormalizeToolsResult {
-  return normalizeToolsForProvider(tools, baseUrl, toolChoice);
+  return normalizeToolsForProvider(tools, baseUrl, toolChoice, options);
 }
 
 /**
@@ -255,9 +212,10 @@ export function applyPlatformToolTransforms(
 export function applyPlatformRequestOverride(
   chatBody: Record<string, unknown>,
   chatPath: string,
-  baseUrl: string
+  baseUrl: string,
+  options?: PlatformMatchOptions
 ): PlatformRequestOverrideResult | null {
-  const rule = matchRequestOverrideRule(baseUrl);
+  const rule = matchRequestOverrideRule(baseUrl, options);
   if (!rule?.requestOverride) {
     return null;
   }
@@ -268,9 +226,10 @@ export function applyPlatformRequestOverride(
 /** Apply per-provider outbound message transforms inside Chat bodies. */
 export function applyPlatformMessageTransforms(
   messages: OpenAIMessage[],
-  baseUrl: string
+  baseUrl: string,
+  options?: PlatformMatchOptions
 ): OpenAIMessage[] {
-  const rule = matchPlatformMessageRule(baseUrl);
+  const rule = matchPlatformMessageRule(baseUrl, options);
   if (!rule?.messages) {
     return messages;
   }
@@ -284,8 +243,12 @@ export function applyPlatformMessageTransforms(
 /**
  * Apply outbound Chat Completions body sanitization when the platform rule declares `requestSanitize`.
  */
-export function applyPlatformRequestSanitize(body: Record<string, unknown>, baseUrl: string): void {
-  const rule = matchHostedToolRuleForBaseUrl(baseUrl);
+export function applyPlatformRequestSanitize(
+  body: Record<string, unknown>,
+  baseUrl: string,
+  options?: PlatformMatchOptions
+): void {
+  const rule = matchHostedToolRuleForBaseUrl(baseUrl, options);
   const key = rule?.requestSanitize;
   if (!key) {
     return;
@@ -300,9 +263,10 @@ export function applyPlatformRequestSanitize(body: Record<string, unknown>, base
  */
 export function applyPlatformChatResponseSanitize(
   body: Record<string, unknown>,
-  baseUrl: string
+  baseUrl: string,
+  options?: PlatformMatchOptions
 ): void {
-  const rule = matchHostedToolRuleForBaseUrl(baseUrl);
+  const rule = matchHostedToolRuleForBaseUrl(baseUrl, options);
   const key = rule?.chatResponseSanitize;
   if (!key) {
     return;
@@ -312,8 +276,11 @@ export function applyPlatformChatResponseSanitize(
 }
 
 /** True when the platform rule buffers streamed assistant text to rewrite tool XML at finish. */
-export function platformBuffersChatContentForToolParse(baseUrl: string): boolean {
-  const rule = matchHostedToolRuleForBaseUrl(baseUrl);
+export function platformBuffersChatContentForToolParse(
+  baseUrl: string,
+  options?: PlatformMatchOptions
+): boolean {
+  const rule = matchHostedToolRuleForBaseUrl(baseUrl, options);
   return typeof rule?.chatResponseSanitize === "string" && rule.chatResponseSanitize.length > 0;
 }
 
@@ -323,9 +290,10 @@ export function platformBuffersChatContentForToolParse(baseUrl: string): boolean
 export function applyPlatformResponseTransforms(
   openaiCompletionBody: Record<string, unknown>,
   anthropicContent: AnthropicContentBlock[],
-  baseUrl: string
+  baseUrl: string,
+  options?: PlatformMatchOptions
 ): AnthropicContentBlock[] {
-  const rule = matchPlatformResponseRule(baseUrl);
+  const rule = matchPlatformResponseRule(baseUrl, options);
   if (!rule?.responses) {
     return anthropicContent;
   }
@@ -342,9 +310,10 @@ export function applyPlatformResponseTransforms(
  */
 export function applyAnthropicSseRowsPlatformTransform(
   rows: AnthropicSseEventRow[],
-  baseUrl: string
+  baseUrl: string,
+  options?: PlatformMatchOptions
 ): AnthropicSseEventRow[] {
-  const rule = matchAnthropicSseRule(baseUrl);
+  const rule = matchAnthropicSseRule(baseUrl, options);
   if (!rule?.anthropicSse) {
     return rows;
   }

--- a/packages/core/src/converter/platform-transforms/matchRule.ts
+++ b/packages/core/src/converter/platform-transforms/matchRule.ts
@@ -1,0 +1,39 @@
+/**
+ * Resolve a platform transform rule from upstream hostname and/or provider openaiCompat.
+ */
+
+import type { OpenAICompat } from "../../types";
+import { normalizedHostnameFromBaseUrl } from "./hostname";
+import { ruleHostnameMatches } from "./ruleHostname";
+import { PLATFORM_TRANSFORM_RULES, type HostedToolRule } from "./rules";
+
+export interface PlatformMatchOptions {
+  /** When `azure_openai`, apply Azure Chat rules even if hostname is a custom router. */
+  openaiCompat?: OpenAICompat;
+}
+
+function azureOpenAiRule(): HostedToolRule | undefined {
+  return PLATFORM_TRANSFORM_RULES.find(r => r.provider === "azure-openai");
+}
+
+/**
+ * First matching hostname rule wins. If none match and `openaiCompat` is `azure_openai`,
+ * return the Azure OpenAI platform rule (custom domains / Azure-compatible routers).
+ */
+export function matchHostedToolRuleForBaseUrl(
+  baseUrl: string,
+  options?: PlatformMatchOptions
+): HostedToolRule | undefined {
+  const hostname = normalizedHostnameFromBaseUrl(baseUrl);
+  if (hostname) {
+    for (const rule of PLATFORM_TRANSFORM_RULES) {
+      if (ruleHostnameMatches(hostname, rule)) {
+        return rule;
+      }
+    }
+  }
+  if (options?.openaiCompat === "azure_openai") {
+    return azureOpenAiRule();
+  }
+  return undefined;
+}

--- a/packages/core/src/converter/platform-transforms/openai-chat-strict-tools.ts
+++ b/packages/core/src/converter/platform-transforms/openai-chat-strict-tools.ts
@@ -4,23 +4,8 @@
  */
 
 import { ScopedLogger } from "../../utils/logger";
-import { normalizedHostnameFromBaseUrl } from "./hostname";
 import { isPlainObject } from "./passthrough";
-import { ruleHostnameMatches } from "./ruleHostname";
-import { PLATFORM_TRANSFORM_RULES, type HostedToolRule } from "./rules";
-
-function matchRuleForBaseUrl(baseUrl: string): HostedToolRule | undefined {
-  const hostname = normalizedHostnameFromBaseUrl(baseUrl);
-  if (!hostname) {
-    return undefined;
-  }
-  for (const rule of PLATFORM_TRANSFORM_RULES) {
-    if (ruleHostnameMatches(hostname, rule)) {
-      return rule;
-    }
-  }
-  return undefined;
-}
+import { matchHostedToolRuleForBaseUrl, type PlatformMatchOptions } from "./matchRule";
 
 const log = new ScopedLogger("PlatformStrictTools");
 
@@ -123,9 +108,10 @@ function normalizeToolChoiceAfterDrop(
  */
 export function openaiChatStrictToolsSanitize(
   body: Record<string, unknown>,
-  baseUrl: string
+  baseUrl: string,
+  options?: PlatformMatchOptions
 ): void {
-  const rule = matchRuleForBaseUrl(baseUrl);
+  const rule = matchHostedToolRuleForBaseUrl(baseUrl, options);
   if (!rule?.strictTools) {
     return;
   }

--- a/packages/core/src/converter/platform-transforms/rules.ts
+++ b/packages/core/src/converter/platform-transforms/rules.ts
@@ -101,6 +101,8 @@ export const PLATFORM_TRANSFORM_RULES: readonly PlatformTransformRule[] = [
     requestOverride: "azure-web-search-to-responses",
     responses: "azure-responses-web-search",
     requestSanitize: "azure-chat-sanitize",
+    // Chat Completions schema rejects Responses `custom` tools and non-function types.
+    strictTools: true,
   },
   {
     provider: "gemini",

--- a/packages/core/src/server/proxy/executor.ts
+++ b/packages/core/src/server/proxy/executor.ts
@@ -1304,7 +1304,8 @@ export class ProxyExecutor {
         const openaiResponse = JSON.parse(responseBody) as OpenAIChatCompletionResponse;
         applyPlatformChatResponseSanitize(
           openaiResponse as unknown as Record<string, unknown>,
-          provider.baseUrl
+          provider.baseUrl,
+          { openaiCompat: provider.openaiCompat }
         );
         const anthropicResponse = convertResponseToAnthropic(
           openaiResponse,
@@ -1313,7 +1314,8 @@ export class ProxyExecutor {
         anthropicResponse.content = applyPlatformResponseTransforms(
           openaiResponse as unknown as Record<string, unknown>,
           anthropicResponse.content,
-          provider.baseUrl
+          provider.baseUrl,
+          { openaiCompat: provider.openaiCompat }
         );
 
         ctx.responseChunks.push(Buffer.from(JSON.stringify(anthropicResponse), "utf-8"));
@@ -1418,7 +1420,8 @@ export class ProxyExecutor {
         anthropicResponse.content = applyPlatformResponseTransforms(
           parsed,
           anthropicResponse.content,
-          provider.baseUrl
+          provider.baseUrl,
+          { openaiCompat: provider.openaiCompat }
         );
 
         ctx.responseChunks.push(Buffer.from(JSON.stringify(anthropicResponse), "utf-8"));
@@ -1649,7 +1652,8 @@ export class ProxyExecutor {
         const openaiResponse = JSON.parse(jsonBody) as OpenAIChatCompletionResponse;
         applyPlatformChatResponseSanitize(
           openaiResponse as unknown as Record<string, unknown>,
-          provider.baseUrl
+          provider.baseUrl,
+          { openaiCompat: provider.openaiCompat }
         );
         const out = convertChatCompletionToResponses(
           openaiResponse,
@@ -1765,7 +1769,9 @@ export class ProxyExecutor {
 
     const state = createStreamingState({
       echo: task.originalResponsesEcho,
-      bufferContentForToolParse: platformBuffersChatContentForToolParse(provider.baseUrl),
+      bufferContentForToolParse: platformBuffersChatContentForToolParse(provider.baseUrl, {
+        openaiCompat: provider.openaiCompat,
+      }),
     });
     const upstreamLog: Buffer[] = [];
 

--- a/packages/core/src/server/request/bodyProcessor.ts
+++ b/packages/core/src/server/request/bodyProcessor.ts
@@ -64,7 +64,11 @@ function applyAnthropicOutboundSanitizeIfNeeded(
   return sanitizeAnthropicOutboundBody(body);
 }
 
-function applyHostedToolsToOpenAiChatRecord(data: Record<string, unknown>, baseUrl: string): void {
+function applyHostedToolsToOpenAiChatRecord(
+  data: Record<string, unknown>,
+  baseUrl: string,
+  openaiCompat?: RoutingContext["provider"]["openaiCompat"]
+): void {
   const tools = data.tools;
   if (!Array.isArray(tools) || tools.length === 0) {
     return;
@@ -72,7 +76,8 @@ function applyHostedToolsToOpenAiChatRecord(data: Record<string, unknown>, baseU
   const { tools: outTools, toolChoice } = normalizeToolsForProvider(
     tools as Record<string, unknown>[],
     baseUrl,
-    data.tool_choice
+    data.tool_choice,
+    { openaiCompat }
   );
   data.tools = outTools;
   if (toolChoice !== undefined) {
@@ -82,19 +87,23 @@ function applyHostedToolsToOpenAiChatRecord(data: Record<string, unknown>, baseU
 
 function applyPlatformMessagesToOpenAiChatRecord(
   data: Record<string, unknown>,
-  baseUrl: string
+  baseUrl: string,
+  openaiCompat?: RoutingContext["provider"]["openaiCompat"]
 ): void {
   const messages = data.messages;
   if (!Array.isArray(messages) || messages.length === 0) {
     return;
   }
-  data.messages = applyPlatformMessageTransforms(messages as OpenAIMessage[], baseUrl);
+  data.messages = applyPlatformMessageTransforms(messages as OpenAIMessage[], baseUrl, {
+    openaiCompat,
+  });
 }
 
 function applyPlatformTransformsToOpenAiChatBody(
   body: Buffer,
   baseUrl: string,
-  clientModelHint?: string
+  clientModelHint?: string,
+  openaiCompat?: RoutingContext["provider"]["openaiCompat"]
 ): Buffer {
   if (!body.length) {
     return body;
@@ -104,12 +113,13 @@ function applyPlatformTransformsToOpenAiChatBody(
     if (!isOpenAIChatCompletionsRequest(data)) {
       return body;
     }
+    const matchOpts = { openaiCompat };
     normalizeOpenAiChatMaxOutputFields(data, clientModelHint);
     ensureOpenAiChatStreamUsageIncluded(data);
-    applyHostedToolsToOpenAiChatRecord(data, baseUrl);
-    openaiChatStrictToolsSanitize(data, baseUrl);
-    applyPlatformMessagesToOpenAiChatRecord(data, baseUrl);
-    applyPlatformRequestSanitize(data, baseUrl);
+    applyHostedToolsToOpenAiChatRecord(data, baseUrl, openaiCompat);
+    openaiChatStrictToolsSanitize(data, baseUrl, matchOpts);
+    applyPlatformMessagesToOpenAiChatRecord(data, baseUrl, openaiCompat);
+    applyPlatformRequestSanitize(data, baseUrl, matchOpts);
     sanitizeOpenAiChatToolArgumentsInMessages(data.messages);
     sanitizeOpenAiChatRequestRecord(data);
     return Buffer.from(JSON.stringify(data), "utf-8");
@@ -324,7 +334,8 @@ export class BodyProcessor {
           const override = applyPlatformRequestOverride(
             parsed,
             result.newPath,
-            routing.provider.baseUrl
+            routing.provider.baseUrl,
+            { openaiCompat: routing.provider.openaiCompat }
           );
           if (override) {
             nextBody = Buffer.from(JSON.stringify(override.body), "utf-8");
@@ -364,7 +375,8 @@ export class BodyProcessor {
       body = applyPlatformTransformsToOpenAiChatBody(
         body,
         routing.provider.baseUrl,
-        clientWireModel
+        clientWireModel,
+        routing.provider.openaiCompat
       );
     }
 
@@ -383,7 +395,9 @@ export class BodyProcessor {
       routing.method === "POST" &&
       routing.targetPath === "/v1/messages" &&
       body.length > 0 &&
-      matchAnthropicSseRule(routing.provider.baseUrl)?.anthropicSse
+      matchAnthropicSseRule(routing.provider.baseUrl, {
+        openaiCompat: routing.provider.openaiCompat,
+      })?.anthropicSse
     ) {
       try {
         const d = JSON.parse(body.toString("utf-8")) as Record<string, unknown>;
@@ -481,7 +495,11 @@ export class BodyProcessor {
         providerBaseUrl: routing.provider.baseUrl,
       });
       const chatReq = chat.request as unknown as Record<string, unknown>;
-      applyHostedToolsToOpenAiChatRecord(chatReq, routing.provider.baseUrl);
+      applyHostedToolsToOpenAiChatRecord(
+        chatReq,
+        routing.provider.baseUrl,
+        routing.provider.openaiCompat
+      );
       const c = convertOpenAIRequestToAnthropic(
         chatReq as unknown as Parameters<typeof convertOpenAIRequestToAnthropic>[0],
         chat.newPath
@@ -507,7 +525,11 @@ export class BodyProcessor {
       if (!isOpenAIChatCompletionsRequest(oai)) {
         return null;
       }
-      applyHostedToolsToOpenAiChatRecord(oai, routing.provider.baseUrl);
+      applyHostedToolsToOpenAiChatRecord(
+        oai,
+        routing.provider.baseUrl,
+        routing.provider.openaiCompat
+      );
       const c = convertOpenAIRequestToAnthropic(
         oai as unknown as Parameters<typeof convertOpenAIRequestToAnthropic>[0],
         routing.targetPath

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -439,8 +439,9 @@ export interface Provider {
    */
   customModelsList?: string[];
   /**
-   * Legacy YAML/API field; parsed for backward compatibility but **ignored** at runtime.
-   * Azure Chat outbound sanitization is selected by upstream hostname (`platform-transforms`).
+   * When `azure_openai`, apply Azure Chat Completions sanitization and strict tools
+   * even if the upstream hostname is a custom Azure-compatible router.
+   * Official `*.cognitiveservices.azure.com` hosts are still matched automatically.
    */
   openaiCompat?: OpenAICompat;
 }

--- a/packages/desktop-tauri/package.json
+++ b/packages/desktop-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ccrelay/desktop-tauri",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "description": "CCRelay desktop app (Tauri)",
   "scripts": {

--- a/packages/desktop-tauri/src-tauri/Cargo.toml
+++ b/packages/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccrelay"
-version = "0.2.8"
+version = "0.2.9"
 description = "CCRelay desktop app"
 authors = ["Inflab"]
 edition = "2021"

--- a/packages/desktop-tauri/src-tauri/tauri.conf.json
+++ b/packages/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CCRelay",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "identifier": "org.inflab.ccrelay",
   "build": {
     "frontendDist": "../web",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccrelay-desktop",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "description": "CCRelay desktop tray app",
   "license": "MIT",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "CCRelay",
   "icon": "assets/icon-128.png",
   "description": "VSCode extension with built-in API proxy server - switch between AI providers seamlessly",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "publisher": "inflab",
   "license": "MIT",
   "repository": {

--- a/tests/unit/converter/adapters/openai-responses-to-chat.test.ts
+++ b/tests/unit/converter/adapters/openai-responses-to-chat.test.ts
@@ -8,6 +8,7 @@ import {
   collectResponsesToolsRaw,
 } from "@/converter/adapters/openai-responses-to-chat";
 import {
+  azureChatSanitize,
   normalizeToolsForProvider,
   openaiChatStrictToolsSanitize,
 } from "@/converter/platform-transforms";
@@ -318,7 +319,10 @@ describe("convertResponsesRequestToChatCompletions", () => {
     expect(request.messages).toEqual([{ role: "user", content: "list dirs" }]);
 
     expect(request.tools).toHaveLength(3);
-    expect(request.tools?.[0]).toMatchObject({ type: "custom", name: "exec" });
+    expect(request.tools?.[0]).toMatchObject({
+      type: "function",
+      function: { name: "exec" },
+    });
     expect(request.tools?.[1]).toMatchObject({
       type: "function",
       function: { name: "wait" },
@@ -393,6 +397,43 @@ describe("convertResponsesRequestToChatCompletions", () => {
     ]);
   });
 
+  it("maps developer messages to system and preserves input_image as image_url", () => {
+    const { request } = convertResponsesRequestToChatCompletions(
+      {
+        model: "m",
+        input: [
+          {
+            type: "message",
+            role: "developer",
+            content: [{ type: "input_text", text: "You are Codex." }],
+          },
+          {
+            type: "message",
+            role: "user",
+            content: [
+              { type: "input_text", text: "what is this" },
+              {
+                type: "input_image",
+                image_url: "data:image/png;base64,abc",
+              },
+            ],
+          },
+        ],
+      },
+      "/v1/responses"
+    );
+    expect(request.messages).toEqual([
+      { role: "system", content: "You are Codex." },
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "what is this" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,abc" } },
+        ],
+      },
+    ]);
+  });
+
   it("shims additional_tools custom entries for GLM strictTools", () => {
     const { request } = convertResponsesRequestToChatCompletions(
       {
@@ -437,6 +478,63 @@ describe("convertResponsesRequestToChatCompletions", () => {
     });
     const fn = tools[0].function as { description?: string };
     expect(fn.description).toContain("Run JS");
+  });
+
+  it("shims additional_tools custom entries for Azure OpenAI strictTools", () => {
+    const { request } = convertResponsesRequestToChatCompletions(
+      {
+        model: "gpt-5",
+        input: [
+          {
+            type: "additional_tools",
+            role: "developer",
+            tools: [
+              {
+                type: "custom",
+                name: "exec",
+                description: "Run JS",
+                format: { type: "grammar", syntax: "lark", definition: "start: SOURCE" },
+              },
+              {
+                type: "function",
+                name: "wait",
+                description: "Wait on exec",
+                parameters: {
+                  type: "object",
+                  properties: { cell_id: { type: "string" } },
+                  required: ["cell_id"],
+                },
+              },
+            ],
+          },
+          {
+            type: "message",
+            role: "developer",
+            content: [{ type: "input_text", text: "You are Codex." }],
+          },
+          { type: "message", role: "user", content: "run" },
+        ],
+      },
+      "/v1/responses"
+    );
+    const body = { ...request } as unknown as Record<string, unknown>;
+    openaiChatStrictToolsSanitize(body, "https://example.cognitiveservices.azure.com/openai/v1");
+    azureChatSanitize(body);
+
+    const messages = body.messages as { role: string; content: string }[];
+    expect(messages.map(m => m.role)).toEqual(["system", "user"]);
+    expect(messages[0].content).toBe("You are Codex.");
+
+    const tools = body.tools as Record<string, unknown>[];
+    expect(tools).toHaveLength(2);
+    expect(tools[0]).toMatchObject({
+      type: "function",
+      function: { name: "exec" },
+    });
+    expect(tools[1]).toMatchObject({
+      type: "function",
+      function: { name: "wait" },
+    });
   });
 });
 

--- a/tests/unit/converter/platform-transforms/azure-openai/chat-sanitize.test.ts
+++ b/tests/unit/converter/platform-transforms/azure-openai/chat-sanitize.test.ts
@@ -4,16 +4,31 @@ import {
   applyPlatformRequestSanitize,
   azureChatSanitize,
   matchHostedToolRuleForBaseUrl,
+  openaiChatStrictToolsSanitize,
 } from "@/converter/platform-transforms";
 import { describe, expect, it } from "vitest";
 
 const AZURE_BASE = "https://example.cognitiveservices.azure.com/openai/v1";
 
 describe("Azure OpenAI platform rule", () => {
-  it("matches cognitiveservices.azure.com with requestSanitize", () => {
+  it("matches cognitiveservices.azure.com with requestSanitize and strictTools", () => {
     const r = matchHostedToolRuleForBaseUrl(`${AZURE_BASE}/chat/completions`);
     expect(r?.provider).toBe("azure-openai");
     expect(r?.requestSanitize).toBe("azure-chat-sanitize");
+    expect(r?.strictTools).toBe(true);
+  });
+
+  it("matches openaiCompat azure_openai on custom domains", () => {
+    const r = matchHostedToolRuleForBaseUrl("https://llm-router.bizs.app/v1", {
+      openaiCompat: "azure_openai",
+    });
+    expect(r?.provider).toBe("azure-openai");
+    expect(r?.strictTools).toBe(true);
+    expect(r?.requestSanitize).toBe("azure-chat-sanitize");
+  });
+
+  it("does not match custom domains without openaiCompat", () => {
+    expect(matchHostedToolRuleForBaseUrl("https://llm-router.bizs.app/v1")).toBeUndefined();
   });
 });
 
@@ -59,6 +74,21 @@ describe("azureChatSanitize", () => {
     expect((asst.tool_calls as Record<string, unknown>[])[0].extra_content).toBeUndefined();
     expect((asst.tool_calls as { function: { name: string } }[])[0].function.name).toBe("noop");
   });
+
+  it("maps developer role to system for Azure Chat Completions schema", () => {
+    const body: Record<string, unknown> = {
+      model: "gpt-4",
+      messages: [
+        { role: "developer", content: "You are Codex." },
+        { role: "developer", content: "<permissions instructions>" },
+        { role: "user", content: "hi" },
+      ],
+    };
+    azureChatSanitize(body);
+    const messages = body.messages as { role: string; content: string }[];
+    expect(messages.map(m => m.role)).toEqual(["system", "system", "user"]);
+    expect(messages[0].content).toBe("You are Codex.");
+  });
 });
 
 describe("applyPlatformRequestSanitize (Azure)", () => {
@@ -71,5 +101,33 @@ describe("applyPlatformRequestSanitize (Azure)", () => {
     applyPlatformRequestSanitize(body, AZURE_BASE);
     expect(body.reasoning_effort).toBe("low");
     expect((body.messages as Record<string, unknown>[])[0].thinking).toBeUndefined();
+  });
+
+  it("maps developer roles via applyPlatformRequestSanitize", () => {
+    const body: Record<string, unknown> = {
+      model: "gpt-4",
+      messages: [{ role: "developer", content: "sys" }],
+    };
+    applyPlatformRequestSanitize(body, AZURE_BASE);
+    expect((body.messages as { role: string }[])[0].role).toBe("system");
+  });
+
+  it("applies azure-chat-sanitize via openaiCompat on custom domains", () => {
+    const body: Record<string, unknown> = {
+      model: "gpt-4",
+      messages: [{ role: "developer", content: "sys" }],
+      tools: [{ type: "custom", name: "exec", description: "Run JS" }],
+    };
+    applyPlatformRequestSanitize(body, "https://llm-router.bizs.app/v1", {
+      openaiCompat: "azure_openai",
+    });
+    openaiChatStrictToolsSanitize(body, "https://llm-router.bizs.app/v1", {
+      openaiCompat: "azure_openai",
+    });
+    expect((body.messages as { role: string }[])[0].role).toBe("system");
+    expect((body.tools as Record<string, unknown>[])[0]).toMatchObject({
+      type: "function",
+      function: { name: "exec" },
+    });
   });
 });

--- a/tests/unit/converter/platform-transforms/openai-chat-strict-tools.test.ts
+++ b/tests/unit/converter/platform-transforms/openai-chat-strict-tools.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 
 const MIMO_API = "https://api.xiaomimimo.com/v1/chat/completions";
 const MIMO_TOKEN_PLAN = "https://token-plan-sgp.xiaomimimo.com/v1/chat/completions";
+const AZURE = "https://example.cognitiveservices.azure.com/openai/v1/chat/completions";
 const UNKNOWN = "https://api.openai.com/v1/chat/completions";
 
 function fnTool(name: string): Record<string, unknown> {
@@ -138,5 +139,30 @@ describe("openaiChatStrictToolsSanitize", () => {
     };
     openaiChatStrictToolsSanitize(body, MIMO_TOKEN_PLAN);
     expect(body.tools).toBeUndefined();
+  });
+
+  it("shims Codex custom exec to function on Azure OpenAI", () => {
+    const body: Record<string, unknown> = {
+      tools: [
+        {
+          type: "custom",
+          name: "exec",
+          description: "Run JS",
+          format: { type: "grammar", syntax: "lark", definition: "start: SOURCE" },
+        },
+        fnTool("wait"),
+      ],
+    };
+    openaiChatStrictToolsSanitize(body, AZURE);
+    const tools = body.tools as Record<string, unknown>[];
+    expect(tools).toHaveLength(2);
+    expect(tools[0]).toMatchObject({
+      type: "function",
+      function: { name: "exec" },
+    });
+    expect(tools[1]).toMatchObject({
+      type: "function",
+      function: { name: "wait" },
+    });
   });
 });

--- a/tests/unit/web/wizard-engine.test.ts
+++ b/tests/unit/web/wizard-engine.test.ts
@@ -274,6 +274,7 @@ describe("generateProviders", () => {
     expect(out[0].providerType).toBe("openai");
     expect(out[0].authHeader).toBe("authorization");
     expect(out[0].id).toBe("azure-gpt");
+    expect(out[0].openaiCompat).toBe("azure_openai");
   });
 
   it("applies Xiaomi authHeader only for token plan", () => {

--- a/web/src/features/providers/Providers.tsx
+++ b/web/src/features/providers/Providers.tsx
@@ -379,6 +379,7 @@ export default function Providers() {
       modelMappingEnabled: provider.modelMappingEnabled !== false,
       useCustomModelsList: Boolean(provider.useCustomModelsList),
       customModelsList: provider.customModelsList,
+      openaiCompat: provider.openaiCompat,
     });
     setModelMapText(modelMap ? yaml.dump(modelMap, { indent: 2, lineWidth: -1 }) : "");
     setModelMapError(null);
@@ -462,6 +463,12 @@ export default function Providers() {
       ...payload,
       useCustomModelsList: formData.useCustomModelsList === true,
       customModelsList: formData.useCustomModelsList === true ? customLines : undefined,
+      openaiCompat:
+        formData.providerType === "openai" || formData.providerType === "openai_chat"
+          ? formData.openaiCompat === "azure_openai"
+            ? "azure_openai"
+            : undefined
+          : undefined,
     };
   };
 
@@ -1207,6 +1214,7 @@ export default function Providers() {
                       setFormData(prev => ({
                         ...prev,
                         providerType: t,
+                        ...(t === "anthropic" ? { openaiCompat: undefined } : {}),
                       }));
                     }}
                     className="h-8 text-xs"
@@ -1225,6 +1233,30 @@ export default function Providers() {
                   />
                 </div>
               </div>
+
+              {(formData.providerType === "openai" || formData.providerType === "openai_chat") && (
+                <div className="flex items-start gap-2 rounded-md border border-border/60 px-3 py-2">
+                  <Checkbox
+                    id="openai-compat-azure"
+                    checked={formData.openaiCompat === "azure_openai"}
+                    onCheckedChange={checked =>
+                      setFormData(prev => ({
+                        ...prev,
+                        openaiCompat: checked === true ? "azure_openai" : undefined,
+                      }))
+                    }
+                    className="mt-0.5"
+                  />
+                  <div className="space-y-0.5">
+                    <Label htmlFor="openai-compat-azure" className="text-xs font-medium">
+                      {t("providers.modal.azureChatCompat")}
+                    </Label>
+                    <p className="text-[10px] text-muted-foreground">
+                      {t("providers.modal.azureChatCompatHelp")}
+                    </p>
+                  </div>
+                </div>
+              )}
 
               {/* API Key */}
               <div className="space-y-1">

--- a/web/src/features/providers/wizard/presets.ts
+++ b/web/src/features/providers/wizard/presets.ts
@@ -301,6 +301,7 @@ const PARTNER_PRESETS_LIST: PartnerPreset[] = [
         urlTemplate: "{userBaseUrl}",
         idSuffix: "gpt",
         nameSuffix: "",
+        overrides: { openaiCompat: "azure_openai" },
       },
     ],
   },

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -383,6 +383,8 @@
       "type": "Type",
       "typeOpenaiFull": "OpenAI (Full)",
       "typeOpenaiChatOnly": "OpenAI (Chat Only)",
+      "azureChatCompat": "Azure Chat compatibility",
+      "azureChatCompatHelp": "Enable for Azure OpenAI or Azure-compatible routers on custom domains (maps developer→system, shims custom tools). Official *.cognitiveservices.azure.com hosts are detected automatically.",
       "modePassthrough": "Passthrough",
       "modeInject": "Inject",
       "apiKey": "API Key",

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -383,6 +383,8 @@
       "type": "类型",
       "typeOpenaiFull": "OpenAI（完整）",
       "typeOpenaiChatOnly": "OpenAI（仅 Chat）",
+      "azureChatCompat": "Azure Chat 兼容",
+      "azureChatCompatHelp": "用于 Azure OpenAI 或自定义域名的 Azure 兼容网关（developer→system，custom 工具转 function）。官方 *.cognitiveservices.azure.com 会自动识别。",
       "modePassthrough": "透传",
       "modeInject": "注入",
       "apiKey": "API 密钥",

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -23,6 +23,8 @@ export interface Provider {
   customModelsList?: string[];
   /** Read-only: true when this provider ID is in the global webSearch.providers list. */
   webSearchEnabled?: boolean;
+  /** When `azure_openai`, apply Azure Chat Completions sanitization (custom domains). */
+  openaiCompat?: "default" | "azure_openai";
 }
 
 export interface ProvidersResponse {
@@ -71,6 +73,8 @@ export interface AddProviderRequest {
   useCustomModelsList?: boolean;
   /** Each entry: `realId`, `realId;displayName`, or `realId;displayName;alias` (see Provider.customModelsList). */
   customModelsList?: string[];
+  /** When `azure_openai`, apply Azure Chat Completions sanitization (custom domains). */
+  openaiCompat?: "default" | "azure_openai";
 }
 
 export interface AddProviderResponse {


### PR DESCRIPTION
Codex Responses→Chat maps developer→system, shims custom tools, and preserves input_image; revive openaiCompat azure_openai for custom domains.