### PR TITLE
chore: 0.3.0 pre-release version bump

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -333,14 +333,23 @@ jobs:
           APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}
         run: |
           set -euo pipefail
+          # Pin channel to "latest" so app-update.yml requests latest-mac.yml /
+          # latest.yml. Without this, electron-builder derives the channel from
+          # the version prerelease (e.g. 0.2.9-dev.N → "dev") and the client
+          # looks for missing files like dev-mac.yml. Feed separation is already
+          # handled by distinct channel-* publish URLs.
           node -e "
             const fs = require('fs');
             const p = 'package.json';
             const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
             pkg.build = pkg.build || {};
-            pkg.build.publish = { provider: 'generic', url: process.env.PUBLISH_URL };
+            pkg.build.publish = {
+              provider: 'generic',
+              url: process.env.PUBLISH_URL,
+              channel: 'latest',
+            };
             fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
-            console.log('publish.url =', pkg.build.publish.url);
+            console.log('publish.url =', pkg.build.publish.url, 'channel =', pkg.build.publish.channel);
           "
           npx electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish never
 
@@ -630,6 +639,19 @@ jobs:
               --notes "Rolling auto-update manifests for the ${CHANNEL} channel. Not a downloadable build."
           fi
           gh release upload "$TAG" release-metadata/* --clobber
+          # Older/dev builds whose version prerelease is "dev" (e.g. 0.2.9-dev.N)
+          # still request ${CHANNEL}-mac.yml / ${CHANNEL}.yml. Mirror latest-* so
+          # those clients keep updating until they pick up channel: latest builds.
+          if [[ "$CHANNEL" != "prod" && "$CHANNEL" != "latest" ]]; then
+            mkdir -p release-metadata-aliases
+            [[ -f release-metadata/latest-mac.yml ]] && cp release-metadata/latest-mac.yml "release-metadata-aliases/${CHANNEL}-mac.yml"
+            [[ -f release-metadata/latest.yml ]] && cp release-metadata/latest.yml "release-metadata-aliases/${CHANNEL}.yml"
+            shopt -s nullglob
+            aliases=(release-metadata-aliases/*)
+            if [[ ${#aliases[@]} -gt 0 ]]; then
+              gh release upload "$TAG" "${aliases[@]}" --clobber
+            fi
+          fi
 
   publish-openvsx:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-25 (pre-release)
+
+Pre-release line for 0.3.0.
+
 ### Fixed
 
 **Desktop**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+**Desktop**
+
+- Dev Electron builds can check for updates again: the updater feed always uses `latest-*.yml` (and channel-dev also mirrors `dev-*.yml` for older installs), so prerelease versions no longer 404 on `dev-mac.yml`.
+
 ## [0.2.9] - 2026-07-25
 
 Chat testing lands in the dashboard with multimodal image input. Electron packaged builds can auto-update from the tray. Codex Client Config writes a model catalog and warns when the selected model is stale. Azure Chat conversion and Anthropic streaming through OpenAI-compatible upstreams are more reliable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccrelay-monorepo",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccrelay-monorepo",
-      "version": "0.2.9",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -10402,7 +10402,7 @@
     },
     "packages/core": {
       "name": "@ccrelay/core",
-      "version": "0.2.9",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.1",
@@ -10460,7 +10460,7 @@
     },
     "packages/desktop": {
       "name": "ccrelay-desktop",
-      "version": "0.2.9",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -10477,7 +10477,7 @@
     },
     "packages/desktop-tauri": {
       "name": "@ccrelay/desktop-tauri",
-      "version": "0.2.9",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "dependencies": {
         "@ccrelay/core": "*",
@@ -11173,7 +11173,7 @@
     },
     "packages/vscode": {
       "name": "ccrelay-vscode",
-      "version": "0.2.9",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@ccrelay/core": "*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "ccrelay-monorepo",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "license": "MIT",
   "packageManager": "npm@10.9.4",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ccrelay/core",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "private": true,
   "description": "CCRelay proxy server core (Node.js)",
   "license": "MIT",

--- a/packages/desktop-tauri/package.json
+++ b/packages/desktop-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ccrelay/desktop-tauri",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "private": true,
   "description": "CCRelay desktop app (Tauri)",
   "scripts": {

--- a/packages/desktop-tauri/src-tauri/Cargo.toml
+++ b/packages/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccrelay"
-version = "0.2.9"
+version = "0.3.0"
 description = "CCRelay desktop app"
 authors = ["Inflab"]
 edition = "2021"

--- a/packages/desktop-tauri/src-tauri/tauri.conf.json
+++ b/packages/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CCRelay",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "identifier": "org.inflab.ccrelay",
   "build": {
     "frontendDist": "../web",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccrelay-desktop",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "private": true,
   "description": "CCRelay desktop tray app",
   "license": "MIT",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -64,7 +64,8 @@
     ],
     "publish": {
       "provider": "generic",
-      "url": "https://github.com/inflaborg/ccrelay/releases/download/channel-prod"
+      "url": "https://github.com/inflaborg/ccrelay/releases/download/channel-prod",
+      "channel": "latest"
     },
     "mac": {
       "extendInfo": {

--- a/packages/desktop/src/autoUpdate.ts
+++ b/packages/desktop/src/autoUpdate.ts
@@ -1,7 +1,9 @@
 /**
  * Packaged-build auto-update via electron-updater (generic provider).
  * Feed URL is baked at pack time from electron-builder `publish.url`
- * (channel-prod / channel-dev → latest-mac.yml / latest.yml).
+ * (channel-prod / channel-dev). Manifest filenames are always
+ * latest-mac.yml / latest.yml (`publish.channel: latest`) so prerelease
+ * app versions like 0.2.9-dev.N do not request missing dev-mac.yml files.
  */
 
 import { BrowserWindow, app, dialog } from "electron";

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "CCRelay",
   "icon": "assets/icon-128.png",
   "description": "VSCode extension with built-in API proxy server - switch between AI providers seamlessly",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "publisher": "inflab",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump monorepo version to **0.3.0** (pre-release line) across packages, lockfile, and Tauri configs.
- Fix Electron auto-update for dev/prerelease builds: pin `publish.channel` to `latest` and mirror `dev-*.yml` on `channel-dev` so clients stop 404ing on missing channel files.

## Test plan
- [ ] Confirm package versions are all `0.3.0`
- [ ] After merge to `main`, Build Dev (Auto) produces `0.3.0-dev.N` and refreshes `channel-dev` manifests (`latest-*` + `dev-*`)
- [ ] Installed Electron dev build can check for updates without `dev-mac.yml` 404


Made with [Cursor](https://cursor.com)