### PR TITLE
fix: always show endpoint test and right-align provider modal actions

### DIFF
--- a/web/src/features/providers/Providers.tsx
+++ b/web/src/features/providers/Providers.tsx
@@ -1427,8 +1427,8 @@ export default function Providers() {
               </div>
             </CardContent>
 
-            {/* Modal Footer */}
-            <div className="border-t px-4 pt-4 pb-5 flex-shrink-0 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            {/* Modal Footer: Test on left, Cancel/Submit right-aligned */}
+            <div className="border-t px-4 pt-4 pb-5 flex-shrink-0 flex flex-col gap-3 sm:flex-row sm:items-center">
               <WizardEndpointTest
                 wizardOpen={showAddModal}
                 variants={testVariants}
@@ -1439,7 +1439,7 @@ export default function Providers() {
                 probeModels={formData.useCustomModelsList === true ? null : upstreamModels.models}
                 disabled={saveProviderMutation.isPending}
               />
-              <div className="flex w-full shrink-0 flex-wrap justify-end gap-2 sm:w-auto">
+              <div className="ml-auto flex w-full shrink-0 flex-wrap justify-end gap-2 sm:w-auto">
                 <Button size="sm" variant="outline" className="h-7 text-xs" onClick={closeModal}>
                   {t("common.cancel")}
                 </Button>

--- a/web/src/features/providers/wizard/WizardDialog.tsx
+++ b/web/src/features/providers/wizard/WizardDialog.tsx
@@ -323,7 +323,7 @@ export function WizardDialog({
           ) : null}
         </div>
 
-        <DialogFooter className="mx-0 mb-0 shrink-0 flex-col gap-3 rounded-b-xl border-t bg-muted/50 px-6 pt-4 pb-6 sm:flex-row sm:items-center sm:justify-between">
+        <DialogFooter className="mx-0 mb-0 shrink-0 flex-col gap-3 rounded-b-xl border-t bg-muted/50 px-6 pt-4 pb-6 sm:flex-row sm:items-center">
           {phase === "choose" ? (
             <Button
               type="button"
@@ -346,7 +346,7 @@ export function WizardDialog({
                 probeModels={useCustomModels ? null : upstreamModels.models}
                 disabled={busy}
               />
-              <div className="flex w-full shrink-0 flex-wrap justify-end gap-2 sm:w-auto">
+              <div className="ml-auto flex w-full shrink-0 flex-wrap justify-end gap-2 sm:w-auto">
                 <Button
                   type="button"
                   variant="outline"

--- a/web/src/features/providers/wizard/WizardEndpointTest.tsx
+++ b/web/src/features/providers/wizard/WizardEndpointTest.tsx
@@ -112,7 +112,13 @@ export function WizardEndpointTest({
       ? Boolean(customFirstModelId)
       : Boolean(probeModels && probeModels.length >= 1));
 
-  const noModelReason = useMemo(() => {
+  const disabledReason = useMemo(() => {
+    if (!variants?.length) {
+      return t("wizard.test.incomplete");
+    }
+    if (!hasAuth) {
+      return t("wizard.test.needAuth");
+    }
     if (useCustomModels && !customFirstModelId) {
       return t("wizard.test.noModel");
     }
@@ -122,7 +128,7 @@ export function WizardEndpointTest({
       }
     }
     return null;
-  }, [useCustomModels, customFirstModelId, probeModels, t]);
+  }, [variants, hasAuth, useCustomModels, customFirstModelId, probeModels, t]);
 
   const runWithModelId = useCallback(
     (modelId: string) => {
@@ -179,10 +185,6 @@ export function WizardEndpointTest({
     runWithModelId(modalModelId);
   }, [modalModelId, runWithModelId]);
 
-  if (!variants?.length) {
-    return null;
-  }
-
   return (
     <>
       <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1">
@@ -192,8 +194,8 @@ export function WizardEndpointTest({
             variant="outline"
             size="sm"
             className="h-8 shrink-0"
-            disabled={!canClickTest || Boolean(noModelReason)}
-            title={noModelReason ?? undefined}
+            disabled={!canClickTest || Boolean(disabledReason)}
+            title={disabledReason ?? undefined}
             onClick={handleTestClick}
           >
             {state.phase === "testing" ? (

--- a/web/src/i18n/en.json
+++ b/web/src/i18n/en.json
@@ -590,6 +590,8 @@
       "testing": "Testing…",
       "pass": "OK",
       "fail": "Failed",
+      "incomplete": "Complete the required fields to enable testing.",
+      "needAuth": "Enter an API key to enable testing.",
       "noModel": "Enter at least one upstream model ID to test.",
       "noProbeModels": "No models listed yet — wait for endpoint fetch or enable custom model list.",
       "selectModel": "Select model to test",

--- a/web/src/i18n/zh.json
+++ b/web/src/i18n/zh.json
@@ -590,6 +590,8 @@
       "testing": "测试中…",
       "pass": "通过",
       "fail": "失败",
+      "incomplete": "请先完善必填项后再测试。",
+      "needAuth": "请先填写 API 密钥后再测试。",
       "noModel": "请至少填写一行上游模型 ID 后再测试。",
       "noProbeModels": "暂无可用模型 — 请等待端点获取列表或开启自定义模型列表。",
       "selectModel": "选择测试模型",


### PR DESCRIPTION
Keep the Test control visible (disabled with reasons) in custom add/edit and wizard footers, and pin Cancel/Submit to the right with ml-auto.