### PR TITLE
feat: Electron frameless UI, update channel switch, disable Tauri CI

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -59,9 +59,10 @@ jobs:
       want_any_build: ${{ steps.targets.outputs.want_any_build }}
       want_build_vscode: ${{ steps.targets.outputs.want_build_vscode }}
       want_build_desktop: ${{ steps.targets.outputs.want_build_desktop }}
-      want_build_tauri: ${{ steps.targets.outputs.want_build_tauri }}
+      # Tauri CI builds disabled — package code kept under packages/desktop-tauri
+      # want_build_tauri: ${{ steps.targets.outputs.want_build_tauri }}
       desktop_matrix: ${{ steps.targets.outputs.desktop_matrix }}
-      tauri_matrix: ${{ steps.targets.outputs.tauri_matrix }}
+      # tauri_matrix: ${{ steps.targets.outputs.tauri_matrix }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -94,17 +95,18 @@ jobs:
           MATRIX_WIN_X64='[{"os":"windows-latest","platform":"win","arch":"x64"}]'
           MATRIX_WIN_ARM64='[{"os":"windows-latest","platform":"win","arch":"arm64"}]'
 
-          TAURI_MATRIX='[{"os":"macos-latest","platform":"mac","arch":"arm64","rust_target":"aarch64-apple-darwin"},{"os":"windows-latest","platform":"win","arch":"x64","rust_target":"x86_64-pc-windows-msvc"}]'
-          TAURI_MAC='[{"os":"macos-latest","platform":"mac","arch":"arm64","rust_target":"aarch64-apple-darwin"}]'
-          TAURI_WIN='[{"os":"windows-latest","platform":"win","arch":"x64","rust_target":"x86_64-pc-windows-msvc"}]'
-          TAURI_MAC_ARM64='[{"os":"macos-latest","platform":"mac","arch":"arm64","rust_target":"aarch64-apple-darwin"}]'
-          TAURI_WIN_X64='[{"os":"windows-latest","platform":"win","arch":"x64","rust_target":"x86_64-pc-windows-msvc"}]'
+          # Tauri CI builds disabled — keep matrices for easy re-enable later
+          # TAURI_MATRIX='[{"os":"macos-latest","platform":"mac","arch":"arm64","rust_target":"aarch64-apple-darwin"},{"os":"windows-latest","platform":"win","arch":"x64","rust_target":"x86_64-pc-windows-msvc"}]'
+          # TAURI_MAC='[{"os":"macos-latest","platform":"mac","arch":"arm64","rust_target":"aarch64-apple-darwin"}]'
+          # TAURI_WIN='[{"os":"windows-latest","platform":"win","arch":"x64","rust_target":"x86_64-pc-windows-msvc"}]'
+          # TAURI_MAC_ARM64='[{"os":"macos-latest","platform":"mac","arch":"arm64","rust_target":"aarch64-apple-darwin"}]'
+          # TAURI_WIN_X64='[{"os":"windows-latest","platform":"win","arch":"x64","rust_target":"x86_64-pc-windows-msvc"}]'
 
           WANT_V=false
           WANT_D=false
-          WANT_T=false
+          # WANT_T=false
           DESKTOP_MATRIX='[]'
-          TAURI_TARGETS='[]'
+          # TAURI_TARGETS='[]'
 
           apply_target() {
             local t="$1"
@@ -112,9 +114,9 @@ jobs:
               all)
                 WANT_V=true
                 WANT_D=true
-                WANT_T=true
+                # WANT_T=true
                 DESKTOP_MATRIX="$MATRIX"
-                TAURI_TARGETS="$TAURI_MATRIX"
+                # TAURI_TARGETS="$TAURI_MATRIX"
                 ;;
               vscode)
                 WANT_V=true
@@ -147,25 +149,29 @@ jobs:
                 WANT_D=true
                 DESKTOP_MATRIX="$MATRIX_WIN_ARM64"
                 ;;
-              tauri)
-                WANT_T=true
-                TAURI_TARGETS="$TAURI_MATRIX"
-                ;;
-              tauri-mac)
-                WANT_T=true
-                TAURI_TARGETS="$TAURI_MAC"
-                ;;
-              tauri-win)
-                WANT_T=true
-                TAURI_TARGETS="$TAURI_WIN"
-                ;;
-              tauri-mac-arm64)
-                WANT_T=true
-                TAURI_TARGETS="$TAURI_MAC_ARM64"
-                ;;
-              tauri-win-x64)
-                WANT_T=true
-                TAURI_TARGETS="$TAURI_WIN_X64"
+              # Tauri targets disabled in CI — packages/desktop-tauri code retained
+              # tauri)
+              #   WANT_T=true
+              #   TAURI_TARGETS="$TAURI_MATRIX"
+              #   ;;
+              # tauri-mac)
+              #   WANT_T=true
+              #   TAURI_TARGETS="$TAURI_MAC"
+              #   ;;
+              # tauri-win)
+              #   WANT_T=true
+              #   TAURI_TARGETS="$TAURI_WIN"
+              #   ;;
+              # tauri-mac-arm64)
+              #   WANT_T=true
+              #   TAURI_TARGETS="$TAURI_MAC_ARM64"
+              #   ;;
+              # tauri-win-x64)
+              #   WANT_T=true
+              #   TAURI_TARGETS="$TAURI_WIN_X64"
+              #   ;;
+              tauri|tauri-mac|tauri-win|tauri-mac-arm64|tauri-win-x64)
+                echo "Tauri CI builds are disabled; ignoring target: $t" >&2
                 ;;
               none)
                 ;;
@@ -188,7 +194,7 @@ jobs:
             done
           fi
 
-          if [ "$WANT_V" = true ] || [ "$WANT_D" = true ] || [ "$WANT_T" = true ]; then
+          if [ "$WANT_V" = true ] || [ "$WANT_D" = true ]; then
             echo "want_any_build=true" >> "$GITHUB_OUTPUT"
           else
             echo "want_any_build=false" >> "$GITHUB_OUTPUT"
@@ -196,17 +202,17 @@ jobs:
 
           echo "want_build_vscode=$WANT_V" >> "$GITHUB_OUTPUT"
           echo "want_build_desktop=$WANT_D" >> "$GITHUB_OUTPUT"
-          echo "want_build_tauri=$WANT_T" >> "$GITHUB_OUTPUT"
+          # echo "want_build_tauri=$WANT_T" >> "$GITHUB_OUTPUT"
           {
             echo "desktop_matrix<<__MATRIX_EOF__"
             echo "$DESKTOP_MATRIX"
             echo "__MATRIX_EOF__"
           } >> "$GITHUB_OUTPUT"
-          {
-            echo "tauri_matrix<<__TAURI_MATRIX_EOF__"
-            echo "$TAURI_TARGETS"
-            echo "__TAURI_MATRIX_EOF__"
-          } >> "$GITHUB_OUTPUT"
+          # {
+          #   echo "tauri_matrix<<__TAURI_MATRIX_EOF__"
+          #   echo "$TAURI_TARGETS"
+          #   echo "__TAURI_MATRIX_EOF__"
+          # } >> "$GITHUB_OUTPUT"
 
   build-vscode:
     runs-on: ubuntu-latest
@@ -416,155 +422,157 @@ jobs:
         if: matrix.platform == 'mac' && always()
         run: security delete-keychain build.keychain || true
 
-  build-tauri:
-    needs: configure
-    if: ${{ needs.configure.outputs.want_build_tauri == 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.configure.outputs.tauri_matrix) }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.rust_target }}
-
-      - name: Cache Cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            packages/desktop-tauri/src-tauri/target
-          key: cargo-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('packages/desktop-tauri/src-tauri/Cargo.lock') }}
-          restore-keys: |
-            cargo-${{ runner.os }}-${{ matrix.arch }}-
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: |
-            package-lock.json
-            web/package-lock.json
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Build Tauri (frontend, sidecar, Rust host prep)
-        run: npm run tauri:build
-
-      - name: Import signing certificate
-        id: tauri_mac_signing
-        if: matrix.platform == 'mac'
-        env:
-          CSC_LINK: ${{ secrets.APPLE_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CSC_KEY_PASSWORD }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${CSC_LINK:-}" ]]; then
-            echo "signed=false" >> "$GITHUB_OUTPUT"
-            echo "No APPLE_CSC_LINK secret — skipping signing certificate import"
-            exit 0
-          fi
-          KEYCHAIN=build.keychain
-          KEYCHAIN_PASSWORD="$(openssl rand -base64 16)"
-          P12_FILE="$RUNNER_TEMP/cert.p12"
-          echo "$CSC_LINK" | base64 --decode > "$P12_FILE"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security default-keychain -s "$KEYCHAIN"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security import "$P12_FILE" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
-          rm -f "$P12_FILE"
-          echo "signed=true" >> "$GITHUB_OUTPUT"
-
-      - name: Sign native .node binaries for notarization
-        if: matrix.platform == 'mac' && steps.tauri_mac_signing.outputs.signed == 'true'
-        env:
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-        run: |
-          find packages/desktop-tauri/out -name "*.node" -exec \
-            codesign --sign "$APPLE_SIGNING_IDENTITY" \
-                     --timestamp \
-                     --options runtime \
-                     --force {} \;
-
-      - name: Pack Tauri (${{ matrix.platform }} ${{ matrix.arch }})
-        run: npx tauri build --target ${{ matrix.rust_target }}
-        working-directory: packages/desktop-tauri
-        env:
-          APPLE_SIGNING_IDENTITY: ${{ matrix.platform == 'mac' && secrets.APPLE_SIGNING_IDENTITY || '' }}
-          APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}
-          APPLE_PASSWORD: ${{ matrix.platform == 'mac' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
-          APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}
-
-      - name: Stage Tauri bundle files
-        shell: bash
-        env:
-          VERSION: ${{ needs.configure.outputs.version }}
-          MATRIX_PLATFORM: ${{ matrix.platform }}
-          MATRIX_ARCH: ${{ matrix.arch }}
-        run: |
-          set -euo pipefail
-          mkdir -p tauri-dist
-          BUNDLE="packages/desktop-tauri/src-tauri/target/${{ matrix.rust_target }}/release/bundle"
-          if [[ "$MATRIX_PLATFORM" == "mac" ]]; then
-            EB_PLATFORM=darwin
-          else
-            EB_PLATFORM=win32
-          fi
-          # Mirror Electron artifactName: ${productName}-${version}-${platform}-${arch}.${ext}, plus "-tauri-"
-          BASE="CCRelay-${VERSION}-tauri-${EB_PLATFORM}-${MATRIX_ARCH}"
-          if [[ ! -d "$BUNDLE" ]]; then
-            echo "Missing bundle dir: $BUNDLE" >&2
-            exit 1
-          fi
-          copied=0
-          while IFS= read -r -d '' f; do
-            case "$f" in
-              *.dmg)
-                cp "$f" "tauri-dist/${BASE}.dmg"
-                copied=$((copied + 1))
-                ;;
-              *.exe)
-                cp "$f" "tauri-dist/${BASE}.exe"
-                copied=$((copied + 1))
-                ;;
-              *.app.tar.gz)
-                cp "$f" "tauri-dist/${BASE}.app.tar.gz"
-                copied=$((copied + 1))
-                ;;
-              *) ;;
-            esac
-          done < <(find "$BUNDLE" -type f \( -name '*.dmg' -o -name '*.exe' -o -name '*.app.tar.gz' \) -print0)
-          if [[ "$copied" -eq 0 ]]; then
-            echo "No installable .dmg/.exe/.app.tar.gz under $BUNDLE" >&2
-            exit 1
-          fi
-          ls -la tauri-dist/
-
-      - name: Upload Tauri artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ccrelay-tauri-${{ matrix.platform }}-${{ matrix.arch }}-${{ needs.configure.outputs.version }}${{ inputs.suffix }}
-          path: tauri-dist/*
-          if-no-files-found: error
-          retention-days: ${{ inputs.retention_days }}
-
-      - name: Cleanup signing keychain
-        if: matrix.platform == 'mac' && always()
-        run: security delete-keychain build.keychain || true
+  # Tauri CI builds disabled — packages/desktop-tauri code retained for local builds
+  # build-tauri:
+  #   needs: configure
+  #   if: ${{ needs.configure.outputs.want_build_tauri == 'true' }}
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include: ${{ fromJSON(needs.configure.outputs.tauri_matrix) }}
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #
+  #     - name: Setup Rust
+  #       uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         targets: ${{ matrix.rust_target }}
+  #
+  #     - name: Cache Cargo
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: |
+  #           ~/.cargo/registry
+  #           ~/.cargo/git
+  #           packages/desktop-tauri/src-tauri/target
+  #         key: cargo-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('packages/desktop-tauri/src-tauri/Cargo.lock') }}
+  #         restore-keys: |
+  #           cargo-${{ runner.os }}-${{ matrix.arch }}-
+  #
+  #     - name: Setup Node.js
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: '22'
+  #         cache: 'npm'
+  #         cache-dependency-path: |
+  #           package-lock.json
+  #           web/package-lock.json
+  #
+  #     - name: Install dependencies
+  #       run: npm install
+  #
+  #     - name: Build Tauri (frontend, sidecar, Rust host prep)
+  #       run: npm run tauri:build
+  #
+  #     - name: Import signing certificate
+  #       id: tauri_mac_signing
+  #       if: matrix.platform == 'mac'
+  #       env:
+  #         CSC_LINK: ${{ secrets.APPLE_CSC_LINK }}
+  #         CSC_KEY_PASSWORD: ${{ secrets.APPLE_CSC_KEY_PASSWORD }}
+  #       run: |
+  #         set -euo pipefail
+  #         if [[ -z "${CSC_LINK:-}" ]]; then
+  #           echo "signed=false" >> "$GITHUB_OUTPUT"
+  #           echo "No APPLE_CSC_LINK secret — skipping signing certificate import"
+  #           exit 0
+  #         fi
+  #         KEYCHAIN=build.keychain
+  #         KEYCHAIN_PASSWORD="$(openssl rand -base64 16)"
+  #         P12_FILE="$RUNNER_TEMP/cert.p12"
+  #         echo "$CSC_LINK" | base64 --decode > "$P12_FILE"
+  #         security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+  #         security default-keychain -s "$KEYCHAIN"
+  #         security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+  #         security import "$P12_FILE" -k "$KEYCHAIN" -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+  #         security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+  #         security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
+  #         rm -f "$P12_FILE"
+  #         echo "signed=true" >> "$GITHUB_OUTPUT"
+  #
+  #     - name: Sign native .node binaries for notarization
+  #       if: matrix.platform == 'mac' && steps.tauri_mac_signing.outputs.signed == 'true'
+  #       env:
+  #         APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+  #       run: |
+  #         find packages/desktop-tauri/out -name "*.node" -exec \
+  #           codesign --sign "$APPLE_SIGNING_IDENTITY" \
+  #                    --timestamp \
+  #                    --options runtime \
+  #                    --force {} \;
+  #
+  #     - name: Pack Tauri (${{ matrix.platform }} ${{ matrix.arch }})
+  #       run: npx tauri build --target ${{ matrix.rust_target }}
+  #       working-directory: packages/desktop-tauri
+  #       env:
+  #         APPLE_SIGNING_IDENTITY: ${{ matrix.platform == 'mac' && secrets.APPLE_SIGNING_IDENTITY || '' }}
+  #         APPLE_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_ID || '' }}
+  #         APPLE_PASSWORD: ${{ matrix.platform == 'mac' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+  #         APPLE_TEAM_ID: ${{ matrix.platform == 'mac' && secrets.APPLE_TEAM_ID || '' }}
+  #
+  #     - name: Stage Tauri bundle files
+  #       shell: bash
+  #       env:
+  #         VERSION: ${{ needs.configure.outputs.version }}
+  #         MATRIX_PLATFORM: ${{ matrix.platform }}
+  #         MATRIX_ARCH: ${{ matrix.arch }}
+  #       run: |
+  #         set -euo pipefail
+  #         mkdir -p tauri-dist
+  #         BUNDLE="packages/desktop-tauri/src-tauri/target/${{ matrix.rust_target }}/release/bundle"
+  #         if [[ "$MATRIX_PLATFORM" == "mac" ]]; then
+  #           EB_PLATFORM=darwin
+  #         else
+  #           EB_PLATFORM=win32
+  #         fi
+  #         # Mirror Electron artifactName: ${productName}-${version}-${platform}-${arch}.${ext}, plus "-tauri-"
+  #         BASE="CCRelay-${VERSION}-tauri-${EB_PLATFORM}-${MATRIX_ARCH}"
+  #         if [[ ! -d "$BUNDLE" ]]; then
+  #           echo "Missing bundle dir: $BUNDLE" >&2
+  #           exit 1
+  #         fi
+  #         copied=0
+  #         while IFS= read -r -d '' f; do
+  #           case "$f" in
+  #             *.dmg)
+  #               cp "$f" "tauri-dist/${BASE}.dmg"
+  #               copied=$((copied + 1))
+  #               ;;
+  #             *.exe)
+  #               cp "$f" "tauri-dist/${BASE}.exe"
+  #               copied=$((copied + 1))
+  #               ;;
+  #             *.app.tar.gz)
+  #               cp "$f" "tauri-dist/${BASE}.app.tar.gz"
+  #               copied=$((copied + 1))
+  #               ;;
+  #             *) ;;
+  #           esac
+  #         done < <(find "$BUNDLE" -type f \( -name '*.dmg' -o -name '*.exe' -o -name '*.app.tar.gz' \) -print0)
+  #         if [[ "$copied" -eq 0 ]]; then
+  #           echo "No installable .dmg/.exe/.app.tar.gz under $BUNDLE" >&2
+  #           exit 1
+  #         fi
+  #         ls -la tauri-dist/
+  #
+  #     - name: Upload Tauri artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: ccrelay-tauri-${{ matrix.platform }}-${{ matrix.arch }}-${{ needs.configure.outputs.version }}${{ inputs.suffix }}
+  #         path: tauri-dist/*
+  #         if-no-files-found: error
+  #         retention-days: ${{ inputs.retention_days }}
+  #
+  #     - name: Cleanup signing keychain
+  #       if: matrix.platform == 'mac' && always()
+  #       run: security delete-keychain build.keychain || true
 
   release:
     runs-on: ubuntu-latest
-    needs: [configure, build-vscode, build-desktop, build-tauri]
+    # build-tauri removed from needs (Tauri CI builds disabled)
+    needs: [configure, build-vscode, build-desktop]
     if: >-
       ${{ always()
         && inputs.create_release
@@ -572,7 +580,6 @@ jobs:
         && needs.configure.outputs.want_any_build == 'true'
         && (needs.configure.outputs.want_build_vscode != 'true' || needs.build-vscode.result == 'success')
         && (needs.configure.outputs.want_build_desktop != 'true' || needs.build-desktop.result == 'success')
-        && (needs.configure.outputs.want_build_tauri != 'true' || needs.build-tauri.result == 'success')
       }}
     steps:
       # Checkout first: download-artifact after checkout so clean:true does not wipe assets.

--- a/.github/workflows/build-dev-auto.yml
+++ b/.github/workflows/build-dev-auto.yml
@@ -25,11 +25,12 @@ on:
           - desktop-mac-arm64
           - desktop-win-x64
           - desktop-win-arm64
-          - tauri
-          - tauri-mac
-          - tauri-win
-          - tauri-mac-arm64
-          - tauri-win-x64
+          # Tauri CI builds disabled
+          # - tauri
+          # - tauri-mac
+          # - tauri-win
+          # - tauri-mac-arm64
+          # - tauri-win-x64
         default: all
 
 permissions:
@@ -68,8 +69,9 @@ jobs:
               - 'packages/vscode/**'
             desktop:
               - 'packages/desktop/**'
-            tauri:
-              - 'packages/desktop-tauri/**'
+            # Tauri CI builds disabled — packages/desktop-tauri changes no longer trigger builds
+            # tauri:
+            #   - 'packages/desktop-tauri/**'
 
       - name: Resolve build targets
         id: targets
@@ -79,7 +81,7 @@ jobs:
           SHARED: ${{ steps.filter.outputs.shared }}
           VSCODE: ${{ steps.filter.outputs.vscode }}
           DESKTOP: ${{ steps.filter.outputs.desktop }}
-          TAURI: ${{ steps.filter.outputs.tauri }}
+          # TAURI: ${{ steps.filter.outputs.tauri }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
@@ -103,9 +105,9 @@ jobs:
           if [ "$DESKTOP" = "true" ]; then
             TARGETS="${TARGETS:+$TARGETS,}desktop"
           fi
-          if [ "$TAURI" = "true" ]; then
-            TARGETS="${TARGETS:+$TARGETS,}tauri"
-          fi
+          # if [ "$TAURI" = "true" ]; then
+          #   TARGETS="${TARGETS:+$TARGETS,}tauri"
+          # fi
 
           if [ -z "$TARGETS" ]; then
             echo "build_targets=none" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-dev-manual.yml
+++ b/.github/workflows/build-dev-manual.yml
@@ -17,11 +17,12 @@ on:
           - desktop-mac-arm64
           - desktop-win-x64
           - desktop-win-arm64
-          - tauri
-          - tauri-mac
-          - tauri-win
-          - tauri-mac-arm64
-          - tauri-win-x64
+          # Tauri CI builds disabled
+          # - tauri
+          # - tauri-mac
+          # - tauri-win
+          # - tauri-mac-arm64
+          # - tauri-win-x64
         default: all
       suffix:
         description: 'Optional suffix for artifact name (e.g., test, debug)'

--- a/.github/workflows/build-prod.yml
+++ b/.github/workflows/build-prod.yml
@@ -17,11 +17,12 @@ on:
           - desktop-mac-arm64
           - desktop-win-x64
           - desktop-win-arm64
-          - tauri
-          - tauri-mac
-          - tauri-win
-          - tauri-mac-arm64
-          - tauri-win-x64
+          # Tauri CI builds disabled
+          # - tauri
+          # - tauri-mac
+          # - tauri-win
+          # - tauri-mac-arm64
+          # - tauri-win-x64
         default: all
       tag_name:
         description: 'Tag name to release (e.g., v1.0.0), will use package.json version if empty'

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ An optional Electron desktop app (`packages/desktop`) runs the same core as the 
 - Tray menu → **Open Dashboard** loads the web UI in an app window; **Open Logs Folder** opens runtime diagnostics under `~/.ccrelay/logs/`
 - Packaged builds check for updates automatically (about 15 seconds after launch, then once every 24 hours). Use the tray menu → **Check for Updates…** to check immediately. Confirming an update downloads it and restarts the app to install. Auto-update is not available when running from source.
 - Tray → **Update Channel** switches between **Stable** (`channel-prod`) and **Dev** (`channel-dev`). The choice is stored locally under the app user data directory and overrides the feed baked into that install.
+- Packaged dashboard uses a frameless window: macOS keeps native traffic lights; Windows/Linux show minimize / maximize / close in the header. Drag the empty header area to move the window.
 - Download from [GitHub Releases](https://github.com/inflaborg/ccrelay/releases):
   - **macOS**: `CCRelay-<version>-darwin-arm64.dmg` or `-darwin-x64.dmg`
   - **Windows**: `CCRelay-<version>-win32-x64.exe` or `-win32-arm64.exe`

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ An optional Electron desktop app (`packages/desktop`) runs the same core as the 
 - Stores request logs with in-process SQLite (no system `sqlite3` binary required for the default desktop build)
 - Tray menu → **Open Dashboard** loads the web UI in an app window; **Open Logs Folder** opens runtime diagnostics under `~/.ccrelay/logs/`
 - Packaged builds check for updates automatically (about 15 seconds after launch, then once every 24 hours). Use the tray menu → **Check for Updates…** to check immediately. Confirming an update downloads it and restarts the app to install. Auto-update is not available when running from source.
+- Tray → **Update Channel** switches between **Stable** (`channel-prod`) and **Dev** (`channel-dev`). The choice is stored locally under the app user data directory and overrides the feed baked into that install.
 - Download from [GitHub Releases](https://github.com/inflaborg/ccrelay/releases):
   - **macOS**: `CCRelay-<version>-darwin-arm64.dmg` or `-darwin-x64.dmg`
   - **Windows**: `CCRelay-<version>-win32-x64.exe` or `-win32-arm64.exe`

--- a/README_CN.md
+++ b/README_CN.md
@@ -139,6 +139,7 @@ npm run compile        # 或 npm run watch
 - 请求日志使用进程内 SQLite（默认桌面构建无需系统 `sqlite3` 命令）
 - 托盘菜单 → **打开控制台** 在应用窗口内加载 Web UI；**打开日志目录** 可打开 `~/.ccrelay/logs/` 下的运行诊断日志
 - 正式安装包会自动检查更新（启动约 15 秒后，以及之后每 24 小时）。也可在托盘菜单 → **Check for Updates…** 立即检查。确认后下载并重启以完成安装。从源码运行时不提供自动更新。
+- 托盘 → **Update Channel** 可在 **Stable**（`channel-prod`）与 **Dev**（`channel-dev`）之间切换。选择保存在本机应用用户数据目录，并覆盖该安装包内置的更新源。
 - 从 [GitHub Releases](https://github.com/inflaborg/ccrelay/releases) 下载：
   - **macOS**: `CCRelay-<版本>-darwin-arm64.dmg` 或 `-darwin-x64.dmg`
   - **Windows**: `CCRelay-<版本>-win32-x64.exe` 或 `-win32-arm64.exe`

--- a/README_CN.md
+++ b/README_CN.md
@@ -140,6 +140,7 @@ npm run compile        # 或 npm run watch
 - 托盘菜单 → **打开控制台** 在应用窗口内加载 Web UI；**打开日志目录** 可打开 `~/.ccrelay/logs/` 下的运行诊断日志
 - 正式安装包会自动检查更新（启动约 15 秒后，以及之后每 24 小时）。也可在托盘菜单 → **Check for Updates…** 立即检查。确认后下载并重启以完成安装。从源码运行时不提供自动更新。
 - 托盘 → **Update Channel** 可在 **Stable**（`channel-prod`）与 **Dev**（`channel-dev`）之间切换。选择保存在本机应用用户数据目录，并覆盖该安装包内置的更新源。
+- 正式版控制台为无边框窗口：macOS 保留原生红绿灯；Windows/Linux 在标题栏右侧提供最小化 / 最大化 / 关闭。在标题栏空白区域拖拽可移动窗口。
 - 从 [GitHub Releases](https://github.com/inflaborg/ccrelay/releases) 下载：
   - **macOS**: `CCRelay-<版本>-darwin-arm64.dmg` 或 `-darwin-x64.dmg`
   - **Windows**: `CCRelay-<版本>-win32-x64.exe` 或 `-win32-arm64.exe`

--- a/packages/desktop/src/autoUpdate.ts
+++ b/packages/desktop/src/autoUpdate.ts
@@ -1,7 +1,8 @@
 /**
  * Packaged-build auto-update via electron-updater (generic provider).
- * Feed URL is baked at pack time from electron-builder `publish.url`
- * (channel-prod / channel-dev). Manifest filenames are always
+ * Feed URL defaults to the pack-time electron-builder `publish.url`
+ * (channel-prod / channel-dev). Users can override via tray → Update Channel;
+ * preference is stored in userData. Manifest filenames are always
  * latest-mac.yml / latest.yml (`publish.channel: latest`) so prerelease
  * app versions like 0.2.9-dev.N do not request missing dev-mac.yml files.
  */
@@ -9,6 +10,12 @@
 import { BrowserWindow, app, dialog } from "electron";
 import type { AppUpdater, UpdateInfo } from "electron-updater";
 import { Logger } from "@ccrelay/core";
+import {
+  feedUrlForChannel,
+  loadUpdateChannel,
+  saveUpdateChannel,
+  type UpdateChannel,
+} from "./updateChannel";
 
 const log = Logger.getInstance();
 
@@ -21,6 +28,8 @@ let manualCheck = false;
 let checking = false;
 let startupTimer: ReturnType<typeof setTimeout> | null = null;
 let dailyInterval: ReturnType<typeof setInterval> | null = null;
+/** Runtime preference; null means use pack-time baked feed. */
+let activeChannel: UpdateChannel | null = null;
 
 function parentWindow(): BrowserWindow | null {
   return BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0] ?? null;
@@ -95,6 +104,31 @@ async function promptInstall(info: UpdateInfo): Promise<void> {
   }
 }
 
+function applyUpdateChannel(channel: UpdateChannel): void {
+  if (!updater) {
+    return;
+  }
+  const url = feedUrlForChannel(channel);
+  updater.setFeedURL({
+    provider: "generic",
+    url,
+    channel: "latest",
+  });
+  updater.allowPrerelease = channel === "dev";
+  activeChannel = channel;
+  log.info(`[autoUpdater] update channel set to ${channel} (${url})`);
+}
+
+export function getUpdateChannel(): UpdateChannel | null {
+  return activeChannel;
+}
+
+export async function setUpdateChannel(channel: UpdateChannel): Promise<void> {
+  saveUpdateChannel(channel);
+  applyUpdateChannel(channel);
+  await requestUpdateCheck(true);
+}
+
 export function isNativeUpdaterEnabled(): boolean {
   return app.isPackaged && updater !== null;
 }
@@ -155,6 +189,11 @@ export function initAutoUpdate(): void {
     // blockmap path rewriting always 404s; skip the failed attempt and full-download.
     autoUpdater.disableDifferentialDownload = true;
     updater = autoUpdater;
+
+    const preferred = loadUpdateChannel();
+    if (preferred) {
+      applyUpdateChannel(preferred);
+    }
 
     autoUpdater.on("update-available", (info: UpdateInfo) => {
       void promptDownload(info);

--- a/packages/desktop/src/dashboardProtocol.ts
+++ b/packages/desktop/src/dashboardProtocol.ts
@@ -14,6 +14,8 @@ export type DashboardInjectConfig = {
   apiBearer: string;
   locale?: string;
   nativeUpdater?: boolean;
+  /** process.platform when running inside Electron desktop */
+  desktopPlatform?: string;
 };
 
 /* eslint-disable @typescript-eslint/naming-convention -- file extension keys */
@@ -59,7 +61,7 @@ export function registerDashboardProtocolSchemes(): void {
 }
 
 function buildInjectScript(config: DashboardInjectConfig): string {
-  return `<script>window.CCRELAY_API_URL=${JSON.stringify(config.apiOrigin)};window.CCRELAY_API_BEARER=${JSON.stringify(config.apiBearer)};window.CCRELAY_LOCALE=${JSON.stringify(config.locale ?? "")};window.CCRELAY_NATIVE_UPDATER=${config.nativeUpdater === true ? "true" : "false"};</script>`;
+  return `<script>window.CCRELAY_API_URL=${JSON.stringify(config.apiOrigin)};window.CCRELAY_API_BEARER=${JSON.stringify(config.apiBearer)};window.CCRELAY_LOCALE=${JSON.stringify(config.locale ?? "")};window.CCRELAY_NATIVE_UPDATER=${config.nativeUpdater === true ? "true" : "false"};window.CCRELAY_DESKTOP_PLATFORM=${JSON.stringify(config.desktopPlatform ?? "")};</script>`;
 }
 
 function resolveAssetPath(urlPathname: string): string | null {

--- a/packages/desktop/src/preload.ts
+++ b/packages/desktop/src/preload.ts
@@ -1,0 +1,23 @@
+/**
+ * Preload bridge for frameless window controls (Windows/Linux).
+ * Drag uses CSS -webkit-app-region in the renderer — not simulated here.
+ */
+
+import { contextBridge, ipcRenderer } from "electron";
+
+contextBridge.exposeInMainWorld("ccrelayDesktop", {
+  platform: process.platform,
+  minimize: (): Promise<void> => ipcRenderer.invoke("desktop:window-minimize"),
+  toggleMaximize: (): Promise<void> => ipcRenderer.invoke("desktop:window-toggle-maximize"),
+  close: (): Promise<void> => ipcRenderer.invoke("desktop:window-close"),
+  isMaximized: (): Promise<boolean> => ipcRenderer.invoke("desktop:window-is-maximized"),
+  onMaximizedChange: (callback: (maximized: boolean) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, maximized: boolean): void => {
+      callback(maximized);
+    };
+    ipcRenderer.on("desktop:window-maximized", handler);
+    return () => {
+      ipcRenderer.removeListener("desktop:window-maximized", handler);
+    };
+  },
+});

--- a/packages/desktop/src/tray.ts
+++ b/packages/desktop/src/tray.ts
@@ -6,7 +6,8 @@ import { Tray, Menu, shell, nativeImage, app } from "electron";
 import * as path from "path";
 import { getLogDir, type ConfigManager, type ProxyServer } from "@ccrelay/core";
 import { setOpenAtLogin, getOpenAtLogin } from "./autoLaunch";
-import { requestUpdateCheck } from "./autoUpdate";
+import { getUpdateChannel, requestUpdateCheck, setUpdateChannel } from "./autoUpdate";
+import { labelForChannel, type UpdateChannel } from "./updateChannel";
 import { showDashboardWindow, updateDashboardInjectConfig } from "./window";
 
 /** macOS tray uses template (monochrome); Windows/Linux use the full-color asset. */
@@ -101,6 +102,23 @@ export function createTray(server: ProxyServer, config: ConfigManager): Tray {
         click: (): void => {
           void requestUpdateCheck(true);
         },
+      },
+      {
+        label: "Update Channel",
+        enabled: app.isPackaged,
+        toolTip: app.isPackaged ? undefined : "Update channel is only available in packaged builds",
+        submenu: (["prod", "dev"] as UpdateChannel[]).map(channel => ({
+          label: labelForChannel(channel),
+          type: "radio" as const,
+          checked: (getUpdateChannel() ?? "prod") === channel,
+          enabled: app.isPackaged,
+          click: (): void => {
+            if ((getUpdateChannel() ?? "prod") === channel) {
+              return;
+            }
+            void setUpdateChannel(channel).finally(() => updateMenu());
+          },
+        })),
       },
       { type: "separator" },
       {

--- a/packages/desktop/src/updateChannel.ts
+++ b/packages/desktop/src/updateChannel.ts
@@ -1,0 +1,51 @@
+/**
+ * Persist Electron update channel preference (Stable/prod vs Dev) under userData.
+ */
+
+import { app } from "electron";
+import * as fs from "fs";
+import * as path from "path";
+
+export type UpdateChannel = "prod" | "dev";
+
+const PREFS_FILENAME = "update-channel.json";
+const FEED_BASE = "https://github.com/inflaborg/ccrelay/releases/download";
+
+function prefsPath(): string {
+  return path.join(app.getPath("userData"), PREFS_FILENAME);
+}
+
+export function isUpdateChannel(value: unknown): value is UpdateChannel {
+  return value === "prod" || value === "dev";
+}
+
+export function feedUrlForChannel(channel: UpdateChannel): string {
+  return `${FEED_BASE}/channel-${channel}`;
+}
+
+export function labelForChannel(channel: UpdateChannel): string {
+  return channel === "prod" ? "Stable" : "Dev";
+}
+
+export function loadUpdateChannel(): UpdateChannel | null {
+  try {
+    const raw = fs.readFileSync(prefsPath(), "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      isUpdateChannel((parsed as { channel?: unknown }).channel)
+    ) {
+      return (parsed as { channel: UpdateChannel }).channel;
+    }
+  } catch {
+    // Missing or invalid file — use pack-time feed.
+  }
+  return null;
+}
+
+export function saveUpdateChannel(channel: UpdateChannel): void {
+  const file = prefsPath();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify({ channel }, null, 2)}\n`, "utf8");
+}

--- a/packages/desktop/src/window.ts
+++ b/packages/desktop/src/window.ts
@@ -1,9 +1,14 @@
 /**
  * Electron BrowserWindow loads the dashboard from bundled web assets (custom protocol).
  * API calls still target the proxy server on the configured host/port.
+ *
+ * Frameless chrome:
+ * - macOS: hiddenInset title bar + native traffic lights; drag via CSS app-region
+ * - Windows/Linux: frame:false + renderer caption buttons via preload IPC
  */
 
 import { BrowserWindow, app } from "electron";
+import * as path from "path";
 import type { ProxyServer, ConfigManager } from "@ccrelay/core";
 import { isNativeUpdaterEnabled } from "./autoUpdate";
 import {
@@ -12,6 +17,7 @@ import {
   type DashboardInjectConfig,
 } from "./dashboardProtocol";
 import { attachExternalLinkHandlers } from "./externalLinks";
+import { attachMaximizedEvents, registerWindowControlIpc } from "./windowControlsIpc";
 
 let dashboardWin: BrowserWindow | null = null;
 
@@ -26,11 +32,16 @@ function buildInjectConfig(server: ProxyServer, config: ConfigManager): Dashboar
     apiBearer: config.getApiBearerToken(),
     locale: config.locale,
     nativeUpdater: isNativeUpdaterEnabled(),
+    desktopPlatform: process.platform,
   };
 }
 
 export function updateDashboardInjectConfig(server: ProxyServer, config: ConfigManager): void {
   setDashboardInjectConfig(buildInjectConfig(server, config));
+}
+
+function preloadPath(): string {
+  return path.join(__dirname, "preload.js");
 }
 
 export function showDashboardWindow(server: ProxyServer, config: ConfigManager): void {
@@ -51,6 +62,10 @@ export function showDashboardWindow(server: ProxyServer, config: ConfigManager):
     return;
   }
 
+  registerWindowControlIpc();
+
+  const isMac = process.platform === "darwin";
+
   dashboardWin = new BrowserWindow({
     width: 1024,
     height: 720,
@@ -58,13 +73,25 @@ export function showDashboardWindow(server: ProxyServer, config: ConfigManager):
     minHeight: 480,
     title: "CCRelay",
     show: false,
+    backgroundColor: "#1f1f1f",
+    ...(isMac
+      ? {
+          titleBarStyle: "hiddenInset" as const,
+          trafficLightPosition: { x: 14, y: 12 },
+        }
+      : {
+          frame: false,
+          autoHideMenuBar: true,
+        }),
     webPreferences: {
+      preload: preloadPath(),
       nodeIntegration: false,
       contextIsolation: true,
       sandbox: true,
     },
   });
 
+  attachMaximizedEvents(dashboardWin);
   attachExternalLinkHandlers(dashboardWin.webContents);
 
   void dashboardWin.loadURL(url).catch(() => {
@@ -76,7 +103,7 @@ export function showDashboardWindow(server: ProxyServer, config: ConfigManager):
     dashboardWin?.focus();
   });
 
-  if (process.platform === "darwin") {
+  if (isMac) {
     void app.dock?.show();
   }
 

--- a/packages/desktop/src/windowControlsIpc.ts
+++ b/packages/desktop/src/windowControlsIpc.ts
@@ -1,0 +1,52 @@
+/**
+ * IPC handlers for frameless window caption buttons (Windows/Linux).
+ */
+
+import { BrowserWindow, ipcMain } from "electron";
+
+let registered = false;
+
+function windowFromEvent(event: Electron.IpcMainInvokeEvent): BrowserWindow | null {
+  return BrowserWindow.fromWebContents(event.sender);
+}
+
+export function registerWindowControlIpc(): void {
+  if (registered) {
+    return;
+  }
+  registered = true;
+
+  ipcMain.handle("desktop:window-minimize", event => {
+    windowFromEvent(event)?.minimize();
+  });
+
+  ipcMain.handle("desktop:window-toggle-maximize", event => {
+    const win = windowFromEvent(event);
+    if (!win) {
+      return;
+    }
+    if (win.isMaximized()) {
+      win.unmaximize();
+    } else {
+      win.maximize();
+    }
+  });
+
+  ipcMain.handle("desktop:window-close", event => {
+    windowFromEvent(event)?.close();
+  });
+
+  ipcMain.handle("desktop:window-is-maximized", event => {
+    return windowFromEvent(event)?.isMaximized() ?? false;
+  });
+}
+
+export function attachMaximizedEvents(win: BrowserWindow): void {
+  const send = (maximized: boolean): void => {
+    if (!win.isDestroyed()) {
+      win.webContents.send("desktop:window-maximized", maximized);
+    }
+  };
+  win.on("maximize", () => send(true));
+  win.on("unmaximize", () => send(false));
+}

--- a/scripts/esbuild.desktop.mjs
+++ b/scripts/esbuild.desktop.mjs
@@ -42,8 +42,14 @@ await esbuild.build({
 
 await esbuild.build({
   ...commonOptions,
+  entryPoints: [path.join(desktopDir, "src/preload.ts")],
+  outfile: path.join(outDir, "preload.js"),
+});
+
+await esbuild.build({
+  ...commonOptions,
   entryPoints: [path.join(coreDir, "src/database/worker/worker.ts")],
   outfile: path.join(outDir, "database-worker.cjs"),
 });
 
-console.log("Desktop main + database worker bundles created successfully");
+console.log("Desktop main + preload + database worker bundles created successfully");

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo, type ComponentType } from "react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -10,6 +10,7 @@ import {
   Terminal,
   Route,
   MessageSquare,
+  ChevronDown,
 } from "lucide-react";
 import { api } from "./api/client";
 import { applyAppLocale, parseAppLocale } from "./i18n";
@@ -23,6 +24,17 @@ import Settings from "./features/settings/Settings";
 import Capabilities from "./features/capabilities/Capabilities";
 import { LanguageModal } from "./components/LanguageModal";
 import { VersionFooter } from "./components/VersionFooter";
+import { WindowCaptionButtons } from "./components/WindowCaptionButtons";
+import { Button } from "./components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "./components/ui/dropdown-menu";
+import { isDarwinDesktop, isElectronDesktop, needsWindowCaptionButtons } from "./lib/desktopShell";
 import { cn } from "./lib/utils";
 
 // CCRelay icon as data URI (works in VSCode webview)
@@ -47,6 +59,23 @@ const VALID_TABS: Tab[] = [
   "capabilities",
   "logs",
   "settings",
+];
+
+type NavItem = {
+  id: Tab;
+  labelKey: `nav.${Tab}`;
+  icon: ComponentType<{ className?: string }>;
+};
+
+const NAV_ITEMS: NavItem[] = [
+  { id: "chat", labelKey: "nav.chat", icon: MessageSquare },
+  { id: "clientConfig", labelKey: "nav.clientConfig", icon: Terminal },
+  { id: "dashboard", labelKey: "nav.dashboard", icon: Server },
+  { id: "smartRouting", labelKey: "nav.smartRouting", icon: Route },
+  { id: "providers", labelKey: "nav.providers", icon: Activity },
+  { id: "capabilities", labelKey: "nav.capabilities", icon: Puzzle },
+  { id: "logs", labelKey: "nav.logs", icon: Database },
+  { id: "settings", labelKey: "nav.settings", icon: SettingsIcon },
 ];
 
 function useHashTab(defaultTab: Tab): [Tab, (tab: Tab) => void] {
@@ -110,112 +139,127 @@ function App() {
     }
   }, [loggingEnabled, activeTab, setActiveTab]);
 
+  const navItems = useMemo(
+    () => NAV_ITEMS.filter(item => item.id !== "logs" || loggingEnabled),
+    [loggingEnabled]
+  );
+
+  const activeNav = navItems.find(item => item.id === activeTab) ?? navItems[0];
+  const ActiveIcon = activeNav.icon;
+
   const uiLanguageKey = i18n.resolvedLanguage ?? i18n.language;
+  const electronDesktop = isElectronDesktop();
+  const darwinDesktop = isDarwinDesktop();
+  const showCaptionButtons = needsWindowCaptionButtons();
 
   return (
     <div key={uiLanguageKey} className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
-      {/* Header - Tab Style */}
-      <header className="bg-card flex-shrink-0 border-b border-border">
-        <div className="max-w-full px-2 sm:px-4">
-          <div className="flex flex-col sm:flex-row items-stretch sm:items-center sm:h-10 justify-between gap-3 sm:gap-0 pt-3 pb-3 sm:py-0">
-            <div className="flex items-center gap-1.5 px-1 sm:px-0">
+      {/* Header - Tab Style (Electron: frameless drag region + OS chrome) */}
+      <header
+        className={cn(
+          "bg-card relative flex-shrink-0 border-b border-border",
+          electronDesktop && "electron-drag select-none"
+        )}
+      >
+        {showCaptionButtons && (
+          <div className="absolute right-0 top-0 z-10">
+            <WindowCaptionButtons />
+          </div>
+        )}
+        <div
+          className={cn(
+            "max-w-full px-2 sm:px-4",
+            darwinDesktop && "pl-[78px] sm:pl-[78px]",
+            showCaptionButtons && "pr-[132px]"
+          )}
+        >
+          <div className="flex h-10 items-center gap-2">
+            <div className="flex min-w-0 shrink-0 items-center gap-1.5">
               <img src={iconSvg} alt="CCRelay" className="h-6 w-6 sm:h-8 sm:w-8" />
               <h1 className="text-[13px] sm:text-sm font-semibold">CCRelay</h1>
             </div>
-            <nav className="flex items-center w-full sm:w-auto">
-              <div className="flex w-full sm:w-auto bg-muted/50 sm:bg-transparent rounded-lg sm:rounded-none p-1 sm:p-0 gap-1 sm:gap-0">
-                <button
-                  className={`flex-1 sm:flex-none h-8 sm:h-10 px-2 sm:px-4 text-[11px] sm:text-xs sm:min-w-[80px] flex items-center justify-center gap-1.5 rounded-md sm:rounded-none transition-all duration-200 ${
-                    activeTab === "chat"
-                      ? "bg-background sm:bg-primary text-foreground sm:text-primary-foreground shadow-sm sm:shadow-none"
-                      : "text-muted-foreground sm:text-foreground hover:text-foreground sm:hover:bg-primary/15"
-                  }`}
-                  onClick={() => setActiveTab("chat")}
-                >
-                  <MessageSquare className="h-3.5 w-3.5" />
-                  <span className="hidden sm:inline">{t("nav.chat")}</span>
-                </button>
-                <button
-                  className={`flex-1 sm:flex-none h-8 sm:h-10 px-2 sm:px-4 text-[11px] sm:text-xs sm:min-w-[80px] flex items-center justify-center gap-1.5 rounded-md sm:rounded-none transition-all duration-200 ${
-                    activeTab === "clientConfig"
-                      ? "bg-background sm:bg-primary text-foreground sm:text-primary-foreground shadow-sm sm:shadow-none"
-                      : "text-muted-foreground sm:text-foreground hover:text-foreground sm:hover:bg-primary/15"
-                  }`}
-                  onClick={() => setActiveTab("clientConfig")}
-                >
-                  <Terminal className="h-3.5 w-3.5" />
-                  <span className="hidden sm:inline">{t("nav.clientConfig")}</span>
-                </button>
-                <button
-                  className={`flex-1 sm:flex-none h-8 sm:h-10 px-2 sm:px-4 text-[11px] sm:text-xs sm:min-w-[80px] flex items-center justify-center gap-1.5 rounded-md sm:rounded-none transition-all duration-200 ${
-                    activeTab === "dashboard"
-                      ? "bg-background sm:bg-primary text-foreground sm:text-primary-foreground shadow-sm sm:shadow-none"
-                      : "text-muted-foreground sm:text-foreground hover:text-foreground sm:hover:bg-primary/15"
-                  }`}
-                  onClick={() => setActiveTab("dashboard")}
-                >
-                  <Server className="h-3.5 w-3.5" />
-                  <span className="hidden sm:inline">{t("nav.dashboard")}</span>
-                </button>
-                <button
-                  className={`flex-1 sm:flex-none h-8 sm:h-10 px-2 sm:px-4 text-[11px] sm:text-xs sm:min-w-[80px] flex items-center justify-center gap-1.5 rounded-md sm:rounded-none transition-all duration-200 ${
-                    activeTab === "smartRouting"
-                      ? "bg-background sm:bg-primary text-foreground sm:text-primary-foreground shadow-sm sm:shadow-none"
-                      : "text-muted-foreground sm:text-foreground hover:text-foreground sm:hover:bg-primary/15"
-                  }`}
-                  onClick={() => setActiveTab("smartRouting")}
-                >
-                  <Route className="h-3.5 w-3.5" />
-                  <span className="hidden sm:inline">{t("nav.smartRouting")}</span>
-                </button>
-                <button
-                  className={`flex-1 sm:flex-none h-8 sm:h-10 px-2 sm:px-4 text-[11px] sm:text-xs sm:min-w-[80px] flex items-center justify-center gap-1.5 rounded-md sm:rounded-none transition-all duration-200 ${
-                    activeTab === "providers"
-                      ? "bg-background sm:bg-primary text-foreground sm:text-primary-foreground shadow-sm sm:shadow-none"
-                      : "text-muted-foreground sm:text-foreground hover:text-foreground sm:hover:bg-primary/15"
-                  }`}
-                  onClick={() => setActiveTab("providers")}
-                >
-                  <Activity className="h-3.5 w-3.5" />
-                  <span className="hidden sm:inline">{t("nav.providers")}</span>
-                </button>
-                <button
-                  className={`flex-1 sm:flex-none h-8 sm:h-10 px-2 sm:px-4 text-[11px] sm:text-xs sm:min-w-[80px] flex items-center justify-center gap-1.5 rounded-md sm:rounded-none transition-all duration-200 ${
-                    activeTab === "capabilities"
-                      ? "bg-background sm:bg-primary text-foreground sm:text-primary-foreground shadow-sm sm:shadow-none"
-                      : "text-muted-foreground sm:text-foreground hover:text-foreground sm:hover:bg-primary/15"
-                  }`}
-                  onClick={() => setActiveTab("capabilities")}
-                >
-                  <Puzzle className="h-3.5 w-3.5" />
-                  <span className="hidden sm:inline">{t("nav.capabilities")}</span>
-                </button>
-                {loggingEnabled && (
-                  <button
-                    className={`flex-1 sm:flex-none h-8 sm:h-10 px-2 sm:px-4 text-[11px] sm:text-xs sm:min-w-[80px] flex items-center justify-center gap-1.5 rounded-md sm:rounded-none transition-all duration-200 ${
-                      activeTab === "logs"
-                        ? "bg-background sm:bg-primary text-foreground sm:text-primary-foreground shadow-sm sm:shadow-none"
-                        : "text-muted-foreground sm:text-foreground hover:text-foreground sm:hover:bg-primary/15"
-                    }`}
-                    onClick={() => setActiveTab("logs")}
-                  >
-                    <Database className="h-3.5 w-3.5" />
-                    <span className="hidden sm:inline">{t("nav.logs")}</span>
-                  </button>
-                )}
-                <button
-                  className={`flex-1 sm:flex-none h-8 sm:h-10 px-2 sm:px-4 text-[11px] sm:text-xs sm:min-w-[80px] flex items-center justify-center gap-1.5 rounded-md sm:rounded-none transition-all duration-200 ${
-                    activeTab === "settings"
-                      ? "bg-background sm:bg-primary text-foreground sm:text-primary-foreground shadow-sm sm:shadow-none"
-                      : "text-muted-foreground sm:text-foreground hover:text-foreground sm:hover:bg-primary/15"
-                  }`}
-                  onClick={() => setActiveTab("settings")}
-                >
-                  <SettingsIcon className="h-3.5 w-3.5" />
-                  <span className="hidden sm:inline">{t("nav.settings")}</span>
-                </button>
+
+            {/* Wide: horizontal tabs */}
+            <nav
+              className={cn(
+                "ml-auto hidden min-w-0 items-center lg:flex",
+                electronDesktop && "electron-no-drag"
+              )}
+            >
+              <div className="flex items-center">
+                {navItems.map(item => {
+                  const Icon = item.icon;
+                  const selected = activeTab === item.id;
+                  return (
+                    <button
+                      key={item.id}
+                      type="button"
+                      className={cn(
+                        "flex h-10 min-w-[80px] items-center justify-center gap-1.5 px-4 text-xs transition-all duration-200",
+                        selected
+                          ? "bg-primary text-primary-foreground"
+                          : "text-foreground hover:bg-primary/15"
+                      )}
+                      onClick={() => setActiveTab(item.id)}
+                    >
+                      <Icon className="h-3.5 w-3.5" />
+                      <span>{t(item.labelKey)}</span>
+                    </button>
+                  );
+                })}
               </div>
             </nav>
+
+            {/* Narrow: collapsed current-tab menu */}
+            <div
+              className={cn(
+                "ml-auto flex min-w-0 items-center lg:hidden",
+                electronDesktop && "electron-no-drag"
+              )}
+            >
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-8 max-w-[min(100%,16rem)] gap-1.5 border-border bg-muted/40 px-2.5 text-xs"
+                    aria-label={t("nav.menu")}
+                  >
+                    <ActiveIcon className="h-3.5 w-3.5 shrink-0" />
+                    <span className="truncate">{t(activeNav.labelKey)}</span>
+                    <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-70" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  align="end"
+                  sideOffset={6}
+                  className="w-56 min-w-[12rem] border border-border bg-card p-1 text-card-foreground shadow-md"
+                >
+                  <DropdownMenuLabel className="px-2 py-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    {t("nav.menu")}
+                  </DropdownMenuLabel>
+                  <DropdownMenuRadioGroup
+                    value={activeTab}
+                    onValueChange={value => setActiveTab(value as Tab)}
+                  >
+                    {navItems.map(item => {
+                      const Icon = item.icon;
+                      return (
+                        <DropdownMenuRadioItem
+                          key={item.id}
+                          value={item.id}
+                          className="gap-2 rounded-md px-2 py-1.5 text-xs data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground"
+                        >
+                          <Icon className="h-3.5 w-3.5" />
+                          <span className="truncate">{t(item.labelKey)}</span>
+                        </DropdownMenuRadioItem>
+                      );
+                    })}
+                  </DropdownMenuRadioGroup>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
           </div>
         </div>
       </header>
@@ -261,7 +305,9 @@ function App() {
       <LanguageModal
         open={showLanguagePrompt}
         onOpenChange={open => {
-          if (!open) setLanguagePromptDismissed(true);
+          if (!open) {
+            setLanguagePromptDismissed(true);
+          }
         }}
       />
     </div>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -45,6 +45,17 @@ declare global {
     CCRELAY_LOCALE?: string;
     /** Injected by Electron desktop when native auto-update is active */
     CCRELAY_NATIVE_UPDATER?: boolean;
+    /** Injected by Electron desktop: process.platform (darwin/win32/linux) */
+    CCRELAY_DESKTOP_PLATFORM?: string;
+    /** Preload bridge for frameless window controls */
+    ccrelayDesktop?: {
+      platform: string;
+      minimize: () => Promise<void>;
+      toggleMaximize: () => Promise<void>;
+      close: () => Promise<void>;
+      isMaximized: () => Promise<boolean>;
+      onMaximizedChange: (callback: (maximized: boolean) => void) => () => void;
+    };
   }
 }
 

--- a/web/src/components/WindowCaptionButtons.tsx
+++ b/web/src/components/WindowCaptionButtons.tsx
@@ -1,0 +1,61 @@
+/**
+ * Windows/Linux caption buttons for frameless Electron windows.
+ */
+
+import { useEffect, useState } from "react";
+import { Minus, Square, Copy, X } from "lucide-react";
+import { cn } from "../lib/utils";
+
+function desktopApi(): Window["ccrelayDesktop"] | undefined {
+  return typeof window !== "undefined" ? window.ccrelayDesktop : undefined;
+}
+
+export function WindowCaptionButtons({ className }: { className?: string }) {
+  const api = desktopApi();
+  const [maximized, setMaximized] = useState(false);
+
+  useEffect(() => {
+    if (!api) {
+      return;
+    }
+    void api.isMaximized().then(setMaximized);
+    return api.onMaximizedChange(setMaximized);
+  }, [api]);
+
+  if (!api) {
+    return null;
+  }
+
+  return (
+    <div className={cn("electron-no-drag flex h-10 shrink-0 items-stretch", className)}>
+      <button
+        type="button"
+        aria-label="Minimize"
+        className="flex w-11 items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground"
+        onClick={() => void api.minimize()}
+      >
+        <Minus className="h-3.5 w-3.5" strokeWidth={1.75} />
+      </button>
+      <button
+        type="button"
+        aria-label={maximized ? "Restore" : "Maximize"}
+        className="flex w-11 items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground"
+        onClick={() => void api.toggleMaximize()}
+      >
+        {maximized ? (
+          <Copy className="h-3 w-3 scale-x-[-1]" strokeWidth={1.75} />
+        ) : (
+          <Square className="h-3 w-3" strokeWidth={1.75} />
+        )}
+      </button>
+      <button
+        type="button"
+        aria-label="Close"
+        className="flex w-11 items-center justify-center text-muted-foreground hover:bg-destructive hover:text-destructive-foreground"
+        onClick={() => void api.close()}
+      >
+        <X className="h-3.5 w-3.5" strokeWidth={1.75} />
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,248 @@
+import * as React from "react";
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+import { CheckIcon, ChevronRightIcon } from "lucide-react";
+
+function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return <DropdownMenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
+}
+
+function DropdownMenuContent({
+  className,
+  align = "start",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        align={align}
+        className={cn(
+          "z-50 max-h-(--radix-dropdown-menu-content-available-height) w-(--radix-dropdown-menu-trigger-width) min-w-32 origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:overflow-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />;
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "z-50 min-w-[96px] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+};

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -23,7 +23,8 @@
     "providers": "Providers",
     "capabilities": "Capabilities",
     "logs": "Logs",
-    "settings": "Settings"
+    "settings": "Settings",
+    "menu": "Navigation"
   },
   "chat": {
     "loading": "Loading…",

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -23,7 +23,8 @@
     "providers": "提供商",
     "capabilities": "能力",
     "logs": "日志",
-    "settings": "设置"
+    "settings": "设置",
+    "menu": "导航"
   },
   "chat": {
     "loading": "加载中…",

--- a/web/src/lib/desktopShell.ts
+++ b/web/src/lib/desktopShell.ts
@@ -1,0 +1,31 @@
+/** Electron desktop shell helpers (injected by packages/desktop dashboard protocol). */
+
+export type DesktopPlatform = "darwin" | "win32" | "linux" | string;
+
+export function getDesktopPlatform(): DesktopPlatform | "" {
+  if (typeof window === "undefined") {
+    return "";
+  }
+  const fromInject =
+    typeof window.CCRELAY_DESKTOP_PLATFORM === "string"
+      ? window.CCRELAY_DESKTOP_PLATFORM.trim()
+      : "";
+  if (fromInject) {
+    return fromInject;
+  }
+  return window.ccrelayDesktop?.platform ?? "";
+}
+
+export function isElectronDesktop(): boolean {
+  return getDesktopPlatform().length > 0;
+}
+
+export function isDarwinDesktop(): boolean {
+  return getDesktopPlatform() === "darwin";
+}
+
+/** Frameless platforms that need in-page caption buttons. */
+export function needsWindowCaptionButtons(): boolean {
+  const platform = getDesktopPlatform();
+  return platform === "win32" || platform === "linux";
+}

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -96,3 +96,14 @@ html {
 ::-webkit-scrollbar-thumb:hover {
   background: hsl(var(--muted-foreground));
 }
+
+/* Electron frameless titlebar: OS-native window drag (not JS-simulated). */
+.electron-drag {
+  -webkit-app-region: drag;
+  app-region: drag;
+}
+
+.electron-no-drag {
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+}


### PR DESCRIPTION
## Summary
- Disable Tauri packaging in GitHub Actions while keeping `packages/desktop-tauri` for local builds
- Let packaged Electron apps switch Stable (`channel-prod`) vs Dev (`channel-dev`) update feeds from the tray, with preference stored in userData
- Ship a frameless dashboard window (native macOS traffic lights; Windows/Linux caption buttons) with CSS `app-region` drag, and collapse header tabs into a dropdown below the `lg` breakpoint

## Test plan
- [ ] Confirm CI no longer schedules Tauri build jobs for `all` / shared-path changes
- [ ] Packaged Electron: tray → Update Channel switches Stable/Dev and triggers an update check; preference survives restart
- [ ] macOS: frameless window shows traffic lights; drag empty header area; tabs remain clickable
- [ ] Windows: minimize / maximize-restore / close work; drag empty header area is smooth
- [ ] Narrow window (`< lg`): header shows current-tab control; menu lists tabs and switches correctly
- [ ] Wide window (`≥ lg`): horizontal tabs still work; VS Code webview header unchanged (no desktop chrome)


Made with [Cursor](https://cursor.com)