### PR TITLE
feat: Chat edit/retry, update channel UX, streaming CORS fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+**Desktop**
+
+- Tray Update Channel now keeps the correct selection after restart (resolve preference / version default before building the menu). Dev installs default to Dev; stable installs default to Stable.
+
+### Added
+
+**Desktop**
+
+- Dashboard footer shows the current update channel (Stable / Dev) next to the version; tray changes update it live.
+
 ## [0.3.0] - 2026-07-25 (pre-release)
 
 Pre-release line for 0.3.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Desktop**
 
 - Tray Update Channel now keeps the correct selection after restart (resolve preference / version default before building the menu). Dev installs default to Dev; stable installs default to Stable.
+- Chat tab OpenAI protocol against Anthropic upstreams works again from the desktop dashboard: upstream CORS headers are stripped and CCRelay CORS is re-applied on proxied/streaming responses (writeHead was dropping the earlier CORS headers).
 
 ### Added
 
 **Desktop**
 
 - Dashboard footer shows the current update channel (Stable / Dev) next to the version; tray changes update it live.
+
+**UI**
+
+- Chat user messages can be edited inline; saving truncates later turns and retries the assistant reply.
 
 ## [0.3.0] - 2026-07-25 (pre-release)
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ An optional Electron desktop app (`packages/desktop`) runs the same core as the 
 - Stores request logs with in-process SQLite (no system `sqlite3` binary required for the default desktop build)
 - Tray menu → **Open Dashboard** loads the web UI in an app window; **Open Logs Folder** opens runtime diagnostics under `~/.ccrelay/logs/`
 - Packaged builds check for updates automatically (about 15 seconds after launch, then once every 24 hours). Use the tray menu → **Check for Updates…** to check immediately. Confirming an update downloads it and restarts the app to install. Auto-update is not available when running from source.
-- Tray → **Update Channel** switches between **Stable** (`channel-prod`) and **Dev** (`channel-dev`). The choice is stored locally under the app user data directory and overrides the feed baked into that install.
+- Tray → **Update Channel** switches between **Stable** (`channel-prod`) and **Dev** (`channel-dev`). Default follows the install (dev builds → Dev, stable builds → Stable). A tray choice is stored under the app user data directory and overrides that default.
 - Packaged dashboard uses a frameless window: macOS keeps native traffic lights; Windows/Linux show minimize / maximize / close in the header. Drag the empty header area to move the window.
 - Download from [GitHub Releases](https://github.com/inflaborg/ccrelay/releases):
   - **macOS**: `CCRelay-<version>-darwin-arm64.dmg` or `-darwin-x64.dmg`

--- a/README_CN.md
+++ b/README_CN.md
@@ -139,7 +139,7 @@ npm run compile        # 或 npm run watch
 - 请求日志使用进程内 SQLite（默认桌面构建无需系统 `sqlite3` 命令）
 - 托盘菜单 → **打开控制台** 在应用窗口内加载 Web UI；**打开日志目录** 可打开 `~/.ccrelay/logs/` 下的运行诊断日志
 - 正式安装包会自动检查更新（启动约 15 秒后，以及之后每 24 小时）。也可在托盘菜单 → **Check for Updates…** 立即检查。确认后下载并重启以完成安装。从源码运行时不提供自动更新。
-- 托盘 → **Update Channel** 可在 **Stable**（`channel-prod`）与 **Dev**（`channel-dev`）之间切换。选择保存在本机应用用户数据目录，并覆盖该安装包内置的更新源。
+- 托盘 → **Update Channel** 可在 **Stable**（`channel-prod`）与 **Dev**（`channel-dev`）之间切换。默认随安装包（dev 构建 → Dev，正式版 → Stable）。托盘选择保存在本机应用用户数据目录，并覆盖该默认值。
 - 正式版控制台为无边框窗口：macOS 保留原生红绿灯；Windows/Linux 在标题栏右侧提供最小化 / 最大化 / 关闭。在标题栏空白区域拖拽可移动窗口。
 - 从 [GitHub Releases](https://github.com/inflaborg/ccrelay/releases) 下载：
   - **macOS**: `CCRelay-<版本>-darwin-arm64.dmg` 或 `-darwin-x64.dmg`

--- a/packages/core/src/server/httpAccessGate.ts
+++ b/packages/core/src/server/httpAccessGate.ts
@@ -181,3 +181,30 @@ export function corsExtraAllowedHeadersCsv(): string {
   // anthropic-version is required by Anthropic Messages clients (e.g. Chat tab from desktop origin).
   return `Content-Type, X-API-Key, ${CCRELAY_UI_HEADER_NAME}, Authorization, anthropic-version`;
 }
+
+/** Upstream CORS headers must not be forwarded — they collide with CCRelay's own CORS. */
+const UPSTREAM_CORS_HEADER_NAMES = new Set([
+  "access-control-allow-origin",
+  "access-control-allow-methods",
+  "access-control-allow-headers",
+  "access-control-allow-credentials",
+  "access-control-expose-headers",
+  "access-control-max-age",
+]);
+
+export function isUpstreamCorsHeaderName(name: string): boolean {
+  return UPSTREAM_CORS_HEADER_NAMES.has(name.toLowerCase());
+}
+
+/**
+ * Apply CCRelay CORS on a headers object that will be passed to `writeHead`.
+ * `writeHead(status, headers)` replaces headers previously set via `setHeader`,
+ * so streaming/proxy paths must include CORS in that object.
+ */
+export function applyClientCorsHeaders(
+  headers: Record<string, string | string[] | number | undefined>
+): void {
+  headers["Access-Control-Allow-Origin"] = "*";
+  headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, DELETE, PATCH, OPTIONS";
+  headers["Access-Control-Allow-Headers"] = corsExtraAllowedHeadersCsv();
+}

--- a/packages/core/src/server/proxy/executor.ts
+++ b/packages/core/src/server/proxy/executor.ts
@@ -64,6 +64,7 @@ import type { RequestTask, ProxyResult } from "../../types";
 import type { ResponseLogger } from "../responseLogger";
 import type { LogResponseTiming } from "../../database/types";
 import type { ModelCatalog } from "../smartRouting/modelCatalog";
+import { applyClientCorsHeaders, isUpstreamCorsHeaderName } from "../httpAccessGate";
 import {
   synthesizeSmartRoutingModelsListBody,
   synthesizeSmartRoutingModelDetailBody,
@@ -88,12 +89,15 @@ function headersForResponsesSse(
       kl === "content-length" ||
       kl === "content-encoding" ||
       kl === "transfer-encoding" ||
-      kl === "cache-control"
+      kl === "cache-control" ||
+      isUpstreamCorsHeaderName(kl)
     ) {
       continue;
     }
     out[k] = v;
   }
+  // writeHead replaces earlier setCorsHeaders — keep browser/Electron Chat readable.
+  applyClientCorsHeaders(out);
   return out;
 }
 
@@ -104,6 +108,12 @@ const EXCLUDED_HEADERS = new Set([
   "transfer-encoding",
   "connection",
   "keep-alive",
+  "access-control-allow-origin",
+  "access-control-allow-methods",
+  "access-control-allow-headers",
+  "access-control-allow-credentials",
+  "access-control-expose-headers",
+  "access-control-max-age",
 ]);
 
 // Retryable error codes
@@ -658,6 +668,8 @@ export class ProxyExecutor {
         responseHeaders[key] = value;
       }
     }
+    // writeHead(status, headers) replaces CORS set in handleRequest — re-apply here.
+    applyClientCorsHeaders(responseHeaders);
     ctx.responseHeadersMasked = maskHeadersForLog(responseHeaders);
 
     const isJsonResponse = proxyRes.headers["content-type"]?.includes("application/json");

--- a/packages/desktop/src/autoUpdate.ts
+++ b/packages/desktop/src/autoUpdate.ts
@@ -1,16 +1,17 @@
 /**
  * Packaged-build auto-update via electron-updater (generic provider).
- * Feed URL defaults to the pack-time electron-builder `publish.url`
- * (channel-prod / channel-dev). Users can override via tray → Update Channel;
- * preference is stored in userData. Manifest filenames are always
- * latest-mac.yml / latest.yml (`publish.channel: latest`) so prerelease
- * app versions like 0.2.9-dev.N do not request missing dev-mac.yml files.
+ * Default channel: saved preference, else version-based (`X.Y.Z-dev.N` →
+ * dev, else prod). Users can override via tray → Update Channel; preference
+ * is stored in userData. Manifest filenames are always latest-mac.yml /
+ * latest.yml (`publish.channel: latest`) so prerelease app versions like
+ * 0.2.9-dev.N do not request missing dev-mac.yml files.
  */
 
 import { BrowserWindow, app, dialog } from "electron";
 import type { AppUpdater, UpdateInfo } from "electron-updater";
 import { Logger } from "@ccrelay/core";
 import {
+  defaultUpdateChannelFromVersion,
   feedUrlForChannel,
   loadUpdateChannel,
   saveUpdateChannel,
@@ -28,8 +29,12 @@ let manualCheck = false;
 let checking = false;
 let startupTimer: ReturnType<typeof setTimeout> | null = null;
 let dailyInterval: ReturnType<typeof setInterval> | null = null;
-/** Runtime preference; null means use pack-time baked feed. */
+/** Resolved channel after init (preference or version default). */
 let activeChannel: UpdateChannel | null = null;
+
+function resolveUpdateChannel(): UpdateChannel {
+  return loadUpdateChannel() ?? defaultUpdateChannelFromVersion(app.getVersion());
+}
 
 function parentWindow(): BrowserWindow | null {
   return BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0] ?? null;
@@ -105,6 +110,7 @@ async function promptInstall(info: UpdateInfo): Promise<void> {
 }
 
 function applyUpdateChannel(channel: UpdateChannel): void {
+  activeChannel = channel;
   if (!updater) {
     return;
   }
@@ -115,12 +121,12 @@ function applyUpdateChannel(channel: UpdateChannel): void {
     channel: "latest",
   });
   updater.allowPrerelease = channel === "dev";
-  activeChannel = channel;
   log.info(`[autoUpdater] update channel set to ${channel} (${url})`);
 }
 
-export function getUpdateChannel(): UpdateChannel | null {
-  return activeChannel;
+/** Effective update channel for tray UI (after init, always set). */
+export function getUpdateChannel(): UpdateChannel {
+  return activeChannel ?? resolveUpdateChannel();
 }
 
 export async function setUpdateChannel(channel: UpdateChannel): Promise<void> {
@@ -168,9 +174,13 @@ export async function requestUpdateCheck(manual: boolean): Promise<void> {
 }
 
 /**
- * Wire electron-updater when packaged. Call once from `app.whenReady()`.
+ * Resolve channel (and wire electron-updater when packaged). Call once from
+ * `app.whenReady()` before building the tray so the menu matches reality.
  */
 export function initAutoUpdate(): void {
+  const channel = resolveUpdateChannel();
+  applyUpdateChannel(channel);
+
   if (!app.isPackaged) {
     return;
   }
@@ -189,11 +199,7 @@ export function initAutoUpdate(): void {
     // blockmap path rewriting always 404s; skip the failed attempt and full-download.
     autoUpdater.disableDifferentialDownload = true;
     updater = autoUpdater;
-
-    const preferred = loadUpdateChannel();
-    if (preferred) {
-      applyUpdateChannel(preferred);
-    }
+    applyUpdateChannel(channel);
 
     autoUpdater.on("update-available", (info: UpdateInfo) => {
       void promptDownload(info);

--- a/packages/desktop/src/dashboardProtocol.ts
+++ b/packages/desktop/src/dashboardProtocol.ts
@@ -16,6 +16,8 @@ export type DashboardInjectConfig = {
   nativeUpdater?: boolean;
   /** process.platform when running inside Electron desktop */
   desktopPlatform?: string;
+  /** Effective Electron update feed: prod (Stable) or dev */
+  updateChannel?: "prod" | "dev";
 };
 
 /* eslint-disable @typescript-eslint/naming-convention -- file extension keys */
@@ -61,7 +63,7 @@ export function registerDashboardProtocolSchemes(): void {
 }
 
 function buildInjectScript(config: DashboardInjectConfig): string {
-  return `<script>window.CCRELAY_API_URL=${JSON.stringify(config.apiOrigin)};window.CCRELAY_API_BEARER=${JSON.stringify(config.apiBearer)};window.CCRELAY_LOCALE=${JSON.stringify(config.locale ?? "")};window.CCRELAY_NATIVE_UPDATER=${config.nativeUpdater === true ? "true" : "false"};window.CCRELAY_DESKTOP_PLATFORM=${JSON.stringify(config.desktopPlatform ?? "")};</script>`;
+  return `<script>window.CCRELAY_API_URL=${JSON.stringify(config.apiOrigin)};window.CCRELAY_API_BEARER=${JSON.stringify(config.apiBearer)};window.CCRELAY_LOCALE=${JSON.stringify(config.locale ?? "")};window.CCRELAY_NATIVE_UPDATER=${config.nativeUpdater === true ? "true" : "false"};window.CCRELAY_DESKTOP_PLATFORM=${JSON.stringify(config.desktopPlatform ?? "")};window.CCRELAY_UPDATE_CHANNEL=${JSON.stringify(config.updateChannel ?? "")};</script>`;
 }
 
 function resolveAssetPath(urlPathname: string): string | null {

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -129,7 +129,7 @@ void app.whenReady().then(async () => {
     }
   }
 
-  createTray(server, configManager);
   initAutoUpdate();
+  createTray(server, configManager);
   showDashboardWindow(server, configManager);
 });

--- a/packages/desktop/src/tray.ts
+++ b/packages/desktop/src/tray.ts
@@ -110,13 +110,16 @@ export function createTray(server: ProxyServer, config: ConfigManager): Tray {
         submenu: (["prod", "dev"] as UpdateChannel[]).map(channel => ({
           label: labelForChannel(channel),
           type: "radio" as const,
-          checked: (getUpdateChannel() ?? "prod") === channel,
+          checked: getUpdateChannel() === channel,
           enabled: app.isPackaged,
           click: (): void => {
-            if ((getUpdateChannel() ?? "prod") === channel) {
+            if (getUpdateChannel() === channel) {
               return;
             }
-            void setUpdateChannel(channel).finally(() => updateMenu());
+            void setUpdateChannel(channel).finally(() => {
+              updateDashboardInjectConfig(server, config);
+              updateMenu();
+            });
           },
         })),
       },

--- a/packages/desktop/src/updateChannel.ts
+++ b/packages/desktop/src/updateChannel.ts
@@ -11,6 +11,11 @@ export type UpdateChannel = "prod" | "dev";
 const PREFS_FILENAME = "update-channel.json";
 const FEED_BASE = "https://github.com/inflaborg/ccrelay/releases/download";
 
+/** Dev CI versions are `X.Y.Z-dev.N`; stable releases are plain `X.Y.Z`. */
+export function defaultUpdateChannelFromVersion(version: string): UpdateChannel {
+  return /(?:^|[.-])dev(?:[.-]|$)/i.test(version) ? "dev" : "prod";
+}
+
 function prefsPath(): string {
   return path.join(app.getPath("userData"), PREFS_FILENAME);
 }
@@ -39,7 +44,7 @@ export function loadUpdateChannel(): UpdateChannel | null {
       return (parsed as { channel: UpdateChannel }).channel;
     }
   } catch {
-    // Missing or invalid file — use pack-time feed.
+    // Missing or invalid file — fall back to version-based default.
   }
   return null;
 }

--- a/packages/desktop/src/window.ts
+++ b/packages/desktop/src/window.ts
@@ -10,7 +10,7 @@
 import { BrowserWindow, app } from "electron";
 import * as path from "path";
 import type { ProxyServer, ConfigManager } from "@ccrelay/core";
-import { isNativeUpdaterEnabled } from "./autoUpdate";
+import { getUpdateChannel, isNativeUpdaterEnabled } from "./autoUpdate";
 import {
   dashboardLocalUrl,
   setDashboardInjectConfig,
@@ -33,11 +33,30 @@ function buildInjectConfig(server: ProxyServer, config: ConfigManager): Dashboar
     locale: config.locale,
     nativeUpdater: isNativeUpdaterEnabled(),
     desktopPlatform: process.platform,
+    updateChannel: getUpdateChannel(),
   };
 }
 
+function pushUpdateChannelToDashboard(channel: "prod" | "dev"): void {
+  if (!dashboardWin || dashboardWin.isDestroyed()) {
+    return;
+  }
+  const payload = JSON.stringify(channel);
+  void dashboardWin.webContents
+    .executeJavaScript(
+      `window.CCRELAY_UPDATE_CHANNEL=${payload};window.dispatchEvent(new CustomEvent("ccrelay-update-channel",{detail:${payload}}));`
+    )
+    .catch(() => {
+      /* dashboard may be mid-navigation */
+    });
+}
+
 export function updateDashboardInjectConfig(server: ProxyServer, config: ConfigManager): void {
-  setDashboardInjectConfig(buildInjectConfig(server, config));
+  const inject = buildInjectConfig(server, config);
+  setDashboardInjectConfig(inject);
+  if (inject.updateChannel) {
+    pushUpdateChannelToDashboard(inject.updateChannel);
+  }
 }
 
 function preloadPath(): string {

--- a/tests/unit/server/httpAccessGate.test.ts
+++ b/tests/unit/server/httpAccessGate.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
+  applyClientCorsHeaders,
   hasRequiredUiGateHeader,
   isBearerAuthorized,
+  isUpstreamCorsHeaderName,
   timingSafeBearerEqual,
 } from "@/server/httpAccessGate";
 import { CCRELAY_UI_HEADER_NAME, CCRELAY_UI_HEADER_VALUE } from "@/server/internalUiHeaders";
@@ -45,5 +47,23 @@ describe("httpAccessGate", () => {
   it("timingSafeBearerEqual rejects length mismatch", () => {
     expect(timingSafeBearerEqual("a", "ab")).toBe(false);
     expect(timingSafeBearerEqual("same", "same")).toBe(true);
+  });
+
+  it("isUpstreamCorsHeaderName detects CORS response headers", () => {
+    expect(isUpstreamCorsHeaderName("Access-Control-Allow-Origin")).toBe(true);
+    expect(isUpstreamCorsHeaderName("access-control-allow-credentials")).toBe(true);
+    expect(isUpstreamCorsHeaderName("content-type")).toBe(false);
+  });
+
+  it("applyClientCorsHeaders sets CCRelay CORS for writeHead payloads", () => {
+    const headers: Record<string, string | string[]> = {
+      // eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP header name
+      "content-type": "text/event-stream",
+    };
+    applyClientCorsHeaders(headers);
+    expect(headers["Access-Control-Allow-Origin"]).toBe("*");
+    expect(headers["Access-Control-Allow-Methods"]).toContain("POST");
+    expect(String(headers["Access-Control-Allow-Headers"])).toContain("Authorization");
+    expect(String(headers["Access-Control-Allow-Headers"])).toContain("anthropic-version");
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -161,7 +161,12 @@ function App() {
           electronDesktop && "electron-drag select-none"
         )}
       >
-        <div className={cn("max-w-full pl-2 sm:pl-4", darwinDesktop && "pl-[78px] sm:pl-[78px]")}>
+        <div
+          className={cn(
+            "max-w-full pl-2 sm:pl-4",
+            darwinDesktop && "pl-[78px] pr-3 sm:pl-[78px] sm:pr-4"
+          )}
+        >
           <div className="flex h-10 items-center gap-2">
             <div className="flex min-w-0 shrink-0 items-center gap-1.5">
               <img src={iconSvg} alt="CCRelay" className="h-6 w-6 sm:h-8 sm:w-8" />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -47,6 +47,8 @@ declare global {
     CCRELAY_NATIVE_UPDATER?: boolean;
     /** Injected by Electron desktop: process.platform (darwin/win32/linux) */
     CCRELAY_DESKTOP_PLATFORM?: string;
+    /** Injected by Electron desktop: update feed channel (`prod` | `dev`) */
+    CCRELAY_UPDATE_CHANNEL?: string;
     /** Preload bridge for frameless window controls */
     ccrelayDesktop?: {
       platform: string;

--- a/web/src/components/VersionFooter.tsx
+++ b/web/src/components/VersionFooter.tsx
@@ -22,10 +22,21 @@ function statusTitleKey(status: UpdateCheckStatus): string {
   }
 }
 
+function readInjectedUpdateChannel(): "prod" | "dev" | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  const value = window.CCRELAY_UPDATE_CHANNEL;
+  return value === "prod" || value === "dev" ? value : null;
+}
+
 export function VersionFooter() {
   const { t } = useTranslation();
   const nativeUpdater = typeof window !== "undefined" && window.CCRELAY_NATIVE_UPDATER === true;
   const [version, setVersion] = useState<string | null>(null);
+  const [updateChannel, setUpdateChannel] = useState<"prod" | "dev" | null>(
+    readInjectedUpdateChannel
+  );
   const [updateCheck, setUpdateCheck] = useState<UpdateCheckResponse | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [manualChecking, setManualChecking] = useState(false);
@@ -65,6 +76,19 @@ export function VersionFooter() {
       .getVersion()
       .then(v => setVersion(v.version))
       .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    const onChannel = (event: Event): void => {
+      const detail = (event as CustomEvent<unknown>).detail;
+      if (detail === "prod" || detail === "dev") {
+        setUpdateChannel(detail);
+        return;
+      }
+      setUpdateChannel(readInjectedUpdateChannel());
+    };
+    window.addEventListener("ccrelay-update-channel", onChannel);
+    return () => window.removeEventListener("ccrelay-update-channel", onChannel);
   }, []);
 
   const pollUpdateCheck = useCallback(async () => {
@@ -129,11 +153,29 @@ export function VersionFooter() {
   };
 
   const displayVersion = version ?? updateCheck?.currentVersion ?? null;
+  const channelLabel =
+    updateChannel === "dev"
+      ? t("update.channelDev")
+      : updateChannel === "prod"
+        ? t("update.channelStable")
+        : null;
+
+  const versionAndChannel = (
+    <>
+      {displayVersion && <span>{displayVersion}</span>}
+      {channelLabel && (
+        <>
+          {displayVersion && <span aria-hidden>·</span>}
+          <span title={t("update.channelHint")}>{channelLabel}</span>
+        </>
+      )}
+    </>
+  );
 
   if (nativeUpdater) {
     return (
       <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
-        {displayVersion && <span>{displayVersion}</span>}
+        {versionAndChannel}
       </div>
     );
   }
@@ -179,7 +221,7 @@ export function VersionFooter() {
     <>
       <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
         {isChecking && <Loader2 className="h-3 w-3 animate-spin shrink-0" aria-hidden />}
-        {displayVersion && <span>{displayVersion}</span>}
+        {versionAndChannel}
         <button
           type="button"
           className={`shrink-0 disabled:opacity-50 disabled:pointer-events-none ${statusButtonClass}`}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -51,8 +51,11 @@ function SelectTrigger({
 function SelectContent({
   className,
   children,
-  position = "item-aligned",
-  align = "center",
+  position = "popper",
+  align = "start",
+  side = "bottom",
+  sideOffset = 4,
+  collisionPadding = 8,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
   return (
@@ -68,14 +71,18 @@ function SelectContent({
         )}
         position={position}
         align={align}
+        side={side}
+        sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
         {...props}
       >
         <SelectScrollUpButton />
         <SelectPrimitive.Viewport
           data-position={position}
           className={cn(
-            "data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)",
-            position === "popper" && ""
+            "p-1",
+            position === "popper" &&
+              "w-full min-h-(--radix-select-trigger-height) min-w-(--radix-select-trigger-width)"
           )}
         >
           {children}

--- a/web/src/features/chat/Chat.tsx
+++ b/web/src/features/chat/Chat.tsx
@@ -2,10 +2,13 @@ import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent }
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
 import {
+  Check,
+  Copy,
   Eraser,
   ImagePlus,
   Loader2,
   MessageSquare,
+  Pencil,
   Plus,
   Send,
   Square,
@@ -84,6 +87,9 @@ export default function Chat() {
   const [input, setInput] = useState("");
   const [pendingImages, setPendingImages] = useState<ChatImageAttachment[]>([]);
   const [sending, setSending] = useState(false);
+  const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState("");
+  const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
   const [clearAllOpen, setClearAllOpen] = useState(false);
   const [clearSessionOpen, setClearSessionOpen] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
@@ -191,6 +197,9 @@ export default function Chat() {
   }, [activeSession, modelOptions]);
 
   useEffect(() => {
+    if (!activeSession?.messages.length) {
+      return;
+    }
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [activeSession?.messages, sending]);
 
@@ -255,6 +264,8 @@ export default function Chat() {
       activeSessionId: session.id,
     }));
     setInput("");
+    setEditingMessageId(null);
+    setEditDraft("");
   };
 
   const handleDeleteSession = (id: string) => {
@@ -306,6 +317,111 @@ export default function Chat() {
     focusInput();
   };
 
+  const runAssistantTurn = useCallback(
+    async (
+      session: ChatSession,
+      historyMessages: ChatMessage[],
+      options?: { title?: string }
+    ): Promise<void> => {
+      const assistantId = newMessageId();
+      const assistantMsg: ChatMessage = {
+        id: assistantId,
+        role: "assistant",
+        content: "",
+      };
+
+      setStore(prev => ({
+        ...prev,
+        sessions: prev.sessions.map(s =>
+          s.id === session.id
+            ? {
+                ...s,
+                ...(options?.title !== undefined ? { title: options.title } : {}),
+                messages: [...historyMessages, assistantMsg],
+                updatedAt: Date.now(),
+              }
+            : s
+        ),
+      }));
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setSending(true);
+      focusInput();
+
+      try {
+        await streamChat({
+          protocol: session.protocol,
+          model: session.model,
+          messages: historyMessages,
+          signal: controller.signal,
+          onDelta: chunk => {
+            setStore(prev => ({
+              ...prev,
+              sessions: prev.sessions.map(s => {
+                if (s.id !== session.id) {
+                  return s;
+                }
+                return {
+                  ...s,
+                  updatedAt: Date.now(),
+                  messages: s.messages.map(m =>
+                    m.id === assistantId ? { ...m, content: m.content + chunk } : m
+                  ),
+                };
+              }),
+            }));
+          },
+        });
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          setStore(prev => ({
+            ...prev,
+            sessions: prev.sessions.map(s => {
+              if (s.id !== session.id) {
+                return s;
+              }
+              return {
+                ...s,
+                messages: s.messages.map(m =>
+                  m.id === assistantId && !m.content
+                    ? { ...m, content: "", error: t("chat.stopped") }
+                    : m
+                ),
+              };
+            }),
+          }));
+        } else {
+          const message = err instanceof Error ? err.message : String(err);
+          setStore(prev => ({
+            ...prev,
+            sessions: prev.sessions.map(s => {
+              if (s.id !== session.id) {
+                return s;
+              }
+              return {
+                ...s,
+                messages: s.messages.map(m =>
+                  m.id === assistantId ? { ...m, error: message, content: m.content || "" } : m
+                ),
+              };
+            }),
+          }));
+        }
+      } finally {
+        abortRef.current = null;
+        setStore(prev => {
+          const next = stripImagePayloadsFromStore(prev);
+          saveChatStore(next);
+          return next;
+        });
+        setSending(false);
+        focusInput();
+      }
+    },
+    [focusInput, t]
+  );
+
   const handleSend = async () => {
     if (!activeSession || sending) {
       return;
@@ -325,110 +441,88 @@ export default function Chat() {
       content: text,
       ...(images.length > 0 ? { images } : {}),
     };
-    const assistantId = newMessageId();
-    const assistantMsg: ChatMessage = {
-      id: assistantId,
-      role: "assistant",
-      content: "",
-    };
 
     const nextMessages = [...activeSession.messages, userMsg];
     const title =
       activeSession.messages.length === 0
         ? titleFromFirstUserMessage(text || t("chat.imageMessageTitle"))
-        : activeSession.title;
+        : undefined;
 
     setInput("");
     setPendingImages([]);
-    setStore(prev => ({
-      ...prev,
-      sessions: prev.sessions.map(s =>
-        s.id === activeSession.id
-          ? {
-              ...s,
-              title,
-              messages: [...nextMessages, assistantMsg],
-              updatedAt: Date.now(),
-            }
-          : s
-      ),
-    }));
+    setEditingMessageId(null);
+    await runAssistantTurn(
+      activeSession,
+      nextMessages,
+      title !== undefined ? { title } : undefined
+    );
+  };
 
-    const controller = new AbortController();
-    abortRef.current = controller;
-    setSending(true);
-    focusInput();
-
-    try {
-      await streamChat({
-        protocol: activeSession.protocol,
-        model: activeSession.model,
-        messages: nextMessages,
-        signal: controller.signal,
-        onDelta: chunk => {
-          setStore(prev => ({
-            ...prev,
-            sessions: prev.sessions.map(s => {
-              if (s.id !== activeSession.id) {
-                return s;
-              }
-              return {
-                ...s,
-                updatedAt: Date.now(),
-                messages: s.messages.map(m =>
-                  m.id === assistantId ? { ...m, content: m.content + chunk } : m
-                ),
-              };
-            }),
-          }));
-        },
-      });
-    } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") {
-        setStore(prev => ({
-          ...prev,
-          sessions: prev.sessions.map(s => {
-            if (s.id !== activeSession.id) {
-              return s;
-            }
-            return {
-              ...s,
-              messages: s.messages.map(m =>
-                m.id === assistantId && !m.content
-                  ? { ...m, content: "", error: t("chat.stopped") }
-                  : m
-              ),
-            };
-          }),
-        }));
-      } else {
-        const message = err instanceof Error ? err.message : String(err);
-        setStore(prev => ({
-          ...prev,
-          sessions: prev.sessions.map(s => {
-            if (s.id !== activeSession.id) {
-              return s;
-            }
-            return {
-              ...s,
-              messages: s.messages.map(m =>
-                m.id === assistantId ? { ...m, error: message, content: m.content || "" } : m
-              ),
-            };
-          }),
-        }));
-      }
-    } finally {
-      abortRef.current = null;
-      // Drop image binaries from memory and flush the completed turn (incl. assistant text).
-      setStore(prev => {
-        const next = stripImagePayloadsFromStore(prev);
-        saveChatStore(next);
-        return next;
-      });
-      setSending(false);
-      focusInput();
+  const handleStartEdit = (msg: ChatMessage) => {
+    if (sending || msg.role !== "user") {
+      return;
     }
+    setEditingMessageId(msg.id);
+    setEditDraft(msg.content);
+  };
+
+  const handleCancelEdit = () => {
+    setEditingMessageId(null);
+    setEditDraft("");
+  };
+
+  const handleCopyMessage = async (msg: ChatMessage) => {
+    const text = msg.content.trim() || msg.error?.trim() || "";
+    if (!text) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedMessageId(msg.id);
+      window.setTimeout(() => {
+        setCopiedMessageId(prev => (prev === msg.id ? null : prev));
+      }, 1500);
+    } catch {
+      // Clipboard may be unavailable in some embeds.
+    }
+  };
+
+  const handleSaveEdit = async (messageId: string) => {
+    if (!activeSession || sending) {
+      return;
+    }
+    if (!activeSession.model.trim()) {
+      return;
+    }
+
+    const idx = activeSession.messages.findIndex(m => m.id === messageId);
+    if (idx < 0) {
+      return;
+    }
+    const original = activeSession.messages[idx]!;
+    if (original.role !== "user") {
+      return;
+    }
+
+    const text = editDraft.trim();
+    const hasImages = (original.images?.length ?? 0) > 0;
+    if (!text && !hasImages) {
+      return;
+    }
+
+    const edited: ChatMessage = {
+      ...original,
+      content: text,
+    };
+    const history = [...activeSession.messages.slice(0, idx), edited];
+    const isFirstUser = activeSession.messages.findIndex(m => m.role === "user") === idx;
+    const title = isFirstUser
+      ? titleFromFirstUserMessage(text || t("chat.imageMessageTitle"))
+      : undefined;
+
+    setEditingMessageId(null);
+    setEditDraft("");
+    await runAssistantTurn(activeSession, history, title !== undefined ? { title } : undefined);
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -507,7 +601,11 @@ export default function Chat() {
                   ? "bg-primary/15 text-foreground"
                   : "hover:bg-muted/60 text-muted-foreground"
               )}
-              onClick={() => setStore(prev => ({ ...prev, activeSessionId: session.id }))}
+              onClick={() => {
+                setEditingMessageId(null);
+                setEditDraft("");
+                setStore(prev => ({ ...prev, activeSessionId: session.id }));
+              }}
             >
               <div className="min-w-0 flex-1">
                 <div className="truncate text-[11px] font-medium text-foreground">
@@ -592,84 +690,206 @@ export default function Chat() {
           </Button>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3 space-y-3">
+        <div
+          className={cn(
+            "min-h-0 flex-1 px-3 py-3",
+            activeSession?.messages.length
+              ? "overflow-y-auto space-y-3"
+              : "overflow-hidden flex flex-col"
+          )}
+        >
           {!activeSession?.messages.length ? (
-            <div className="flex h-full min-h-[12rem] flex-col items-center justify-center text-muted-foreground gap-1 text-center px-4">
+            <div className="flex min-h-0 flex-1 flex-col items-center justify-center text-muted-foreground gap-1 text-center px-4">
               <MessageSquare className="h-6 w-6 opacity-40" />
               <p className="text-xs">{t("chat.emptyHint")}</p>
             </div>
           ) : (
-            activeSession.messages.map(msg => (
-              <div
-                key={msg.id}
-                className={cn("flex", msg.role === "user" ? "justify-end" : "justify-start")}
-              >
+            activeSession.messages.map(msg => {
+              const isEditing = msg.role === "user" && editingMessageId === msg.id;
+              const copyText = msg.content.trim() || msg.error?.trim() || "";
+              const canCopy = Boolean(copyText) && !isEditing;
+              const showCopied = copiedMessageId === msg.id;
+              const actionBtnClass =
+                "h-6 w-6 shrink-0 rounded opacity-0 group-hover/msg:opacity-100 flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted/60";
+              return (
                 <div
+                  key={msg.id}
                   className={cn(
-                    "max-w-[85%] rounded-md px-2.5 py-1.5 text-xs",
-                    msg.role === "user"
-                      ? "bg-primary text-primary-foreground"
-                      : "bg-muted/60 text-foreground border border-border"
+                    "group/msg flex items-center gap-1",
+                    msg.role === "user" ? "justify-end" : "justify-start"
                   )}
                 >
-                  {msg.role === "assistant" ? (
-                    msg.error && !msg.content ? (
-                      <p className="text-destructive whitespace-pre-wrap">{msg.error}</p>
-                    ) : (
-                      <>
-                        {msg.content ? (
-                          sending &&
-                          msg.id ===
-                            activeSession.messages[activeSession.messages.length - 1]?.id ? (
-                            <p className="whitespace-pre-wrap leading-relaxed">{msg.content}</p>
+                  {msg.role === "user" && !isEditing ? (
+                    <div className="flex shrink-0 items-center gap-0.5">
+                      {canCopy ? (
+                        <button
+                          type="button"
+                          className={actionBtnClass}
+                          title={showCopied ? t("chat.copied") : t("chat.copy")}
+                          onClick={() => void handleCopyMessage(msg)}
+                        >
+                          {showCopied ? (
+                            <Check className="h-3 w-3" />
                           ) : (
-                            <MarkdownViewer content={msg.content} />
-                          )
-                        ) : null}
-                        {msg.error ? (
-                          <p className="mt-1 text-destructive whitespace-pre-wrap text-[11px]">
-                            {msg.error}
-                          </p>
-                        ) : null}
-                        {sending &&
-                        msg.id === activeSession.messages[activeSession.messages.length - 1]?.id &&
-                        !msg.content &&
-                        !msg.error ? (
-                          <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
-                        ) : null}
-                      </>
-                    )
-                  ) : (
-                    <div className="space-y-1.5">
-                      {msg.images && msg.images.length > 0 ? (
-                        <div className="flex flex-wrap gap-1.5">
-                          {msg.images.map(img =>
-                            img.dataUrl ? (
-                              <img
-                                key={img.id}
-                                src={img.dataUrl}
-                                alt=""
-                                className="max-h-28 max-w-full rounded border border-primary-foreground/20 object-contain"
-                              />
-                            ) : (
-                              <div
-                                key={img.id}
-                                className="flex h-14 min-w-[3.5rem] items-center justify-center rounded border border-primary-foreground/20 px-2 text-[10px] opacity-80"
-                              >
-                                {t("chat.imageOmitted")}
-                              </div>
-                            )
+                            <Copy className="h-3 w-3" />
                           )}
-                        </div>
+                        </button>
                       ) : null}
-                      {msg.content ? <p className="whitespace-pre-wrap">{msg.content}</p> : null}
+                      {!sending ? (
+                        <button
+                          type="button"
+                          className={actionBtnClass}
+                          title={t("chat.edit")}
+                          onClick={() => handleStartEdit(msg)}
+                        >
+                          <Pencil className="h-3 w-3" />
+                        </button>
+                      ) : null}
                     </div>
-                  )}
+                  ) : null}
+                  <div
+                    className={cn(
+                      "max-w-[85%] rounded-md px-2.5 py-1.5 text-xs",
+                      msg.role === "user"
+                        ? "bg-primary text-primary-foreground"
+                        : "bg-muted/60 text-foreground border border-border",
+                      isEditing && "w-full max-w-[min(100%,28rem)]"
+                    )}
+                  >
+                    {msg.role === "assistant" ? (
+                      msg.error && !msg.content ? (
+                        <p className="text-destructive whitespace-pre-wrap">{msg.error}</p>
+                      ) : (
+                        <>
+                          {msg.content ? (
+                            sending &&
+                            msg.id ===
+                              activeSession.messages[activeSession.messages.length - 1]?.id ? (
+                              <p className="whitespace-pre-wrap leading-relaxed">{msg.content}</p>
+                            ) : (
+                              <MarkdownViewer content={msg.content} />
+                            )
+                          ) : null}
+                          {msg.error ? (
+                            <p className="mt-1 text-destructive whitespace-pre-wrap text-[11px]">
+                              {msg.error}
+                            </p>
+                          ) : null}
+                          {sending &&
+                          msg.id ===
+                            activeSession.messages[activeSession.messages.length - 1]?.id &&
+                          !msg.content &&
+                          !msg.error ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                          ) : null}
+                        </>
+                      )
+                    ) : isEditing ? (
+                      <div className="space-y-1.5">
+                        {msg.images && msg.images.length > 0 ? (
+                          <div className="flex flex-wrap gap-1.5">
+                            {msg.images.map(img =>
+                              img.dataUrl ? (
+                                <img
+                                  key={img.id}
+                                  src={img.dataUrl}
+                                  alt=""
+                                  className="max-h-28 max-w-full rounded border border-primary-foreground/20 object-contain"
+                                />
+                              ) : (
+                                <div
+                                  key={img.id}
+                                  className="flex h-14 min-w-[3.5rem] items-center justify-center rounded border border-primary-foreground/20 px-2 text-[10px] opacity-80"
+                                >
+                                  {t("chat.imageOmitted")}
+                                </div>
+                              )
+                            )}
+                          </div>
+                        ) : null}
+                        <textarea
+                          value={editDraft}
+                          onChange={e => setEditDraft(e.target.value)}
+                          rows={3}
+                          className="w-full resize-y rounded-md border border-primary-foreground/30 bg-primary-foreground/10 px-2 py-1.5 text-xs text-primary-foreground outline-none focus-visible:ring-1 focus-visible:ring-primary-foreground/40"
+                          autoFocus
+                          onKeyDown={e => {
+                            if (e.key === "Escape") {
+                              e.preventDefault();
+                              handleCancelEdit();
+                              return;
+                            }
+                            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                              e.preventDefault();
+                              void handleSaveEdit(msg.id);
+                            }
+                          }}
+                        />
+                        <div className="flex items-center justify-end gap-1.5">
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="ghost"
+                            className="h-6 px-2 text-[10px] text-primary-foreground/80 hover:text-primary-foreground hover:bg-primary-foreground/15"
+                            onClick={handleCancelEdit}
+                          >
+                            {t("chat.cancelEdit")}
+                          </Button>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant="secondary"
+                            className="h-6 px-2 text-[10px] gap-1"
+                            disabled={!editDraft.trim() && !(msg.images && msg.images.length > 0)}
+                            onClick={() => void handleSaveEdit(msg.id)}
+                          >
+                            <Check className="h-3 w-3" />
+                            {t("chat.saveEdit")}
+                          </Button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="space-y-1.5">
+                        {msg.images && msg.images.length > 0 ? (
+                          <div className="flex flex-wrap gap-1.5">
+                            {msg.images.map(img =>
+                              img.dataUrl ? (
+                                <img
+                                  key={img.id}
+                                  src={img.dataUrl}
+                                  alt=""
+                                  className="max-h-28 max-w-full rounded border border-primary-foreground/20 object-contain"
+                                />
+                              ) : (
+                                <div
+                                  key={img.id}
+                                  className="flex h-14 min-w-[3.5rem] items-center justify-center rounded border border-primary-foreground/20 px-2 text-[10px] opacity-80"
+                                >
+                                  {t("chat.imageOmitted")}
+                                </div>
+                              )
+                            )}
+                          </div>
+                        ) : null}
+                        {msg.content ? <p className="whitespace-pre-wrap">{msg.content}</p> : null}
+                      </div>
+                    )}
+                  </div>
+                  {msg.role === "assistant" && canCopy ? (
+                    <button
+                      type="button"
+                      className={actionBtnClass}
+                      title={showCopied ? t("chat.copied") : t("chat.copy")}
+                      onClick={() => void handleCopyMessage(msg)}
+                    >
+                      {showCopied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                    </button>
+                  ) : null}
                 </div>
-              </div>
-            ))
+              );
+            })
           )}
-          <div ref={bottomRef} />
+          {activeSession?.messages.length ? <div ref={bottomRef} /> : null}
         </div>
 
         <div className="border-t border-border p-2 space-y-1.5">

--- a/web/src/features/chat/Chat.tsx
+++ b/web/src/features/chat/Chat.tsx
@@ -715,7 +715,7 @@ export default function Chat() {
                 <div
                   key={msg.id}
                   className={cn(
-                    "group/msg flex items-center gap-1",
+                    "group/msg flex items-end gap-1",
                     msg.role === "user" ? "justify-end" : "justify-start"
                   )}
                 >

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -55,6 +55,11 @@
     "send": "Send",
     "stop": "Stop",
     "stopped": "Stopped",
+    "edit": "Edit",
+    "saveEdit": "Save & retry",
+    "cancelEdit": "Cancel",
+    "copy": "Copy",
+    "copied": "Copied",
     "protocol": {
       "openaiChat": "OpenAI Chat",
       "openaiResponses": "OpenAI Responses",

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -76,7 +76,10 @@
     "modalTitle": "New version {{version}}",
     "download": "View release on GitHub",
     "current": "Current version: {{version}}",
-    "noNotes": "No release notes provided."
+    "noNotes": "No release notes provided.",
+    "channelStable": "Stable",
+    "channelDev": "Dev",
+    "channelHint": "Update channel (change from tray → Update Channel)"
   },
   "language": {
     "title": "Choose Language",

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -55,6 +55,11 @@
     "send": "发送",
     "stop": "停止",
     "stopped": "已停止",
+    "edit": "编辑",
+    "saveEdit": "保存并重试",
+    "cancelEdit": "取消",
+    "copy": "复制",
+    "copied": "已复制",
     "protocol": {
       "openaiChat": "OpenAI Chat",
       "openaiResponses": "OpenAI Responses",

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -76,7 +76,10 @@
     "modalTitle": "新版本 {{version}}",
     "download": "在 GitHub 查看发布",
     "current": "当前版本：{{version}}",
-    "noNotes": "暂无发布说明。"
+    "noNotes": "暂无发布说明。",
+    "channelStable": "Stable",
+    "channelDev": "Dev",
+    "channelHint": "更新通道（可在托盘 → Update Channel 切换）"
   },
   "language": {
     "title": "选择语言",

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -9,26 +9,27 @@
   :root,
   .dark {
     --background: 0 0% 12%;
-    --foreground: 0 0% 92%;
+    --foreground: 0 0% 90%;
     --card: 0 0% 16%;
-    --card-foreground: 0 0% 92%;
+    --card-foreground: 0 0% 90%;
     --popover: 0 0% 16%;
-    --popover-foreground: 0 0% 92%;
-    --primary: 0 0% 85%;
-    --primary-foreground: 0 0% 10%;
+    --popover-foreground: 0 0% 90%;
+    /* Selected / primary actions: mid gray — softer than near-white on charcoal UI */
+    --primary: 0 0% 62%;
+    --primary-foreground: 0 0% 8%;
     --secondary: 0 0% 20%;
-    --secondary-foreground: 0 0% 90%;
+    --secondary-foreground: 0 0% 88%;
     --muted: 0 0% 20%;
     --muted-foreground: 0 0% 55%;
-    --accent: 0 0% 25%;
-    --accent-foreground: 0 0% 90%;
+    --accent: 0 0% 24%;
+    --accent-foreground: 0 0% 88%;
     --destructive: 0 60% 55%;
     --destructive-foreground: 0 0% 95%;
     --success: 150 50% 45%;
     --success-foreground: 0 0% 95%;
-    --border: 0 0% 28%;
+    --border: 0 0% 26%;
     --input: 0 0% 10%;
-    --ring: 0 0% 60%;
+    --ring: 0 0% 48%;
     --radius: 0.375rem;
   }
 }


### PR DESCRIPTION
## Summary
- Fix Electron update channel defaults and tray selection after restart (dev builds default to Dev; stable to Stable), and show the active channel in the dashboard footer.
- Polish Select dropdown placement (prefer below trigger), soften dark-theme primary, and add macOS header right padding.
- Chat: edit user messages with truncate-and-retry, copy actions aligned to the bubble bottom, and no empty-state scrollbar.
- Fix desktop Chat streaming CORS when OpenAI protocol targets Anthropic upstreams (`writeHead` was dropping/colliding with CORS headers).

## Test plan
- [ ] Packaged or desktop dashboard: tray Update Channel matches version default and survives restart; footer shows Stable/Dev
- [ ] Chat protocol/model Select opens below the control (not over the title bar)
- [ ] Chat: edit a middle user message → later turns drop → assistant retries
- [ ] Chat: copy user/assistant text via hover buttons (bottom-aligned)
- [ ] Desktop Chat: OpenAI Chat protocol against an Anthropic provider streams successfully
- [ ] Empty Chat session shows no message-area scrollbar


Made with [Cursor](https://cursor.com)