### PR TITLE
fix: cap OpenAI Chat tools at 128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+**Protocol/Conversion**
+
+- Cap OpenAI Chat Completions `tools` at 128 (API hard limit) on every Chat upstream path, including passthrough and cross-protocol conversion.
+
 ## [0.3.1] - 2026-08-02 (pre-release)
 
 Pre-release line for 0.3.1.

--- a/packages/core/src/converter/platform-transforms/index.ts
+++ b/packages/core/src/converter/platform-transforms/index.ts
@@ -60,6 +60,8 @@ export {
   normalizeGeminiEffort,
   passthroughTransform,
   isPlainObject,
+  OPENAI_CHAT_MAX_TOOLS,
+  capOpenAiChatTools,
   customToFunctionShim,
   openaiChatStrictToolsSanitize,
   extractLongcatToolCalls,

--- a/packages/core/src/converter/platform-transforms/openai-chat-strict-tools.ts
+++ b/packages/core/src/converter/platform-transforms/openai-chat-strict-tools.ts
@@ -1,6 +1,7 @@
 /**
- * Chat Completions strict tools sanitize: drop unsupported Responses hosted tools and
- * shim `custom` freeform tools to string-arg `function` entries for Chat-only upstreams.
+ * Chat Completions tools sanitize: drop unsupported Responses hosted tools,
+ * shim `custom` freeform tools to string-arg `function` entries for Chat-only upstreams,
+ * and enforce the OpenAI Chat Completions tools array limit (128).
  */
 
 import { ScopedLogger } from "../../utils/logger";
@@ -8,6 +9,9 @@ import { isPlainObject } from "./passthrough";
 import { matchHostedToolRuleForBaseUrl, type PlatformMatchOptions } from "./matchRule";
 
 const log = new ScopedLogger("PlatformStrictTools");
+
+/** OpenAI Chat Completions rejects requests with more than this many `tools` entries. */
+export const OPENAI_CHAT_MAX_TOOLS = 128;
 
 function formatHint(format: unknown): string | undefined {
   if (!isPlainObject(format)) {
@@ -168,4 +172,39 @@ export function openaiChatStrictToolsSanitize(
   if (body.tool_choice !== undefined) {
     body.tool_choice = normalizeToolChoiceAfterDrop(body.tool_choice, keptFunctionNames);
   }
+}
+
+/**
+ * Truncate `tools[]` to the OpenAI Chat Completions hard limit (default 128).
+ * Keeps the first N entries; if `tool_choice` names a dropped function, resets to `"auto"`.
+ */
+export function capOpenAiChatTools(
+  body: Record<string, unknown>,
+  max: number = OPENAI_CHAT_MAX_TOOLS
+): void {
+  const rawTools = body.tools;
+  if (!Array.isArray(rawTools) || rawTools.length <= max) {
+    return;
+  }
+
+  const before = rawTools.length;
+  const kept = rawTools.slice(0, max) as Record<string, unknown>[];
+  body.tools = kept;
+  log.warn(`[tools-limit] truncated tools from ${before} to ${max} (dropped ${before - max})`);
+
+  if (body.tool_choice === undefined) {
+    return;
+  }
+
+  const keptFunctionNames = new Set<string>();
+  for (const entry of kept) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const name = toolDisplayName(entry);
+    if (name) {
+      keptFunctionNames.add(name);
+    }
+  }
+  body.tool_choice = normalizeToolChoiceAfterDrop(body.tool_choice, keptFunctionNames);
 }

--- a/packages/core/src/converter/platform-transforms/registries.ts
+++ b/packages/core/src/converter/platform-transforms/registries.ts
@@ -114,7 +114,12 @@ export {
 export { geminiThoughtTagsResponseTransform } from "./gemini/response-thoughts";
 export { minimaxChatSanitize } from "./minimax/request-sanitize";
 export { minimaxReasoningDetailsResponseTransform } from "./minimax/response-reasoning";
-export { customToFunctionShim, openaiChatStrictToolsSanitize } from "./openai-chat-strict-tools";
+export {
+  OPENAI_CHAT_MAX_TOOLS,
+  capOpenAiChatTools,
+  customToFunctionShim,
+  openaiChatStrictToolsSanitize,
+} from "./openai-chat-strict-tools";
 export {
   extractLongcatToolCalls,
   parseLongcatArgValue,

--- a/packages/core/src/server/request/bodyProcessor.ts
+++ b/packages/core/src/server/request/bodyProcessor.ts
@@ -34,6 +34,7 @@ import {
   applyPlatformRequestSanitize,
   matchAnthropicSseRule,
   openaiChatStrictToolsSanitize,
+  capOpenAiChatTools,
 } from "../../converter/platform-transforms";
 import { anthropicBodyHasHostedTool } from "../../converter/hosted-tools";
 import { ScopedLogger } from "../../utils/logger";
@@ -118,6 +119,8 @@ function applyPlatformTransformsToOpenAiChatBody(
     ensureOpenAiChatStreamUsageIncluded(data);
     applyHostedToolsToOpenAiChatRecord(data, baseUrl, openaiCompat);
     openaiChatStrictToolsSanitize(data, baseUrl, matchOpts);
+    // OpenAI Chat Completions hard limit — after strictTools so truncation sees the filtered list.
+    capOpenAiChatTools(data);
     applyPlatformMessagesToOpenAiChatRecord(data, baseUrl, openaiCompat);
     applyPlatformRequestSanitize(data, baseUrl, matchOpts);
     sanitizeOpenAiChatToolArgumentsInMessages(data.messages);

--- a/tests/unit/converter/platform-transforms/openai-chat-strict-tools.test.ts
+++ b/tests/unit/converter/platform-transforms/openai-chat-strict-tools.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
 import {
+  OPENAI_CHAT_MAX_TOOLS,
+  capOpenAiChatTools,
   customToFunctionShim,
   matchHostedToolRuleForBaseUrl,
   openaiChatStrictToolsSanitize,
@@ -164,5 +166,50 @@ describe("openaiChatStrictToolsSanitize", () => {
       type: "function",
       function: { name: "wait" },
     });
+  });
+});
+
+describe("capOpenAiChatTools", () => {
+  it("no-ops when tools length is within the limit", () => {
+    const tools = Array.from({ length: OPENAI_CHAT_MAX_TOOLS }, (_, i) => fnTool(`t${i}`));
+    const body: Record<string, unknown> = { tools };
+    capOpenAiChatTools(body);
+    expect(body.tools).toBe(tools);
+    expect((body.tools as unknown[]).length).toBe(OPENAI_CHAT_MAX_TOOLS);
+  });
+
+  it("truncates to the first 128 tools", () => {
+    const body: Record<string, unknown> = {
+      tools: Array.from({ length: OPENAI_CHAT_MAX_TOOLS + 5 }, (_, i) => fnTool(`t${i}`)),
+    };
+    capOpenAiChatTools(body);
+    const tools = body.tools as Record<string, unknown>[];
+    expect(tools).toHaveLength(OPENAI_CHAT_MAX_TOOLS);
+    expect((tools[0].function as { name: string }).name).toBe("t0");
+    expect((tools[OPENAI_CHAT_MAX_TOOLS - 1].function as { name: string }).name).toBe(
+      `t${OPENAI_CHAT_MAX_TOOLS - 1}`
+    );
+  });
+
+  it("resets tool_choice to auto when the forced function was truncated away", () => {
+    const body: Record<string, unknown> = {
+      tools: Array.from({ length: OPENAI_CHAT_MAX_TOOLS + 1 }, (_, i) => fnTool(`t${i}`)),
+      tool_choice: {
+        type: "function",
+        function: { name: `t${OPENAI_CHAT_MAX_TOOLS}` },
+      },
+    };
+    capOpenAiChatTools(body);
+    expect(body.tool_choice).toBe("auto");
+  });
+
+  it("keeps tool_choice when the forced function remains", () => {
+    const choice = { type: "function", function: { name: "t0" } };
+    const body: Record<string, unknown> = {
+      tools: Array.from({ length: OPENAI_CHAT_MAX_TOOLS + 1 }, (_, i) => fnTool(`t${i}`)),
+      tool_choice: choice,
+    };
+    capOpenAiChatTools(body);
+    expect(body.tool_choice).toEqual(choice);
   });
 });

--- a/tests/unit/server/request/bodyProcessor.openaiChatToolsLimit.test.ts
+++ b/tests/unit/server/request/bodyProcessor.openaiChatToolsLimit.test.ts
@@ -1,0 +1,87 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { describe, expect, it } from "vitest";
+import { OPENAI_CHAT_MAX_TOOLS } from "@/converter/platform-transforms";
+import { BodyProcessor } from "@/server/request/bodyProcessor";
+import type { RoutingContext } from "@/server/request/context";
+import type { Provider } from "@/types";
+
+describe("BodyProcessor OpenAI Chat tools limit", () => {
+  const openaiChat: Provider = {
+    id: "openai",
+    name: "OpenAI",
+    baseUrl: "https://api.openai.com/v1",
+    mode: "passthrough",
+    providerType: "openai_chat",
+    apiKey: "sk",
+  };
+
+  function makeRouting(overrides: Partial<RoutingContext> = {}): RoutingContext {
+    return {
+      blocked: false,
+      method: "POST",
+      path: "/openai/v1/chat/completions",
+      provider: openaiChat,
+      clientHeaders: {},
+      headers: {},
+      targetUrl: "https://api.openai.com/v1/chat/completions",
+      targetPath: "/chat/completions",
+      targetQuery: "",
+      isRouted: false,
+      isOpenAIProvider: true,
+      clientSurface: "openai",
+      ...overrides,
+    };
+  }
+
+  function fnTool(name: string): Record<string, unknown> {
+    return {
+      type: "function",
+      function: {
+        name,
+        description: "d",
+        parameters: { type: "object", properties: {} },
+      },
+    };
+  }
+
+  it("truncates tools on Chat passthrough when over the OpenAI limit", () => {
+    const body = Buffer.from(
+      JSON.stringify({
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "hi" }],
+        tools: Array.from({ length: OPENAI_CHAT_MAX_TOOLS + 3 }, (_, i) => fnTool(`t${i}`)),
+      })
+    );
+    const out = new BodyProcessor().process(body, makeRouting(), false);
+    const parsed = JSON.parse(out.body.toString("utf-8")) as Record<string, unknown>;
+    expect(parsed.tools).toHaveLength(OPENAI_CHAT_MAX_TOOLS);
+  });
+
+  it("truncates tools after Anthropic → Chat conversion", () => {
+    const tools = Array.from({ length: OPENAI_CHAT_MAX_TOOLS + 2 }, (_, i) => ({
+      name: `t${i}`,
+      description: "d",
+      input_schema: { type: "object", properties: {} },
+    }));
+    const body = Buffer.from(
+      JSON.stringify({
+        model: "gpt-4o",
+        max_tokens: 64,
+        messages: [{ role: "user", content: "hi" }],
+        tools,
+      })
+    );
+    const out = new BodyProcessor().process(
+      body,
+      makeRouting({
+        path: "/anthropic/v1/messages",
+        clientSurface: "anthropic",
+        targetPath: "/chat/completions",
+      }),
+      false
+    );
+    const parsed = JSON.parse(out.body.toString("utf-8")) as Record<string, unknown>;
+    expect(parsed.tools).toHaveLength(OPENAI_CHAT_MAX_TOOLS);
+  });
+});


### PR DESCRIPTION
## Summary
- Enforce the OpenAI Chat Completions hard limit of 128 `tools` on every outbound Chat upstream path (passthrough and cross-protocol conversion).
- Truncate after `strictTools` filtering; if `tool_choice` points at a dropped function, reset it to `auto`.

## Test plan
- [ ] Unit: `capOpenAiChatTools` truncates to 128 and adjusts `tool_choice`
- [ ] Unit: BodyProcessor Chat passthrough truncates oversized `tools`
- [ ] Unit: BodyProcessor Anthropic → Chat conversion also truncates
- [ ] Manual: send a Chat Completions request with >128 tools to an OpenAI Chat upstream and confirm it no longer fails with the tools-limit error


Made with [Cursor](https://cursor.com)