### PR TITLE
fix: stream tool_use args via input_json_delta in synthetic Anthropic…

### DIFF
--- a/packages/core/src/converter/streaming/sse-formatters.ts
+++ b/packages/core/src/converter/streaming/sse-formatters.ts
@@ -511,7 +511,42 @@ export function formatAnthropicMessageSse(message: AnthropicMessageResponse): st
       push("content_block_stop", { type: "content_block_stop", index });
       continue;
     }
-    // tool_use / server_tool_use / web_search_tool_result: emit as complete blocks (no deltas)
+    // tool_use / server_tool_use: Anthropic clients accumulate input ONLY from
+    // input_json_delta (content_block_start.input is a placeholder {}). Emitting the
+    // full input on start with no deltas causes Claude Code / Anthropic SDK to see {}.
+    if (block.type === "tool_use" || block.type === "server_tool_use") {
+      const input =
+        block.input && typeof block.input === "object" && !Array.isArray(block.input)
+          ? block.input
+          : {};
+      push("content_block_start", {
+        type: "content_block_start",
+        index,
+        content_block: {
+          type: block.type,
+          id: block.id,
+          name: block.name,
+          input: {},
+        },
+      });
+      const fullArgs = JSON.stringify(input);
+      if (fullArgs.length > 0) {
+        for (let i = 0; i < fullArgs.length; i += SSE_TEXT_CHUNK) {
+          push("content_block_delta", {
+            type: "content_block_delta",
+            index,
+            delta: {
+              type: "input_json_delta",
+              partial_json: fullArgs.slice(i, i + SSE_TEXT_CHUNK),
+            },
+          });
+        }
+      }
+      push("content_block_stop", { type: "content_block_stop", index });
+      continue;
+    }
+
+    // Other blocks (e.g. web_search_tool_result): emit as complete blocks (no deltas)
     push("content_block_start", {
       type: "content_block_start",
       index,

--- a/tests/unit/converter/streaming/sse-formatters.test.ts
+++ b/tests/unit/converter/streaming/sse-formatters.test.ts
@@ -228,4 +228,131 @@ describe("formatAnthropicMessageSse", () => {
     expect(text).toBe("Hello world");
     expect(events.some(e => e.type === "message_stop")).toBe(true);
   });
+
+  it("streams tool_use input via input_json_delta (not content_block_start.input)", () => {
+    const message: AnthropicMessageResponse = {
+      id: "msg_tool",
+      type: "message",
+      role: "assistant",
+      model: "m",
+      content: [
+        {
+          type: "thinking",
+          thinking: "need bash",
+        },
+        {
+          type: "tool_use",
+          id: "functions.Bash:7",
+          name: "Bash",
+          input: {
+            command: 'find . -name "*.tscn" | head -50',
+            description: "List scenes",
+          },
+        },
+      ],
+      stop_reason: "tool_use",
+      stop_sequence: null,
+      usage: { input_tokens: 10, output_tokens: 20, cache_read_input_tokens: 0 },
+    };
+    const sse = formatAnthropicMessageSse(message);
+    const events = parseSseDataEvents(sse);
+
+    const toolStart = events.find(e => {
+      if (e.type !== "content_block_start") {
+        return false;
+      }
+      const cb = e.content_block;
+      return !!cb && typeof cb === "object" && (cb as { type?: string }).type === "tool_use";
+    });
+    expect(toolStart).toBeDefined();
+    const startBlock = toolStart?.content_block as {
+      type?: string;
+      id?: string;
+      name?: string;
+      input?: unknown;
+    };
+    expect(startBlock.id).toBe("functions.Bash:7");
+    expect(startBlock.name).toBe("Bash");
+    // Anthropic contract: start.input is a placeholder; real args arrive as deltas.
+    expect(startBlock.input).toEqual({});
+
+    const toolIndex = toolStart?.index;
+    const jsonDeltas = events.filter(e => {
+      if (e.type !== "content_block_delta" || e.index !== toolIndex) {
+        return false;
+      }
+      const delta = e.delta;
+      return (
+        !!delta &&
+        typeof delta === "object" &&
+        (delta as { type?: string }).type === "input_json_delta"
+      );
+    });
+    expect(jsonDeltas.length).toBeGreaterThan(0);
+    const partial = jsonDeltas
+      .map(e => {
+        const delta = e.delta;
+        if (!delta || typeof delta !== "object") {
+          return "";
+        }
+        const pj = (delta as { partial_json?: string }).partial_json;
+        return typeof pj === "string" ? pj : "";
+      })
+      .join("");
+    expect(JSON.parse(partial)).toEqual({
+      command: 'find . -name "*.tscn" | head -50',
+      description: "List scenes",
+    });
+
+    const stop = events.find(e => e.type === "message_delta");
+    const stopDelta = stop?.delta as { stop_reason?: string } | undefined;
+    expect(stopDelta?.stop_reason).toBe("tool_use");
+  });
+
+  it("streams server_tool_use input via input_json_delta", () => {
+    const message: AnthropicMessageResponse = {
+      id: "msg_srv",
+      type: "message",
+      role: "assistant",
+      model: "m",
+      content: [
+        {
+          type: "server_tool_use",
+          id: "srv_1",
+          name: "web_search",
+          input: { query: "ccrelay tool use" },
+        },
+      ],
+      stop_reason: "tool_use",
+      stop_sequence: null,
+      usage: { input_tokens: 1, output_tokens: 2, cache_read_input_tokens: 0 },
+    };
+    const sse = formatAnthropicMessageSse(message);
+    const events = parseSseDataEvents(sse);
+    const start = events.find(e => e.type === "content_block_start");
+    const startBlock = start?.content_block as { input?: unknown } | undefined;
+    expect(startBlock?.input).toEqual({});
+    const partial = events
+      .filter(e => {
+        if (e.type !== "content_block_delta") {
+          return false;
+        }
+        const delta = e.delta;
+        return (
+          !!delta &&
+          typeof delta === "object" &&
+          (delta as { type?: string }).type === "input_json_delta"
+        );
+      })
+      .map(e => {
+        const delta = e.delta;
+        if (!delta || typeof delta !== "object") {
+          return "";
+        }
+        const pj = (delta as { partial_json?: string }).partial_json;
+        return typeof pj === "string" ? pj : "";
+      })
+      .join("");
+    expect(JSON.parse(partial)).toEqual({ query: "ccrelay tool use" });
+  });
 });

--- a/web/src/features/logs/reconstructAnthropicSseMessage.ts
+++ b/web/src/features/logs/reconstructAnthropicSseMessage.ts
@@ -45,24 +45,18 @@ function finalizeContentBlock(block: WorkingBlock): Record<string, unknown> {
   }
 
   if (bType === "tool_use" || bType === "server_tool_use") {
+    // Anthropic contract: input_json_delta fragments are the full JSON string.
+    // Prefer deltas when present; fall back to content_block_start.input for
+    // complete-block synthetic streams that omit deltas.
     let input: unknown = cb.input;
-    if (input === undefined || input === null) {
-      if (block.inputJsonBuf.trim()) {
-        try {
-          input = JSON.parse(block.inputJsonBuf);
-        } catch {
-          input = { _parseError: true, raw: block.inputJsonBuf };
-        }
-      } else {
-        input = {};
-      }
-    } else if (typeof input === "object" && input !== null && block.inputJsonBuf.trim()) {
+    if (block.inputJsonBuf.trim()) {
       try {
-        const add = JSON.parse(block.inputJsonBuf) as Record<string, unknown>;
-        input = { ...(input as Record<string, unknown>), ...add };
+        input = JSON.parse(block.inputJsonBuf);
       } catch {
-        // keep start payload only
+        input = { _parseError: true, raw: block.inputJsonBuf };
       }
+    } else if (input === undefined || input === null) {
+      input = {};
     }
 
     const out: Record<string, unknown> = {


### PR DESCRIPTION
… SSE

Claude Code / Anthropic SDK ignore content_block_start.input and only accumulate tool parameters from input_json_delta, so complete-block synthetic SSE made every tool call look like {}.