### PR TITLE
chore: 0.3.1 pre-release version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-08-02 (pre-release)
+
+Pre-release line for 0.3.1.
+
 ## [0.3.0] - 2026-07-27
 
 Chat gains an Agent mode with local log tools, optional web search, and session memory. The desktop app ships a frameless window and Stable/Dev update channel switching. Chat edit/retry and several desktop streaming fixes round out the release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccrelay-monorepo",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccrelay-monorepo",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [
@@ -10402,7 +10402,7 @@
     },
     "packages/core": {
       "name": "@ccrelay/core",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.1",
@@ -10460,7 +10460,7 @@
     },
     "packages/desktop": {
       "name": "ccrelay-desktop",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -10477,7 +10477,7 @@
     },
     "packages/desktop-tauri": {
       "name": "@ccrelay/desktop-tauri",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "hasInstallScript": true,
       "dependencies": {
         "@ccrelay/core": "*",
@@ -11173,7 +11173,7 @@
     },
     "packages/vscode": {
       "name": "ccrelay-vscode",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@ccrelay/core": "*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "ccrelay-monorepo",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "packageManager": "npm@10.9.4",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ccrelay/core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "CCRelay proxy server core (Node.js)",
   "license": "MIT",

--- a/packages/desktop-tauri/package.json
+++ b/packages/desktop-tauri/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ccrelay/desktop-tauri",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "CCRelay desktop app (Tauri)",
   "scripts": {

--- a/packages/desktop-tauri/src-tauri/Cargo.toml
+++ b/packages/desktop-tauri/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccrelay"
-version = "0.3.0"
+version = "0.3.1"
 description = "CCRelay desktop app"
 authors = ["Inflab"]
 edition = "2021"

--- a/packages/desktop-tauri/src-tauri/tauri.conf.json
+++ b/packages/desktop-tauri/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CCRelay",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "org.inflab.ccrelay",
   "build": {
     "frontendDist": "../web",

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccrelay-desktop",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "CCRelay desktop tray app",
   "license": "MIT",

--- a/packages/desktop/src/tray.ts
+++ b/packages/desktop/src/tray.ts
@@ -7,8 +7,9 @@ import * as path from "path";
 import { getLogDir, type ConfigManager, type ProxyServer } from "@ccrelay/core";
 import { setOpenAtLogin, getOpenAtLogin } from "./autoLaunch";
 import { getUpdateChannel, requestUpdateCheck, setUpdateChannel } from "./autoUpdate";
-import { labelForChannel, type UpdateChannel } from "./updateChannel";
+import { type UpdateChannel } from "./updateChannel";
 import { showDashboardWindow, updateDashboardInjectConfig } from "./window";
+import { channelLabel, resolveTrayLocale, roleLabel, trayStrings } from "./trayI18n";
 
 /** macOS tray uses template (monochrome); Windows/Linux use the full-color asset. */
 function trayIconFile(): string {
@@ -23,13 +24,6 @@ function trayIconPath(): string {
   return path.join(__dirname, "..", "assets", file);
 }
 
-function roleLabel(role: string, running: boolean): string {
-  if (!running) {
-    return "Stopped";
-  }
-  return role.charAt(0).toUpperCase() + role.slice(1);
-}
-
 export function createTray(server: ProxyServer, config: ConfigManager): Tray {
   const img = nativeImage.createFromPath(trayIconPath());
   if (process.platform === "darwin") {
@@ -38,6 +32,8 @@ export function createTray(server: ProxyServer, config: ConfigManager): Tray {
   const tray = new Tray(img.resize({ width: 22, height: 22 }));
 
   const updateMenu = (): void => {
+    const locale = resolveTrayLocale(config.locale);
+    const t = trayStrings(locale);
     const role = server.getRole();
     const running = server.running;
     const router = server.getRouter();
@@ -48,7 +44,7 @@ export function createTray(server: ProxyServer, config: ConfigManager): Tray {
 
     const providerMenuItems = [
       {
-        label: "Smart Routing",
+        label: t.smartRouting,
         type: "radio" as const,
         checked: srEnabled,
         click: (): void => {
@@ -81,34 +77,34 @@ export function createTray(server: ProxyServer, config: ConfigManager): Tray {
 
     const contextMenu = Menu.buildFromTemplate([
       {
-        label: `CCRelay — ${roleLabel(role, running)}`,
+        label: `CCRelay — ${roleLabel(role, running, locale)}`,
         enabled: false,
       },
       {
-        label: `Provider: ${srEnabled ? "Smart Routing" : (provider?.name ?? "N/A")}`,
+        label: `${t.providerPrefix}: ${srEnabled ? t.smartRouting : (provider?.name ?? t.na)}`,
         enabled: false,
       },
       { type: "separator" },
       {
-        label: "Open Dashboard",
+        label: t.openDashboard,
         click: (): void => {
           showDashboardWindow(server, config);
         },
       },
       {
-        label: "Check for Updates…",
+        label: t.checkForUpdates,
         enabled: app.isPackaged,
-        toolTip: app.isPackaged ? undefined : "Auto-update is only available in packaged builds",
+        toolTip: app.isPackaged ? undefined : t.updateUnavailableTooltip,
         click: (): void => {
           void requestUpdateCheck(true);
         },
       },
       {
-        label: "Update Channel",
+        label: t.updateChannel,
         enabled: app.isPackaged,
-        toolTip: app.isPackaged ? undefined : "Update channel is only available in packaged builds",
+        toolTip: app.isPackaged ? undefined : t.updateChannelUnavailableTooltip,
         submenu: (["prod", "dev"] as UpdateChannel[]).map(channel => ({
-          label: labelForChannel(channel),
+          label: channelLabel(channel, locale),
           type: "radio" as const,
           checked: getUpdateChannel() === channel,
           enabled: app.isPackaged,
@@ -125,14 +121,14 @@ export function createTray(server: ProxyServer, config: ConfigManager): Tray {
       },
       { type: "separator" },
       {
-        label: "Start Server",
+        label: t.startServer,
         enabled: !running,
         click: (): void => {
           void server.start().then(() => updateMenu());
         },
       },
       {
-        label: "Stop Server",
+        label: t.stopServer,
         enabled: running,
         click: (): void => {
           void server.stop().then(() => updateMenu());
@@ -140,12 +136,12 @@ export function createTray(server: ProxyServer, config: ConfigManager): Tray {
       },
       { type: "separator" },
       {
-        label: "Switch Provider",
+        label: t.switchProvider,
         submenu: providerMenuItems,
       },
       { type: "separator" },
       {
-        label: "Open at Login",
+        label: t.openAtLogin,
         type: "checkbox",
         checked: getOpenAtLogin(),
         click: (item): void => {
@@ -153,20 +149,20 @@ export function createTray(server: ProxyServer, config: ConfigManager): Tray {
         },
       },
       {
-        label: "Open Config File",
+        label: t.openConfigFile,
         click: (): void => {
           void shell.openPath(config.getConfigPath());
         },
       },
       {
-        label: "Open Logs Folder",
+        label: t.openLogsFolder,
         click: (): void => {
           void shell.openPath(getLogDir());
         },
       },
       { type: "separator" },
       {
-        label: "Quit",
+        label: t.quit,
         click: (): void => {
           void server.stop().finally(() => app.quit());
         },
@@ -174,7 +170,7 @@ export function createTray(server: ProxyServer, config: ConfigManager): Tray {
     ]);
 
     tray.setContextMenu(contextMenu);
-    tray.setToolTip(`CCRelay (${running ? role : "stopped"})`);
+    tray.setToolTip(`CCRelay (${running ? role : t.tooltipStopped})`);
   };
 
   server.onRoleChanged(() => updateMenu());

--- a/packages/desktop/src/trayI18n.ts
+++ b/packages/desktop/src/trayI18n.ts
@@ -1,0 +1,93 @@
+/**
+ * Localized strings for the Electron tray / context menu.
+ * Kept separate from the web i18n bundle (main process cannot import it).
+ */
+
+export type TrayLocale = "en" | "zh";
+
+export function resolveTrayLocale(value: string | undefined): TrayLocale {
+  return value === "zh" ? "zh" : "en";
+}
+
+type TrayStrings = {
+  stopped: string;
+  providerPrefix: string;
+  smartRouting: string;
+  na: string;
+  openDashboard: string;
+  checkForUpdates: string;
+  updateUnavailableTooltip: string;
+  updateChannel: string;
+  updateChannelUnavailableTooltip: string;
+  channelStable: string;
+  channelDev: string;
+  startServer: string;
+  stopServer: string;
+  switchProvider: string;
+  openAtLogin: string;
+  openConfigFile: string;
+  openLogsFolder: string;
+  quit: string;
+  tooltipStopped: string;
+};
+
+const STRINGS: Record<TrayLocale, TrayStrings> = {
+  en: {
+    stopped: "Stopped",
+    providerPrefix: "Provider",
+    smartRouting: "Smart Routing",
+    na: "N/A",
+    openDashboard: "Open Dashboard",
+    checkForUpdates: "Check for Updates…",
+    updateUnavailableTooltip: "Auto-update is only available in packaged builds",
+    updateChannel: "Update Channel",
+    updateChannelUnavailableTooltip: "Update channel is only available in packaged builds",
+    channelStable: "Stable",
+    channelDev: "Dev",
+    startServer: "Start Server",
+    stopServer: "Stop Server",
+    switchProvider: "Switch Provider",
+    openAtLogin: "Open at Login",
+    openConfigFile: "Open Config File",
+    openLogsFolder: "Open Logs Folder",
+    quit: "Quit",
+    tooltipStopped: "stopped",
+  },
+  zh: {
+    stopped: "已停止",
+    providerPrefix: "提供商",
+    smartRouting: "智能路由",
+    na: "无",
+    openDashboard: "打开仪表盘",
+    checkForUpdates: "检查更新…",
+    updateUnavailableTooltip: "自动更新仅在打包后的应用中可用",
+    updateChannel: "更新通道",
+    updateChannelUnavailableTooltip: "更新通道仅在打包后的应用中可用",
+    channelStable: "Stable",
+    channelDev: "Dev",
+    startServer: "启动服务器",
+    stopServer: "停止服务器",
+    switchProvider: "切换提供商",
+    openAtLogin: "开机时启动",
+    openConfigFile: "打开配置文件",
+    openLogsFolder: "打开日志文件夹",
+    quit: "退出",
+    tooltipStopped: "已停止",
+  },
+};
+
+export function trayStrings(locale: TrayLocale): TrayStrings {
+  return STRINGS[locale];
+}
+
+export function roleLabel(role: string, running: boolean, locale: TrayLocale): string {
+  if (!running) {
+    return STRINGS[locale].stopped;
+  }
+  return role.charAt(0).toUpperCase() + role.slice(1);
+}
+
+export function channelLabel(channel: "prod" | "dev", locale: TrayLocale): string {
+  const t = STRINGS[locale];
+  return channel === "prod" ? t.channelStable : t.channelDev;
+}

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "CCRelay",
   "icon": "assets/icon-128.png",
   "description": "VSCode extension with built-in API proxy server - switch between AI providers seamlessly",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "inflab",
   "license": "MIT",
   "repository": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -107,7 +107,7 @@ function useHashTab(defaultTab: Tab): [Tab, (tab: Tab) => void] {
 }
 
 function App() {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const [activeTab, setActiveTab] = useHashTab("clientConfig");
   const [languagePromptDismissed, setLanguagePromptDismissed] = useState(false);
 
@@ -125,8 +125,10 @@ function App() {
     !parseAppLocale(window.CCRELAY_LOCALE);
 
   // Sync language when config changes (e.g. Settings save in Electron).
+  // Only apply from persisted config — do not fall back to CCRELAY_LOCALE here,
+  // or a stale config refetch can overwrite an optimistic language switch.
   useEffect(() => {
-    const locale = parseAppLocale(config?.server?.locale) ?? parseAppLocale(window.CCRELAY_LOCALE);
+    const locale = parseAppLocale(config?.server?.locale);
     if (locale) {
       void applyAppLocale(locale);
     }
@@ -147,13 +149,12 @@ function App() {
   const activeNav = navItems.find(item => item.id === activeTab) ?? navItems[0];
   const ActiveIcon = activeNav.icon;
 
-  const uiLanguageKey = i18n.resolvedLanguage ?? i18n.language;
   const electronDesktop = isElectronDesktop();
   const darwinDesktop = isDarwinDesktop();
   const showCaptionButtons = needsWindowCaptionButtons();
 
   return (
-    <div key={uiLanguageKey} className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
       {/* Header - Tab Style (Electron: frameless drag region + OS chrome) */}
       <header
         className={cn(

--- a/web/src/features/settings/Settings.tsx
+++ b/web/src/features/settings/Settings.tsx
@@ -29,7 +29,7 @@ import {
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import { api } from "@/api/client";
-import { applyAppLocale } from "@/i18n";
+import { applyAppLocale, parseAppLocale } from "@/i18n";
 import type {
   LoggingSettings,
   ConcurrencySettings,
@@ -278,9 +278,19 @@ function Section({
 // ─── Language (auto-save) ───────────────────────────────────────────────────
 
 function LanguageSettingsSection({ locale }: { locale?: string }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const queryClient = useQueryClient();
-  const [value, setValue] = useState(locale ?? "");
+  // Prefer the live UI language so the select stays correct while config catch-up / remounts race.
+  const liveLocale =
+    parseAppLocale(i18n.resolvedLanguage ?? i18n.language) ??
+    parseAppLocale(window.CCRELAY_LOCALE) ??
+    parseAppLocale(locale) ??
+    "";
+  const [value, setValue] = useState(liveLocale);
+
+  useEffect(() => {
+    setValue(liveLocale);
+  }, [liveLocale]);
 
   const localeMutation = useMutation({
     mutationFn: (nextLocale: string | undefined) =>
@@ -301,10 +311,12 @@ function LanguageSettingsSection({ locale }: { locale?: string }) {
     return () => clearTimeout(timer);
   }, [localeSaved, resetLocaleMutation]);
 
-  const handleLocaleChange = (locale: string) => {
-    const nextLocale = locale || undefined;
-    setValue(locale);
-    void applyAppLocale(nextLocale);
+  const handleLocaleChange = (next: string) => {
+    const nextLocale = parseAppLocale(next);
+    setValue(nextLocale ?? "");
+    if (nextLocale) {
+      void applyAppLocale(nextLocale);
+    }
     localeMutation.mutate(nextLocale);
   };
 
@@ -314,7 +326,6 @@ function LanguageSettingsSection({ locale }: { locale?: string }) {
         <SelectField
           value={value}
           options={[
-            { value: "", label: t("common.na") },
             { value: "en", label: t("language.en") },
             { value: "zh", label: t("language.zh") },
           ]}

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -95,7 +95,7 @@
     "noNotes": "暂无发布说明。",
     "channelStable": "Stable",
     "channelDev": "Dev",
-    "channelHint": "更新通道（可在托盘 → Update Channel 切换）"
+    "channelHint": "更新通道（可在托盘 → 更新通道 切换）"
   },
   "language": {
     "title": "选择语言",


### PR DESCRIPTION
## Summary
- Bump monorepo version to **0.3.1** (pre-release line) across all packages, lockfile, and Tauri/Cargo manifests
- Add `CHANGELOG.md` pre-release stub for 0.3.1
- Include Electron tray menu i18n (en/zh) and Settings language-select sync fix from `feat/dev`

## Test plan
- [ ] Confirm all package versions read `0.3.1` (root, core, vscode, desktop, desktop-tauri, lockfile, tauri.conf, Cargo.toml)
- [ ] Confirm CHANGELOG has `## [0.3.1] - 2026-08-02 (pre-release)`
- [ ] CI produces `dev-0.3.1-<PR#>` artifacts as expected
- [ ] Desktop: switch UI language to Chinese and verify tray menu labels update; Settings language select stays in sync


Made with [Cursor](https://cursor.com)