### PR TITLE
fix: apply gpt-5 Chat Completions rules to gpt-6 and later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Protocol/Conversion**
 
 - OpenAI Chat Completions maps `max_tokens` to `max_completion_tokens` for gpt-6 and later (same gpt-5 family rules).
+- OpenAI Chat Completions with function tools forces `reasoning_effort` to `none` for gpt-5.4+ / gpt-6 (omitting the field still uses a default effort and is rejected).
 - Cap OpenAI Chat Completions `tools` at 128 (API hard limit) on every Chat upstream path, including passthrough and cross-protocol conversion.
 - Claude Code mid-conversation system reminders keep their original order when forwarded to OpenAI Chat by merging into the adjacent user or tool message.
 - Anthropic deferred tools (ToolSearch / `defer_loading`) are stripped for OpenRouter stealth models and other unrecognized ids. Gateways that are not first-party Anthropic reject that feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Protocol/Conversion**
 
+- OpenAI Chat Completions maps `max_tokens` to `max_completion_tokens` for gpt-6 and later (same gpt-5 family rules).
 - Cap OpenAI Chat Completions `tools` at 128 (API hard limit) on every Chat upstream path, including passthrough and cross-protocol conversion.
 - Claude Code mid-conversation system reminders keep their original order when forwarded to OpenAI Chat by merging into the adjacent user or tool message.
 - Anthropic deferred tools (ToolSearch / `defer_loading`) are stripped for OpenRouter stealth models and other unrecognized ids. Gateways that are not first-party Anthropic reject that feature.

--- a/packages/core/src/converter/model-meta/families.openai.ts
+++ b/packages/core/src/converter/model-meta/families.openai.ts
@@ -4,11 +4,15 @@ import type { ModelFamilyEntry } from "./types";
 const OPENAI_REASONING_EFFORTS = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
 const MULTIMODAL = inputMetaFromModalities(["text", "image"]);
 
+/** GPT-5 and later Chat Completions ids (gpt-5.4, gpt-6-astra, gpt-10, …). */
+const GPT5_PLUS_REGEX = /^gpt-(?:[5-9]|[1-9]\d+)/;
+
 export const OPENAI_MODEL_FAMILIES: readonly ModelFamilyEntry[] = [
   {
     id: "gpt-5",
     vendor: "openai",
-    match: "gpt-5*",
+    match: [],
+    matchRegex: GPT5_PLUS_REGEX,
     meta: {
       ...MULTIMODAL,
       reasoning: { enabled: true, supportsReasoningEffort: true },

--- a/packages/core/src/converter/model-meta/sanitize-openai-chat.ts
+++ b/packages/core/src/converter/model-meta/sanitize-openai-chat.ts
@@ -37,15 +37,19 @@ export function sanitizeOpenAiChatRequestByMeta(
   if (!reasoning.supportsReasoningEffort && data.reasoning_effort !== undefined) {
     delete data.reasoning_effort;
     stripped.push("reasoning_effort");
-  } else if (
-    openaiChat?.dropReasoningEffortWhenTools &&
-    data.reasoning_effort !== undefined &&
-    chatRequestHasFunctionTools(data)
-  ) {
-    // gpt-5+ / o-series: Chat Completions rejects tools + reasoning_effort together
-    // ("Please use /v1/responses instead"). Prefer keeping tools for Codex agent turns.
-    delete data.reasoning_effort;
-    stripped.push("reasoning_effort");
+  } else if (openaiChat?.dropReasoningEffortWhenTools && chatRequestHasFunctionTools(data)) {
+    // gpt-5.4+ / gpt-6 Chat Completions: tools only with reasoning_effort "none".
+    // Omitting the field still 400s because the model defaults to a non-none effort.
+    const current =
+      typeof data.reasoning_effort === "string" ? data.reasoning_effort.trim().toLowerCase() : "";
+    if (current !== "none") {
+      data.reasoning_effort = "none";
+      stripped.push("reasoning_effort=none");
+    }
+    if (data.reasoning !== undefined) {
+      delete data.reasoning;
+      stripped.push("reasoning");
+    }
   } else if (
     openaiChat?.validReasoningEfforts &&
     typeof data.reasoning_effort === "string" &&

--- a/packages/core/src/converter/model-meta/sanitize-openai-chat.ts
+++ b/packages/core/src/converter/model-meta/sanitize-openai-chat.ts
@@ -42,7 +42,7 @@ export function sanitizeOpenAiChatRequestByMeta(
     data.reasoning_effort !== undefined &&
     chatRequestHasFunctionTools(data)
   ) {
-    // gpt-5 / o-series: Chat Completions rejects tools + reasoning_effort together
+    // gpt-5+ / o-series: Chat Completions rejects tools + reasoning_effort together
     // ("Please use /v1/responses instead"). Prefer keeping tools for Codex agent turns.
     delete data.reasoning_effort;
     stripped.push("reasoning_effort");

--- a/packages/core/src/converter/model-meta/types.ts
+++ b/packages/core/src/converter/model-meta/types.ts
@@ -47,7 +47,7 @@ export interface ModelOpenAiChatMeta {
   validReasoningEfforts?: readonly string[];
   /**
    * OpenAI Chat Completions rejects `reasoning_effort` together with function tools
-   * for some reasoning models (e.g. gpt-5.*); Responses API still accepts both.
+   * for some reasoning models (e.g. gpt-5+ / o-series); Responses API still accepts both.
    * When true, strip `reasoning_effort` if the request includes function tools.
    */
   dropReasoningEffortWhenTools?: boolean;

--- a/packages/core/src/converter/model-meta/types.ts
+++ b/packages/core/src/converter/model-meta/types.ts
@@ -46,9 +46,10 @@ export interface ModelOpenAiChatMeta {
   usesMaxCompletionTokens?: boolean;
   validReasoningEfforts?: readonly string[];
   /**
-   * OpenAI Chat Completions rejects `reasoning_effort` together with function tools
-   * for some reasoning models (e.g. gpt-5+ / o-series); Responses API still accepts both.
-   * When true, strip `reasoning_effort` if the request includes function tools.
+   * OpenAI Chat Completions rejects function tools with `reasoning_effort` other than
+   * `none` for gpt-5.4+ / gpt-6 / o-series; Responses API still accepts both.
+   * When true, force `reasoning_effort` to `none` if the request includes function tools
+   * (omitting the field is not enough — those models default to a non-none effort).
    */
   dropReasoningEffortWhenTools?: boolean;
 }

--- a/tests/unit/converter/adapters/anthropic-to-openai-chat-request.test.ts
+++ b/tests/unit/converter/adapters/anthropic-to-openai-chat-request.test.ts
@@ -416,6 +416,19 @@ describe("converter: anthropic-to-openai-chat-request", () => {
       expect(result.request.max_tokens).toBeUndefined();
     });
 
+    it("maps max_tokens to max_completion_tokens for gpt-6 models", () => {
+      const request: AnthropicMessageRequest = {
+        model: "gpt-6-astra",
+        max_tokens: 32000,
+        messages: [],
+      };
+
+      const result = convertRequestToOpenAI(request, basePath);
+
+      expect(result.request.max_completion_tokens).toBe(32000);
+      expect(result.request.max_tokens).toBeUndefined();
+    });
+
     it("maps max_tokens to max_completion_tokens for o-series models", () => {
       const request: AnthropicMessageRequest = {
         model: "o3",

--- a/tests/unit/converter/model-meta/resolve.test.ts
+++ b/tests/unit/converter/model-meta/resolve.test.ts
@@ -29,6 +29,23 @@ describe("resolveModelMeta", () => {
     expect(meta.openaiChat?.usesMaxCompletionTokens).toBe(true);
   });
 
+  it("matches gpt-6 and later as the gpt-5 family", () => {
+    for (const id of ["gpt-6-astra", "gpt-6", "GPT-6.1-MINI", "gpt-10"]) {
+      const meta = resolveModelMeta(id, { vendor: "openai" });
+      expect(meta.id).toBe("gpt-5");
+      expect(meta.openaiChat?.usesMaxCompletionTokens).toBe(true);
+      expect(meta.reasoning.supportsReasoningEffort).toBe(true);
+    }
+  });
+
+  it("keeps gpt-4 families off max_completion_tokens", () => {
+    expect(resolveModelMeta("gpt-4o", { vendor: "openai" }).id).toBe("gpt-4o");
+    expect(resolveModelMeta("gpt-4.1", { vendor: "openai" }).id).toBe("gpt-4");
+    expect(
+      resolveModelMeta("gpt-4o", { vendor: "openai" }).openaiChat?.usesMaxCompletionTokens
+    ).toBe(false);
+  });
+
   it("matches o-series via regex", () => {
     expect(resolveModelMeta("o3-mini", { vendor: "openai" }).id).toBe("o-series");
     expect(resolveModelMeta("o4-mini", { vendor: "openai" }).id).toBe("o-series");

--- a/tests/unit/converter/model-meta/sanitize-openai-chat.test.ts
+++ b/tests/unit/converter/model-meta/sanitize-openai-chat.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from "vitest";
 import { sanitizeOpenAiChatRequestRecord } from "@/converter/model-meta/sanitize-openai-chat";
 
 describe("sanitizeOpenAiChatRequestRecord", () => {
-  it("strips reasoning_effort when gpt-5 has function tools (Chat Completions limitation)", () => {
+  it("sets reasoning_effort none when gpt-5 has function tools (Chat Completions limitation)", () => {
     const data: Record<string, unknown> = {
       model: "gpt-5.6-terra",
       reasoning_effort: "high",
@@ -19,8 +19,26 @@ describe("sanitizeOpenAiChatRequestRecord", () => {
       messages: [{ role: "user", content: "?" }],
     };
     sanitizeOpenAiChatRequestRecord(data);
-    expect(data.reasoning_effort).toBeUndefined();
+    expect(data.reasoning_effort).toBe("none");
     expect(data.tools).toHaveLength(1);
+  });
+
+  it("forces reasoning_effort none for gpt-6 tools even when the field is omitted", () => {
+    const data: Record<string, unknown> = {
+      model: "gpt-6-astra",
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "exec_command",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+      messages: [{ role: "user", content: "?" }],
+    };
+    sanitizeOpenAiChatRequestRecord(data);
+    expect(data.reasoning_effort).toBe("none");
   });
 
   it("keeps reasoning_effort for gpt-5 when there are no tools", () => {

--- a/tests/unit/converter/rules/openai-chat-model-rules.test.ts
+++ b/tests/unit/converter/rules/openai-chat-model-rules.test.ts
@@ -15,6 +15,8 @@ describe("openaiChatUsesMaxCompletionTokens", () => {
     expect(openaiChatUsesMaxCompletionTokens("gpt-5")).toBe(true);
     expect(openaiChatUsesMaxCompletionTokens("gpt-5.1")).toBe(true);
     expect(openaiChatUsesMaxCompletionTokens("GPT-5-MINI")).toBe(true);
+    expect(openaiChatUsesMaxCompletionTokens("gpt-6-astra")).toBe(true);
+    expect(openaiChatUsesMaxCompletionTokens("gpt-10")).toBe(true);
   });
 
   it("is true for o-series ids", () => {
@@ -79,6 +81,17 @@ describe("normalizeOpenAiChatMaxOutputFields", () => {
   it("maps max_tokens to max_completion_tokens for gpt-5 passthrough bodies", () => {
     const body: Record<string, unknown> = {
       model: "gpt-5.4",
+      messages: [],
+      max_tokens: 4096,
+    };
+    normalizeOpenAiChatMaxOutputFields(body);
+    expect(body.max_completion_tokens).toBe(4096);
+    expect(body.max_tokens).toBeUndefined();
+  });
+
+  it("maps max_tokens to max_completion_tokens for gpt-6 passthrough bodies", () => {
+    const body: Record<string, unknown> = {
+      model: "gpt-6-astra",
       messages: [],
       max_tokens: 4096,
     };


### PR DESCRIPTION
## Summary
- Treat GPT-6 and later (`gpt-6-astra`, `gpt-10`, …) as the gpt-5 family so Chat Completions uses `max_completion_tokens` instead of `max_tokens`.
- When those models are used with function tools on Chat Completions, force `reasoning_effort` to `none` (omitting the field still hits the model default and is rejected).

## Test plan
- [ ] Send a Chat Completions request to `gpt-6-astra` with `max_tokens` and confirm it is rewritten to `max_completion_tokens` (no 400 about unsupported `max_tokens`).
- [ ] Send a Chat Completions request to `gpt-6-astra` with function tools and a non-none `reasoning_effort` (or omit the field) and confirm upstream receives `reasoning_effort: "none"`.
- [ ] Confirm `gpt-4o` / `gpt-4.1` still use `max_tokens` and are unchanged.
- [ ] Confirm gpt-5 family requests without tools still keep the original `reasoning_effort`.


Made with [Cursor](https://cursor.com)