### PR TITLE
fix: strip deferred tools for OpenRouter stealth and unknown models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Cap OpenAI Chat Completions `tools` at 128 (API hard limit) on every Chat upstream path, including passthrough and cross-protocol conversion.
 - Claude Code mid-conversation system reminders keep their original order when forwarded to OpenAI Chat by merging into the adjacent user or tool message.
+- Anthropic deferred tools (ToolSearch / `defer_loading`) are stripped for OpenRouter stealth models and other unrecognized ids. Gateways that are not first-party Anthropic reject that feature.
 
 ## [0.3.1] - 2026-08-02 (pre-release)
 

--- a/packages/core/src/converter/model-meta/defaults.ts
+++ b/packages/core/src/converter/model-meta/defaults.ts
@@ -63,6 +63,8 @@ export const VENDOR_DEFAULT_META: Readonly<Record<ModelVendor, ModelMeta>> = {
       // Drop by default — Azure Hosted-on-Azure and most gateways reject these.
       supportsContextManagement: false,
       supportsStructuredOutputs: false,
+      supportsDeferLoading: false,
+      supportsToolReferenceBlocks: false,
     },
   },
   openai: {

--- a/packages/core/src/converter/model-meta/families.stealth.ts
+++ b/packages/core/src/converter/model-meta/families.stealth.ts
@@ -1,0 +1,30 @@
+import { REASONING_CAPABLE, inputMetaFromModalities } from "./defaults";
+import type { ModelFamilyEntry } from "./types";
+
+const MULTIMODAL = inputMetaFromModalities(["text", "image"]);
+
+/**
+ * OpenRouter stealth / anonymous models (e.g. stealth/ox-alpha).
+ * Anthropic-compatible `/v1/messages` endpoints reject deferred tools (ToolSearch).
+ */
+const STEALTH_ANTHROPIC = {
+  supportsSystemRoleInMessages: true,
+  supportsContextManagement: false,
+  supportsStructuredOutputs: false,
+  supportsDeferLoading: false,
+  supportsToolReferenceBlocks: false,
+  supportsExtendedCacheTtl: false,
+} as const;
+
+export const STEALTH_MODEL_FAMILIES: readonly ModelFamilyEntry[] = [
+  {
+    id: "stealth",
+    vendor: "generic",
+    match: ["stealth/*", "stealth-*"],
+    meta: {
+      ...MULTIMODAL,
+      reasoning: { ...REASONING_CAPABLE },
+      anthropic: { ...STEALTH_ANTHROPIC },
+    },
+  },
+];

--- a/packages/core/src/converter/model-meta/registry.ts
+++ b/packages/core/src/converter/model-meta/registry.ts
@@ -9,6 +9,7 @@ import { KIMI_MODEL_FAMILIES } from "./families.kimi";
 import { LONGCAT_MODEL_FAMILIES } from "./families.longcat";
 import { MIMO_MODEL_FAMILIES } from "./families.mimo";
 import { OPENAI_MODEL_FAMILIES } from "./families.openai";
+import { STEALTH_MODEL_FAMILIES } from "./families.stealth";
 import type {
   ModelFamilyEntry,
   ModelInputModality,
@@ -18,6 +19,7 @@ import type {
 } from "./types";
 
 const ALL_FAMILIES: readonly ModelFamilyEntry[] = [
+  ...STEALTH_MODEL_FAMILIES,
   ...MIMO_MODEL_FAMILIES,
   ...LONGCAT_MODEL_FAMILIES,
   ...GROK_MODEL_FAMILIES,

--- a/tests/unit/converter/model-meta/resolve.test.ts
+++ b/tests/unit/converter/model-meta/resolve.test.ts
@@ -138,7 +138,17 @@ describe("resolveModelMeta", () => {
     expect(meta.anthropic?.supportsSystemRoleInMessages).toBe(true);
     expect(meta.anthropic?.supportsContextManagement).toBe(false);
     expect(meta.anthropic?.supportsStructuredOutputs).toBe(false);
+    expect(meta.anthropic?.supportsDeferLoading).toBe(false);
+    expect(meta.anthropic?.supportsToolReferenceBlocks).toBe(false);
     expect(meta.input.modalities).toContain("image");
+  });
+
+  it("matches OpenRouter stealth models without deferred tools", () => {
+    const meta = resolveModelMeta("stealth/ox-alpha");
+    expect(meta.id).toBe("stealth");
+    expect(meta.anthropic?.supportsDeferLoading).toBe(false);
+    expect(meta.anthropic?.supportsToolReferenceBlocks).toBe(false);
+    expect(meta.input.modalities).toEqual(["text", "image"]);
   });
 
   it("lists all registered families", () => {

--- a/tests/unit/converter/model-meta/sanitize-anthropic.test.ts
+++ b/tests/unit/converter/model-meta/sanitize-anthropic.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { resolveModelMeta } from "@/converter/model-meta/registry";
-import { sanitizeAnthropicRequestByMeta } from "@/converter/model-meta/sanitize-anthropic";
+import {
+  sanitizeAnthropicRequestByMeta,
+  sanitizeAnthropicRequestRecord,
+} from "@/converter/model-meta/sanitize-anthropic";
 
 /* eslint-disable @typescript-eslint/naming-convention -- Anthropic API bodies use snake_case */
 
@@ -155,6 +158,25 @@ describe("sanitizeAnthropicRequestByMeta", () => {
     expect(data.output_config).toEqual({ effort: "high", format });
   });
 
+  it("preserves deferred tools for Claude families", () => {
+    const data: Record<string, unknown> = {
+      model: "claude-sonnet-4-20250514",
+      tools: [
+        {
+          name: "Bash",
+          input_schema: { type: "object" },
+          defer_loading: true,
+        },
+      ],
+      messages: [{ role: "user", content: "hi" }],
+    };
+    const meta = resolveModelMeta("claude-sonnet-4-20250514", { vendor: "anthropic" });
+    const changes = sanitizeAnthropicRequestByMeta(data, meta);
+
+    expect(changes).not.toContain("tools.defer_loading");
+    expect((data.tools as { defer_loading?: boolean }[])[0].defer_loading).toBe(true);
+  });
+
   it("strips structured outputs for glm family", () => {
     const data: Record<string, unknown> = {
       model: "glm-4.7",
@@ -302,5 +324,86 @@ describe("sanitizeAnthropicRequestByMeta", () => {
     expect((userContent[1] as { cache_control?: { ttl?: string } }).cache_control).toEqual({
       type: "ephemeral",
     });
+  });
+
+  it("strips deferred tools for stealth/ox-alpha", () => {
+    const data: Record<string, unknown> = {
+      model: "stealth/ox-alpha",
+      tools: [
+        { name: "ToolSearch", input_schema: { type: "object" } },
+        {
+          name: "Bash",
+          input_schema: { type: "object" },
+          defer_loading: true,
+        },
+        {
+          name: "DeferredToolPlaceholder",
+          description: "placeholder",
+          input_schema: { type: "object" },
+          defer_loading: true,
+        },
+      ],
+      messages: [
+        { role: "user", content: "run ls" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "call_1",
+              name: "ToolSearch",
+              input: { query: "select:Bash", max_results: 5 },
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "call_1",
+              content: [{ type: "tool_reference", tool_name: "Bash" }],
+            },
+          ],
+        },
+      ],
+    };
+    const meta = resolveModelMeta("stealth/ox-alpha");
+    const changes = sanitizeAnthropicRequestByMeta(data, meta);
+
+    expect(meta.id).toBe("stealth");
+    expect(changes).toContain("tools.defer_loading");
+    expect(changes).toContain("tool_reference");
+    expect(data.tools).toHaveLength(2);
+    expect(
+      (data.tools as { name?: string; defer_loading?: boolean }[]).every(
+        t => t.defer_loading === undefined && t.name !== "DeferredToolPlaceholder"
+      )
+    ).toBe(true);
+    const userContent = (data.messages as { role: string; content: unknown[] }[])[2].content;
+    expect(userContent[0]).toEqual({
+      type: "tool_result",
+      tool_use_id: "call_1",
+      content: [{ type: "text", text: "Tool loaded: Bash." }],
+    });
+  });
+
+  it("strips deferred tools for unrecognized Anthropic-endpoint model ids", () => {
+    const data: Record<string, unknown> = {
+      model: "some-custom-gateway-model",
+      tools: [
+        {
+          name: "Bash",
+          input_schema: { type: "object" },
+          defer_loading: true,
+        },
+      ],
+      messages: [{ role: "user", content: "hi" }],
+    };
+    sanitizeAnthropicRequestRecord(data);
+
+    expect(
+      (data.tools as { name?: string; defer_loading?: boolean }[])[0].defer_loading
+    ).toBeUndefined();
   });
 });

--- a/tests/unit/server/request/bodyProcessor.stealthAnthropic.test.ts
+++ b/tests/unit/server/request/bodyProcessor.stealthAnthropic.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { BodyProcessor } from "@/server/request/bodyProcessor";
+import type { RoutingContext } from "@/server/request/context";
+import type { Provider } from "@/types";
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
+describe("BodyProcessor OpenRouter stealth Anthropic outbound sanitize", () => {
+  const openrouter: Provider = {
+    id: "openrouter",
+    name: "OpenRouter",
+    baseUrl: "https://openrouter.ai/api",
+    mode: "passthrough",
+    providerType: "anthropic",
+    apiKey: "sk",
+    modelMap: [{ pattern: "claude-*", model: "stealth/ox-alpha" }],
+    modelMappingEnabled: true,
+  };
+
+  function makeRouting(): RoutingContext {
+    return {
+      blocked: false,
+      method: "POST",
+      path: "/v1/messages",
+      provider: openrouter,
+      clientHeaders: {},
+      headers: {},
+      targetUrl: "https://openrouter.ai/api/v1/messages",
+      targetPath: "/v1/messages",
+      targetQuery: "?beta=true",
+      isRouted: false,
+      isOpenAIProvider: false,
+      clientSurface: "anthropic",
+    };
+  }
+
+  it("strips deferred tools after mapping claude-* to stealth/ox-alpha", () => {
+    const input = {
+      model: "claude-75987ea6",
+      max_tokens: 32000,
+      tools: [
+        { name: "ToolSearch", input_schema: { type: "object" } },
+        {
+          name: "Bash",
+          input_schema: { type: "object" },
+          defer_loading: true,
+        },
+        {
+          name: "DeferredToolPlaceholder",
+          input_schema: { type: "object" },
+          defer_loading: true,
+        },
+      ],
+      messages: [{ role: "user", content: "hi" }],
+    };
+
+    const proc = new BodyProcessor();
+    const result = proc.process(Buffer.from(JSON.stringify(input), "utf-8"), makeRouting(), false);
+    const parsed = JSON.parse(result.body.toString("utf-8")) as Record<string, unknown>;
+
+    expect(parsed.model).toBe("stealth/ox-alpha");
+    expect(parsed.tools).toHaveLength(2);
+    expect(JSON.stringify(parsed)).not.toContain("defer_loading");
+    expect(JSON.stringify(parsed)).not.toContain("DeferredToolPlaceholder");
+  });
+});


### PR DESCRIPTION
OpenRouter rejects ToolSearch/defer_loading on non-Anthropic endpoints such as stealth/ox-alpha; sanitize those requests before forwarding.