### PR TITLE
Adjust header layout and add caption buttons

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -161,18 +161,7 @@ function App() {
           electronDesktop && "electron-drag select-none"
         )}
       >
-        {showCaptionButtons && (
-          <div className="absolute right-0 top-0 z-10">
-            <WindowCaptionButtons />
-          </div>
-        )}
-        <div
-          className={cn(
-            "max-w-full px-2 sm:px-4",
-            darwinDesktop && "pl-[78px] sm:pl-[78px]",
-            showCaptionButtons && "pr-[132px]"
-          )}
-        >
+        <div className={cn("max-w-full pl-2 sm:pl-4", darwinDesktop && "pl-[78px] sm:pl-[78px]")}>
           <div className="flex h-10 items-center gap-2">
             <div className="flex min-w-0 shrink-0 items-center gap-1.5">
               <img src={iconSvg} alt="CCRelay" className="h-6 w-6 sm:h-8 sm:w-8" />
@@ -182,11 +171,11 @@ function App() {
             {/* Wide: horizontal tabs */}
             <nav
               className={cn(
-                "ml-auto hidden min-w-0 items-center lg:flex",
+                "ml-auto hidden min-w-0 items-center overflow-hidden lg:flex",
                 electronDesktop && "electron-no-drag"
               )}
             >
-              <div className="flex items-center">
+              <div className="flex max-w-full items-center">
                 {navItems.map(item => {
                   const Icon = item.icon;
                   const selected = activeTab === item.id;
@@ -195,15 +184,15 @@ function App() {
                       key={item.id}
                       type="button"
                       className={cn(
-                        "flex h-10 min-w-[80px] items-center justify-center gap-1.5 px-4 text-xs transition-all duration-200",
+                        "flex h-10 min-w-0 shrink items-center justify-center gap-1.5 px-3 text-xs transition-all duration-200 xl:min-w-[80px] xl:px-4",
                         selected
                           ? "bg-primary text-primary-foreground"
                           : "text-foreground hover:bg-primary/15"
                       )}
                       onClick={() => setActiveTab(item.id)}
                     >
-                      <Icon className="h-3.5 w-3.5" />
-                      <span>{t(item.labelKey)}</span>
+                      <Icon className="h-3.5 w-3.5 shrink-0" />
+                      <span className="truncate">{t(item.labelKey)}</span>
                     </button>
                   );
                 })}
@@ -260,6 +249,8 @@ function App() {
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
+
+            {showCaptionButtons && <WindowCaptionButtons className="shrink-0" />}
           </div>
         </div>
       </header>

--- a/web/src/components/ServerStoppedScreen.tsx
+++ b/web/src/components/ServerStoppedScreen.tsx
@@ -1,6 +1,9 @@
 import { useTranslation } from "react-i18next";
 import { Loader2, ServerOff } from "lucide-react";
 import { getApiOriginLabel } from "@/api/serverReachability";
+import { WindowCaptionButtons } from "./WindowCaptionButtons";
+import { isDarwinDesktop, isElectronDesktop, needsWindowCaptionButtons } from "@/lib/desktopShell";
+import { cn } from "@/lib/utils";
 
 type ServerStoppedScreenProps = {
   checking: boolean;
@@ -9,9 +12,23 @@ type ServerStoppedScreenProps = {
 export default function ServerStoppedScreen({ checking }: ServerStoppedScreenProps) {
   const { t } = useTranslation();
   const endpoint = getApiOriginLabel();
+  const electronDesktop = isElectronDesktop();
+  const darwinDesktop = isDarwinDesktop();
+  const showCaptionButtons = needsWindowCaptionButtons();
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-6 py-12 text-center">
+    <div
+      className={cn(
+        "relative flex min-h-screen flex-col items-center justify-center bg-background px-6 py-12 text-center",
+        electronDesktop && "electron-drag select-none",
+        darwinDesktop && "pt-10"
+      )}
+    >
+      {showCaptionButtons && (
+        <div className="absolute right-0 top-0 z-10">
+          <WindowCaptionButtons />
+        </div>
+      )}
       <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-muted">
         <ServerOff className="h-7 w-7 text-muted-foreground" aria-hidden />
       </div>


### PR DESCRIPTION
Refactor App header to improve responsiveness and spacing: move/restore WindowCaptionButtons into header row, add overflow handling, shrinkable tab items, responsive min-width/padding, and truncate tab labels. Update ServerStoppedScreen to show window caption buttons on desktop builds, apply electron-drag/select-none, and add Darwin top padding. Import desktop helper functions and cn where needed. These UI tweaks fix layout clipping and ensure caption controls appear consistently on desktop shells.